### PR TITLE
refactor: harden site store writes

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -8,7 +8,7 @@ This page describes the current `deck` command surface, starting with the defaul
 - `validate`: validate a workflow file against the top-level workflow schema and the relevant step schema
 - `pack`: gather artifacts, copy workflows, embed the `deck` binary, and write `bundle.tar`
 - `diff`: inspect which apply steps would run or skip before you execute
-- `doctor`: generate a validation or preflight-style report
+- `doctor`: generate a validation report for workflow inputs and referenced artifacts
 - `apply`: execute the `apply` workflow locally
 
 ## Optional site-local helpers

--- a/internal/site/store/assignments.go
+++ b/internal/site/store/assignments.go
@@ -30,6 +30,9 @@ func (s *Store) SaveAssignment(sessionID string, assignment Assignment) error {
 	if assignment.SessionID != sessionID {
 		return fmt.Errorf("assignment session_id must match %q", sessionID)
 	}
+	if _, err := s.requireOpenSession(sessionID); err != nil {
+		return err
+	}
 
 	path := filepath.Join(s.sessionDir(sessionID), "assignments", assignment.ID+".json")
 	return writeAtomicJSON(path, assignment)

--- a/internal/site/store/assignments_test.go
+++ b/internal/site/store/assignments_test.go
@@ -68,3 +68,50 @@ func TestAssignmentMissingMatch(t *testing.T) {
 		t.Fatalf("expected explicit assignment miss error, got %v", err)
 	}
 }
+
+func TestAssignmentRejectsMissingSession(t *testing.T) {
+	root := t.TempDir()
+	st, err := New(root)
+	if err != nil {
+		t.Fatalf("new store: %v", err)
+	}
+
+	err = st.SaveAssignment("session-missing", Assignment{ID: "assign-1", NodeID: "node-1"})
+	if err == nil {
+		t.Fatalf("expected missing session rejection")
+	}
+	if !strings.Contains(err.Error(), "not found") {
+		t.Fatalf("expected missing session error, got %v", err)
+	}
+}
+
+func TestAssignmentRejectsClosedSession(t *testing.T) {
+	st := newSessionStore(t, "session-assign-closed")
+	if _, err := st.CloseSession("session-assign-closed", "2026-03-08T12:00:00Z"); err != nil {
+		t.Fatalf("close session: %v", err)
+	}
+
+	err := st.SaveAssignment("session-assign-closed", Assignment{ID: "assign-1", NodeID: "node-1"})
+	if err == nil {
+		t.Fatalf("expected closed session rejection")
+	}
+	if !strings.Contains(err.Error(), "is closed") {
+		t.Fatalf("expected closed session error, got %v", err)
+	}
+}
+
+func TestAssignmentSessionMismatchPreserved(t *testing.T) {
+	root := t.TempDir()
+	st, err := New(root)
+	if err != nil {
+		t.Fatalf("new store: %v", err)
+	}
+
+	err = st.SaveAssignment("session-1", Assignment{ID: "assign-1", SessionID: "session-2", NodeID: "node-1"})
+	if err == nil {
+		t.Fatalf("expected session mismatch rejection")
+	}
+	if !strings.Contains(err.Error(), "session_id must match") {
+		t.Fatalf("expected mismatch error, got %v", err)
+	}
+}

--- a/internal/site/store/releases.go
+++ b/internal/site/store/releases.go
@@ -8,6 +8,8 @@ import (
 	"strings"
 )
 
+var copyDirFunc = copyDir
+
 func (s *Store) ImportRelease(release Release, importedBundlePath string) error {
 	if err := validateRecordID(release.ID, "release id"); err != nil {
 		return err
@@ -38,15 +40,32 @@ func (s *Store) ImportRelease(release Release, importedBundlePath string) error 
 		return fmt.Errorf("check release bundle path: %w", err)
 	}
 
-	if err := os.MkdirAll(releaseDir, 0o755); err != nil {
-		return fmt.Errorf("create release directory: %w", err)
+	if err := os.MkdirAll(s.releasesDir(), 0o755); err != nil {
+		return fmt.Errorf("create releases directory: %w", err)
 	}
-	if err := copyDir(importedBundlePath, bundlePath); err != nil {
+	tmpDir, err := os.MkdirTemp(s.releasesDir(), release.ID+".tmp-")
+	if err != nil {
+		return fmt.Errorf("create temporary release directory: %w", err)
+	}
+	cleanupTmp := true
+	defer func() {
+		if cleanupTmp {
+			_ = os.RemoveAll(tmpDir)
+		}
+	}()
+
+	tmpBundlePath := filepath.Join(tmpDir, "bundle")
+	tmpManifestPath := filepath.Join(tmpDir, "manifest.json")
+	if err := copyDirFunc(importedBundlePath, tmpBundlePath); err != nil {
 		return fmt.Errorf("copy release bundle: %w", err)
 	}
-	if err := writeAtomicJSON(manifestPath, release); err != nil {
+	if err := writeAtomicJSON(tmpManifestPath, release); err != nil {
 		return fmt.Errorf("write release manifest: %w", err)
 	}
+	if err := os.Rename(tmpDir, releaseDir); err != nil {
+		return fmt.Errorf("finalize release import: %w", err)
+	}
+	cleanupTmp = false
 	return nil
 }
 

--- a/internal/site/store/releases_test.go
+++ b/internal/site/store/releases_test.go
@@ -1,6 +1,7 @@
 package store
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -98,5 +99,42 @@ func TestSiteStoreSeparateFromInstallState(t *testing.T) {
 	installStatePath := filepath.Join(home, ".deck", "state")
 	if _, err := os.Stat(installStatePath); !os.IsNotExist(err) {
 		t.Fatalf("expected no writes to local install-state path %q, got err=%v", installStatePath, err)
+	}
+}
+
+func TestImportReleaseCleansPartialArtifactsOnCopyFailure(t *testing.T) {
+	root := t.TempDir()
+	importedBundle := filepath.Join(t.TempDir(), "bundle-src")
+	if err := os.MkdirAll(importedBundle, 0o755); err != nil {
+		t.Fatalf("mkdir imported bundle: %v", err)
+	}
+
+	st, err := New(root)
+	if err != nil {
+		t.Fatalf("new store: %v", err)
+	}
+
+	originalCopyDir := copyDirFunc
+	copyDirFunc = func(srcDir, dstDir string) error {
+		if err := os.MkdirAll(dstDir, 0o755); err != nil {
+			return err
+		}
+		if err := os.WriteFile(filepath.Join(dstDir, "partial.txt"), []byte("partial"), 0o644); err != nil {
+			return err
+		}
+		return fmt.Errorf("forced copy failure")
+	}
+	defer func() {
+		copyDirFunc = originalCopyDir
+	}()
+
+	err = st.ImportRelease(Release{ID: "release-partial"}, importedBundle)
+	if err == nil {
+		t.Fatalf("expected import failure")
+	}
+
+	releaseDir := filepath.Join(root, ".deck", "site", "releases", "release-partial")
+	if _, statErr := os.Stat(releaseDir); !os.IsNotExist(statErr) {
+		t.Fatalf("expected no leftover release dir, got err=%v", statErr)
 	}
 }


### PR DESCRIPTION
## Summary
- reject assignment writes for missing or closed sessions so store write behavior matches the rest of the session lifecycle
- make release imports write through a temporary directory so partial copy failures do not leave release artifacts behind
- add regression coverage for the new store policies and remove leftover preflight wording from the CLI docs