### PR TITLE
docs: simplify positioning and workflow guidance

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -2,98 +2,56 @@
 
 [English README](./README.md) | [문서 홈](./docs/README.md)
 
-`deck`은 no SSH, no PXE, no BMC, 그리고 인터넷 연결 자체를 전제할 수 없는 극단적인 air-gapped 환경에서 manual-first maintenance session을 수행하기 위한 단일 바이너리 도구입니다.
+`deck`은 air-gapped 환경과 운영 제약이 큰 현장을 위한 단순한 워크플로 도구입니다.
 
-운영자는 self-contained bundle을 준비해 사이트로 반입하고, 변경이 필요한 대상 장비에서 작업을 로컬로 직접 실행할 수 있습니다.
+더 큰 자동화 플랫폼이 맞지 않고, 커져버린 Bash 절차가 읽기 어렵고 검토하기 힘들어지는 상황을 위해 만들었습니다. `deck`의 모델은 작고 분명합니다. 워크플로를 작성하고, 검증하고, 필요한 것을 번들로 묶어 반입하고, 현장에서 로컬로 실행합니다.
 
 ## Visuals
 
 ![deck terminal demo](docs/assets/deck-cli.gif)
 
-## deck이 적합한 문제
+## Why deck exists
 
-- **수동 우선 운영**: 기본 경로는 대상 사이트에서 운영자가 직접 로컬 실행하는 방식입니다.
-- **극단적 air-gap 환경 집중**: 연결된 제어 루프를 사용할 수 없거나 신뢰할 수 없는 환경을 전제로 합니다.
-- **자가 포함 번들**: `bundle.tar`는 오프라인 작업에 필요한 워크플로, 아티팩트, `deck` 바이너리를 함께 담습니다.
-- **YAML 기반 워크플로**: 더 큰 제어 시스템 없이도 운영자가 읽고, 검토하고, 조정할 수 있습니다.
-- **명시적 site assistance**: 사이트 내부에서 임시 공유 서버나 조정 지점을 두고 싶다면 추가적으로 사용할 수 있지만, 그것이 기본 모드는 아닙니다.
+- **Air-gapped by design**: no SSH, no PXE, no BMC, 인터넷 비의존 환경을 기본으로 둡니다.
+- **작은 도구, 제한된 문제**: 새로운 범용 자동화 플랫폼을 만들려는 것이 아닙니다.
+- **Bash 확장 문제 완화**: 큰 운영 절차를 긴 shell 파일 대신 step과 phase로 읽을 수 있게 합니다.
+- **개발자 친화적 형태**: CI/CD YAML, Kubernetes manifest에 익숙한 사람이 빠르게 적응할 수 있습니다.
+- **번들 중심 실행**: 유지보수 전에 워크플로, 아티팩트, `deck` 바이너리를 함께 묶습니다.
 
-## deck을 써야 할 때
+## What deck is for
 
-- 아티팩트를 사전에 준비해서 승인된 경로로 반입한 뒤, 현장에서 로컬 실행해야 할 때
-- `validate -> pack -> apply`처럼 작고 명확한 운영 흐름이 필요할 때
-- 연결이 끊긴 호스트, 클러스터, 어플라이언스에 반복 가능한 유지보수 절차가 필요할 때
-- 나중에 선택적으로 site-local assistance를 추가할 수는 있어도, 각 노드의 실행 모델은 계속 로컬 실행으로 유지하고 싶을 때
+- 대상 호스트나 노드에서 로컬로 직접 실행해야 하는 반복 가능한 유지보수 절차
+- 패키지, 이미지, 파일, 워크플로 입력을 오프라인으로 준비해 반입해야 하는 작업
+- 더 큰 controller, agent, runtime stack 없이도 유지할 수 있는 단순한 도구가 필요한 팀
+- Bash로 시작했지만 이제는 절차가 너무 커져 가독성과 리뷰 품질이 무너진 경우
 
-## deck을 쓰지 말아야 할 때
+## What deck is not for
 
-- 원격 오케스트레이션 플랫폼, 장기 실행 control plane, agent 기반 rollout 시스템이 필요할 때
-- 항상 연결된 환경, 실시간 cloud API, SSH 기반 자동화가 기본 전제일 때
-- Terraform, Pulumi, Ansible 같은 범용 인프라 플랫폼을 대체하려고 할 때
+- 항상 연결된 인프라를 원격 오케스트레이션해야 하는 경우
+- Terraform, Pulumi, Ansible, Chef, Puppet 같은 범용 플랫폼의 대체를 기대하는 경우
+- 장기 실행 control plane, fleet agent, policy engine이 필요한 경우
+- live API와 중앙 controller가 정상 전제인 cloud-first 워크플로
 
-## Install
+## Why not just use Bash
 
-요구 사항:
+- 작은 스크립트는 빠르지만, 큰 운영 절차는 그렇지 않습니다.
+- Bash는 운영자의 의도보다 구현 디테일을 먼저 드러냅니다.
+- 절차가 길어질수록 리뷰 품질이 빠르게 떨어집니다.
+- 재사용, 검증, step 단위 reasoning이 약해집니다.
 
-- Go 1.22+
-- Linux 타깃 환경
+`deck`은 shell을 완전히 없애려는 도구가 아닙니다. 절차를 더 잘 보이게 구조화하고, `RunCommand`는 기본 작성 방식이 아니라 escape hatch로 남겨둡니다.
 
-```bash
-# 소스에서 바로 실행
-go run ./cmd/deck --help
+## Core flow
 
-# 바이너리 설치
-go install ./cmd/deck
+1. 유지보수 세션에 맞는 YAML 워크플로를 작성하거나 조정합니다.
+2. 반입 전과 실행 전에 워크플로 구조를 검증합니다.
+3. 워크플로, 아티팩트, `deck` 바이너리를 함께 묶은 self-contained bundle을 만듭니다.
+4. 승인된 경로를 통해 현장으로 번들을 반입합니다.
+5. 변경이 필요한 장비에서 `deck`을 로컬로 실행합니다.
 
-# 확인
-deck --help
-```
+## Minimal workflow
 
-## Quick Start
-
-1. 시작용 작업 공간을 만듭니다.
-
-```bash
-deck init --out ./demo
-```
-
-2. `./demo/workflows/pack.yaml`, `./demo/workflows/apply.yaml`, `./demo/workflows/vars.yaml`을 유지보수 세션에 맞게 수정합니다.
-
-3. 패키징이나 적용 전에 워크플로를 검증합니다.
-
-```bash
-deck validate --file ./demo/workflows/apply.yaml
-```
-
-4. 자체 포함형 오프라인 번들을 만듭니다.
-
-```bash
-deck pack --out ./bundle.tar
-```
-
-5. 번들을 오프라인 사이트로 반입한 뒤, 현장에서 로컬로 실행합니다.
-
-```bash
-deck apply
-```
-
-6. site-assisted execution은 사이트 내부에서 임시 공유 번들 소스나 로컬 coordination point가 정말 필요할 때만 추가합니다. 이 경로는 기본 로컬 흐름에 대한 보조적 선택지입니다.
-
-단계별 가이드는 `docs/tutorials/quick-start.md`부터 시작하시면 됩니다.
-
-## deck이 동작하는 방식
-
-1. 유지보수 작업에 맞는 YAML 워크플로를 작성하거나 조정합니다.
-2. `pack`이 패키지, 이미지, 파일, 워크플로, `deck` 바이너리를 번들에 모읍니다.
-3. 승인된 오프라인 반입 경로를 통해 번들을 전달합니다.
-4. `apply`는 SSH나 원격 실행 의존성 없이 대상 사이트에서 로컬로 실행됩니다.
-5. 선택적인 site-assisted workflow는 임시 로컬 서버나 공유 가시성을 추가할 수 있지만, 운영자는 여전히 각 대상에서 `deck`을 직접 실행합니다.
-
-## Workflow Model
-
-워크플로 DSL은 YAML 기반이며 step 실행을 중심으로 구성됩니다. 워크플로는 `role`(`pack` 또는 `apply`)을 선언하고, top-level `steps` 또는 이름 있는 `phases`를 사용합니다.
-
-일반적인 호스트 변경에는 typed primitive를 우선 사용하세요. 적절한 step kind가 없을 때만 `RunCommand`를 마지막 수단으로 남겨두는 것이 좋습니다.
+일반적인 호스트 변경에는 typed step을 우선 사용하고, 적절한 step kind가 없을 때만 `RunCommand`를 사용하세요.
 
 ```yaml
 role: apply
@@ -112,57 +70,63 @@ steps:
         gpgcheck=0
 ```
 
-공통 step 기능:
+## Install
 
-- `when` 조건 실행
-- `retry`, `timeout` 제어
-- step 출력값을 다음 step에 전달하는 `register`
-- 워크플로 및 각 지원 step kind에 대한 JSON Schema 검증
+Requirements:
 
-## Bundle Contract
+- Go 1.22+
+- Linux 타깃 환경
 
-설계상 준비된 번들에는 다음이 포함될 수 있습니다.
+```bash
+# 소스에서 바로 실행
+go run ./cmd/deck --help
 
-- 오프라인 실행 입력을 담는 `workflows/`
-- 수집된 아티팩트를 담는 `packages/`, `images/`, `files/`
-- 자체 실행을 위한 `deck` 및 `files/deck`
-- 아티팩트 체크섬 메타데이터를 담는 `.deck/manifest.json`
+# 바이너리 설치
+go install ./cmd/deck
 
-## Command Surface
+# verify
+deck --help
+```
 
-- 핵심 로컬 흐름: `init`, `validate`, `pack`, `apply`
-- 로컬 계획 및 진단: `diff`, `doctor`
-- 선택적 site-local helper: `serve`, `list`, `health`, `logs`
-- 번들 수명주기 및 캐시 관리: `bundle`, `cache`
-- 호환성과 고급 step은 계속 지원되지만, 새 워크플로에서는 `RunCommand`를 마지막 수단으로 두는 것이 좋습니다.
+## Quick Start
 
-## Documentation Map
+```bash
+deck init --out ./demo
+deck validate --file ./demo/workflows/apply.yaml
+deck validate --file ./demo/workflows/pack.yaml
 
-- 문서 홈: `docs/README.md`
-- Quick start 튜토리얼: `docs/tutorials/quick-start.md`
-- Offline Kubernetes 튜토리얼: `docs/tutorials/offline-kubernetes.md`
-- CLI 레퍼런스: `docs/reference/cli.md`
+cd ./demo
+deck pack --out ./bundle.tar
+deck apply
+```
+
+단계별 가이드는 `docs/tutorials/quick-start.md`부터 시작하시면 됩니다.
+
+## Learn more
+
+- Docs home: `docs/README.md`
+- 왜 deck인가: `docs/concepts/why-deck.md`
 - 워크플로 모델: `docs/reference/workflow-model.md`
-- 번들 구조: `docs/reference/bundle-layout.md`
-- 스키마 레퍼런스: `docs/reference/schema-reference.md`
-- 서버 감사 로그 레퍼런스: `docs/reference/server-audit-log.md`
+- CLI 레퍼런스: `docs/reference/cli.md`
 - 예제 워크플로: `docs/examples/README.md`
-- 원본 JSON Schema: `docs/schemas/README.md`
 
-## Scope and Non-goals
+## Scope and non-goals
 
-- `deck`은 air-gapped 준비, 패키징, 오프라인 설치, 결정적 로컬 실행에 집중합니다.
+- `deck`은 disconnected 환경에서의 단순하고 로컬한 bundle-first 실행에 집중합니다.
 - site-assisted 사용은 명시적이고 부가적인 선택지입니다. 로컬 운영자 경로를 대체하지 않습니다.
 - `deck`은 원격 오케스트레이션 프레임워크가 아닙니다.
-- 항상 연결된 cloud-first 워크플로를 최적화 대상으로 삼지 않습니다.
+- `deck`은 광범위한 온라인 인프라 자동화를 최적화 대상으로 삼지 않습니다.
 
-## Contributing and Validation
+## Contributing and validation
 
-변경 전에는 작업에 맞는 검증을 실행합니다.
+변경을 보내기 전에 작업에 맞는 검증을 실행합니다.
 
 ```bash
 go test ./...
 go run ./cmd/deck validate --file <workflow.yaml>
+
+# linux host with libvirt-backed vagrant
+bash test/vagrant/run-offline-multinode-agent.sh
 ```
 
 ## License

--- a/README.md
+++ b/README.md
@@ -2,34 +2,73 @@
 
 [Korean README](./README.ko.md) | [Documentation](./docs/README.md)
 
-`deck` is a single-binary tool for manual-first maintenance sessions in extreme air-gapped environments: no SSH, no PXE, no BMC, and no internet assumptions.
+`deck` is a simple workflow tool for air-gapped and operationally constrained environments.
 
-It helps operators prepare a self-contained bundle, carry it into the site, and run the work locally on the machine that needs the change.
+It exists for the cases where larger automation platforms are a bad fit and growing Bash procedures become hard to read, review, and maintain. `deck` keeps the model small: write a workflow, validate it, bundle what the site needs, carry it in, and run it locally.
 
 ## Visuals
 
 ![deck terminal demo](docs/assets/deck-cli.gif)
 
+## Why deck exists
+
+- **Air-gapped by design**: built for sites with no SSH, no PXE, no BMC, and no internet assumptions.
+- **Small tool, bounded problem**: not a new general-purpose automation platform.
+- **Structured over sprawling shell**: large procedures stay readable as steps and phases instead of turning into long Bash files.
+- **Developer-friendly shape**: YAML workflows feel familiar to people who already work with CI/CD pipelines and Kubernetes manifests.
+- **Bundle-first execution**: package the workflow, artifacts, and `deck` binary together before the maintenance session.
+
 ## What deck is for
 
-- **Manual-first operation**: the default path is local execution by an operator at the target site.
-- **Extreme air-gap focus**: `deck` is built for places where connected control loops are not available or not trusted.
-- **Hermetic bundles**: `bundle.tar` carries workflows, artifacts, and the `deck` binary needed for offline work.
-- **YAML-driven workflows**: operators can read, review, and adapt workflows without adding a larger control system.
-- **Explicit site assistance**: if a site wants a temporary shared server or coordination point inside the air gap, that is additive and deliberate, not the base mode.
+- Repeatable maintenance procedures that must run locally on the target host or node.
+- Offline preparation and transfer of packages, images, files, and workflow inputs.
+- Teams that want a simple workflow engine instead of a larger controller, agent system, or runtime stack.
+- Situations where Bash started simple but the procedure is now too large to review comfortably.
 
-## When to use deck
+## What deck is not for
 
-- You need to prepare artifacts ahead of time, transfer them through an approved path, and execute locally at the site.
-- You want a small operator workflow such as `validate -> pack -> apply`.
-- You need repeatable maintenance steps for disconnected hosts, clusters, or appliances.
-- You may need optional site-local assistance later, but you still want the same local execution model on each node.
+- Remote orchestration across always-connected infrastructure.
+- General replacement for Terraform, Pulumi, Ansible, Chef, Puppet, or other broad platforms.
+- Long-lived control planes, fleet agents, or policy engines.
+- Cloud-first workflows where live APIs and central controllers are normal assumptions.
 
-## When not to use deck
+## Why not just use Bash
 
-- You want a remote orchestration platform, long-lived control plane, or agent-based rollout system.
-- You expect always-on connectivity, live cloud APIs, or SSH-driven automation as the normal path.
-- You need a general replacement for Terraform, Pulumi, Ansible, or other broad infrastructure platforms.
+- Small scripts are fast. Large procedures are not.
+- Bash tends to hide operator intent inside command details.
+- Review quality drops when a procedure becomes one long shell file.
+- Reuse, validation, and step-level reasoning get weak quickly.
+
+`deck` does not try to eliminate shell completely. It gives the procedure a clearer structure and keeps `RunCommand` as the escape hatch, not the default authoring model.
+
+## Core flow
+
+1. Write or adapt YAML workflows for the maintenance session.
+2. Validate the workflow shape before transport or execution.
+3. Build a self-contained bundle with the workflow, artifacts, and `deck` binary.
+4. Carry the bundle into the site through the approved path.
+5. Run `deck` locally on the machine that needs the change.
+
+## Minimal workflow
+
+Prefer typed steps for common host changes. Keep `RunCommand` for the cases where no supported step kind fits yet.
+
+```yaml
+role: apply
+version: v1alpha1
+steps:
+  - id: write-repo-config
+    apiVersion: deck/v1alpha1
+    kind: WriteFile
+    spec:
+      path: /etc/example.repo
+      content: |
+        [offline-base]
+        name=offline-base
+        baseurl=file:///srv/offline-repo
+        enabled=1
+        gpgcheck=0
+```
 
 ## Install
 
@@ -51,112 +90,34 @@ deck --help
 
 ## Quick Start
 
-1. Create a starter workspace.
-
 ```bash
 deck init --out ./demo
-```
-
-2. Edit `./demo/workflows/pack.yaml`, `./demo/workflows/apply.yaml`, and `./demo/workflows/vars.yaml` for the maintenance session you want to run.
-
-3. Validate the workflow before packaging or applying it.
-
-```bash
 deck validate --file ./demo/workflows/apply.yaml
-```
+deck validate --file ./demo/workflows/pack.yaml
 
-4. Build a self-contained offline bundle.
-
-```bash
+cd ./demo
 deck pack --out ./bundle.tar
-```
-
-5. Carry the bundle into the offline site and execute locally.
-
-```bash
 deck apply
 ```
 
-6. Add site-assisted execution only if you explicitly want a temporary shared bundle source or local coordination point inside the air gap. That path is secondary to the default local flow.
+Start with `docs/tutorials/quick-start.md` for the guided path.
 
-For a guided walkthrough, start with `docs/tutorials/quick-start.md`.
-
-## How deck works
-
-1. Author or adapt YAML workflows for the maintenance task.
-2. `pack` gathers packages, images, files, workflows, and the `deck` binary into a bundle.
-3. Transfer the bundle through an approved offline path.
-4. `apply` runs locally at the target site with no SSH or remote execution dependency.
-5. Optional site-assisted workflows can add a temporary local server or shared visibility, but the operator still runs `deck` directly on each target.
-
-## Workflow Model
-
-The workflow DSL is YAML-based and centered on step execution. A workflow declares a `role` (`pack` or `apply`) and then defines either top-level `steps` or named `phases`.
-
-Prefer typed primitives for common host changes. Keep `RunCommand` for cases where no supported step kind fits yet.
-
-```yaml
-role: apply
-version: v1alpha1
-steps:
-  - id: write-repo-config
-    apiVersion: deck/v1alpha1
-    kind: WriteFile
-    spec:
-      path: /etc/example.repo
-      content: |
-        [offline-base]
-        name=offline-base
-        baseurl=file:///srv/offline-repo
-        enabled=1
-        gpgcheck=0
-```
-
-Common step features include:
-
-- `when` for conditional execution
-- `retry` and `timeout` for controlled retries
-- `register` for passing step outputs into later steps
-- JSON Schema validation for the workflow and each supported step kind
-
-## Bundle Contract
-
-By design, a prepared bundle can include:
-
-- `workflows/` for offline execution inputs
-- `packages/`, `images/`, and `files/` for fetched artifacts
-- `deck` and `files/deck` for self-contained execution
-- `.deck/manifest.json` for artifact checksum metadata
-
-## Command Surface
-
-- Core local flow: `init`, `validate`, `pack`, `apply`
-- Local planning and diagnostics: `diff`, `doctor`
-- Optional site-local helpers: `serve`, `list`, `health`, `logs`
-- Bundle lifecycle and cache management: `bundle`, `cache`
-- Compatibility and advanced steps still exist, but `RunCommand` should be a last resort in new workflows
-
-## Documentation Map
+## Learn more
 
 - Docs home: `docs/README.md`
-- Quick start tutorial: `docs/tutorials/quick-start.md`
-- Offline Kubernetes tutorial: `docs/tutorials/offline-kubernetes.md`
-- CLI reference: `docs/reference/cli.md`
+- Why deck: `docs/concepts/why-deck.md`
 - Workflow model: `docs/reference/workflow-model.md`
-- Bundle layout: `docs/reference/bundle-layout.md`
-- Schema reference: `docs/reference/schema-reference.md`
-- Server audit log reference: `docs/reference/server-audit-log.md`
+- CLI reference: `docs/reference/cli.md`
 - Example workflows: `docs/examples/README.md`
-- Raw JSON schemas: `docs/schemas/README.md`
 
-## Scope and Non-goals
+## Scope and non-goals
 
-- `deck` focuses on air-gapped preparation, packaging, offline installation, and deterministic local execution.
+- `deck` focuses on simple, local, bundle-first execution in disconnected environments.
 - Site-assisted use is explicit and additive. It does not replace the local operator path.
 - `deck` is not a remote orchestration framework.
-- `deck` is not optimized for cloud-first or always-connected workflows.
+- `deck` is not optimized for broad online infrastructure automation.
 
-## Contributing and Validation
+## Contributing and validation
 
 Before sending changes, run the checks that match your work:
 
@@ -167,9 +128,6 @@ go run ./cmd/deck validate --file <workflow.yaml>
 # linux host with libvirt-backed vagrant
 bash test/vagrant/run-offline-multinode-agent.sh
 ```
-
-Local Vagrant runs keep machine state in `test/vagrant/.vagrant/` and reuse the prepared bundle cache in `test/artifacts/cache/offline-multinode-prepared-bundle/` across runs.
-The default local loop now prefers `rsync`, keeps VMs alive, and reuses `test/artifacts/offline-multinode-local/` unless you choose a different `--art-dir` or run with `--fresh`.
 
 ## License
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,49 +1,41 @@
 # deck documentation
 
-This directory is organized around the default `deck` operator path: prepare a bundle, carry it into the site, and run the maintenance session locally.
+`deck` documentation follows the same idea as the product itself: keep the model small, explicit, and easy to scan.
 
-Site-assisted execution is documented here too, but it is a secondary, explicit choice for teams that want temporary shared visibility or a site-local content source inside the air gap.
+`deck` is for air-gapped and operationally constrained environments where larger automation systems are a bad fit and growing Bash procedures become hard to manage.
 
 ## Start here
 
 - New to `deck`: `tutorials/quick-start.md`
-- Building an offline Kubernetes maintenance flow: `tutorials/offline-kubernetes.md`
+- Why the tool exists: `concepts/why-deck.md`
+- Looking for workflow structure: `reference/workflow-model.md`
 - Looking for commands: `reference/cli.md`
-- Looking for YAML structure: `reference/workflow-model.md`
 - Looking for bundle contents: `reference/bundle-layout.md`
-- Looking for schemas: `reference/schema-reference.md` and `schemas/README.md`
 - Looking for examples: `examples/README.md`
 
-## When to use deck
+## Core ideas
 
-- You are preparing work outside the air gap and executing it locally inside the site.
-- You want one operator-friendly workflow that stays useful even with no network services at the destination.
-- You need optional site-local assistance without changing the underlying local execution model.
+- `deck` is not a broad automation platform.
+- `deck` is a simple workflow tool for local execution.
+- The workflow should stay readable when the procedure grows.
+- The safest offline default is to bundle what the site needs.
+- Site-assisted helpers are optional and secondary.
 
-## When not to use deck
+## Guides
 
-- You need a remote executor, long-lived service controller, or agent platform.
-- You want online-first infrastructure automation as the main operating model.
-- You need a broad infrastructure provisioning suite rather than a bounded offline maintenance tool.
-
-## Tutorials
-
-- `tutorials/quick-start.md`: create a workspace, validate it, build a bundle, and apply it locally
-- `tutorials/offline-kubernetes.md`: adapt the shipped examples for Kubernetes-oriented offline maintenance sessions
+- `concepts/why-deck.md`: scope, positioning, and why large Bash procedures are the real problem
+- `tutorials/quick-start.md`: create, validate, pack, and run a workflow
+- `tutorials/offline-kubernetes.md`: use `deck` for offline Kubernetes-oriented maintenance work
 
 ## Reference
 
-- `reference/cli.md`: command groups, default local flow, and secondary site-local helpers
-- `reference/workflow-model.md`: workflow structure, step fields, and execution semantics
-- `reference/bundle-layout.md`: what `pack` puts into a bundle and why it matters offline
-- `reference/schema-reference.md`: workflow schema, tool schema layout, and supported step kinds
-- `reference/server-audit-log.md`: audit log location and JSONL record shape for `deck serve`
+- `reference/workflow-model.md`: workflow shape, phases, steps, and execution controls
+- `reference/cli.md`: command surface and default usage pattern
+- `reference/bundle-layout.md`: bundle contract and why it matters offline
+- `reference/schema-reference.md`: schema files and supported step kinds
+- `reference/server-audit-log.md`: audit log format for `deck serve`
 
-## Examples and Raw Schemas
+## Examples and schemas
 
-- `examples/README.md`: example workflows for local execution first, then site-specific adaptation
+- `examples/README.md`: example workflows to adapt to real procedures
 - `schemas/README.md`: raw schema files and validation entry points
-
-## Archive
-
-Older planning notes, CI runbooks, parity drafts, and superseded docs were moved under `archive/` to keep the main documentation focused on current user-facing material.

--- a/docs/concepts/why-deck.md
+++ b/docs/concepts/why-deck.md
@@ -1,0 +1,46 @@
+# Why deck
+
+`deck` exists for a narrow problem.
+
+In connected environments, established tools already cover a lot of ground. `deck` does not try to outgrow or out-market them. It focuses on the places they do not fit well: disconnected sites, constrained operations, and procedures that still need local human execution.
+
+## The real problem
+
+The problem is not only that Bash can be dangerous.
+
+The bigger problem is that Bash-based procedures often collapse as they grow:
+
+- the intent of the procedure gets buried inside implementation details
+- reviews get harder because everything looks like shell
+- reuse becomes informal copy-paste
+- validation usually happens late
+- operators have to reverse-engineer the script before trusting it
+
+`deck` gives those procedures a smaller and clearer shape.
+
+## What deck does
+
+- models maintenance work as YAML workflows with steps and phases
+- prefers typed operations for common host changes
+- validates workflow structure before transport or execution
+- builds a self-contained bundle for offline handoff
+- runs locally on the target machine without requiring SSH or a long-lived controller
+
+## Design principles
+
+- **Simple**: small command surface and a bounded operating model
+- **Local-first**: the default path is local execution on the machine that needs the change
+- **Bundle-first**: bring the workflow and its required artifacts together
+- **Readable**: operators should be able to review intent quickly
+- **Pragmatic**: shell stays available through `RunCommand`, but it should not be the main authoring style
+
+## What deck is not trying to be
+
+- a replacement for broad infrastructure platforms
+- a remote orchestration control plane
+- a permanent site management service
+- a tool that assumes rich online dependencies
+
+## The intended user
+
+`deck` is for operators and DevOps engineers who already think in YAML, stages, manifests, and repeatable procedures, but need a much smaller tool for disconnected work.

--- a/docs/examples/README.md
+++ b/docs/examples/README.md
@@ -1,20 +1,21 @@
 # Example Workflows
 
-The files in `docs/examples/` are examples for the default `deck` model: prepare the bundle outside the site, then execute the workflow locally during the maintenance session.
+The files in `docs/examples/` are small starting points for real procedures.
 
-You can also adapt them for site-assisted use inside the air gap, but that is a deliberate extension of the same local execution path.
+They are meant to show how `deck` keeps operational work readable: use typed steps where possible, keep the workflow shape obvious, and treat shell as the fallback.
 
-## When to use these examples
+## How to use these examples
 
-- Start from them when you want a concrete local workflow to review and adapt.
-- Use them to replace repetitive shell snippets with clearer typed steps where possible.
-- Carry them into a bundle and run them on the target host or node.
+- start from them when you want a concrete workflow to adapt
+- keep the overall structure clear before adding more details
+- replace repetitive shell with typed steps when a step kind already fits
+- validate the result before packaging or transport
 
-## When not to use these examples
+## What not to assume
 
-- Don't treat them as remote orchestration playbooks.
-- Don't assume a shared server is required before they are useful.
-- Don't use `RunCommand` first if a more specific step kind can express the change.
+- these are not remote orchestration playbooks
+- these do not require a shared server to be useful
+- `RunCommand` is not the preferred first choice just because it is flexible
 
 ## Files
 

--- a/docs/reference/bundle-layout.md
+++ b/docs/reference/bundle-layout.md
@@ -1,6 +1,8 @@
 # Bundle Layout
 
-`deck pack` is built around a hermetic bundle contract. The offline site should receive everything needed to execute the workflow locally.
+`deck pack` builds a self-contained bundle because disconnected work gets harder when dependencies stay implicit.
+
+The bundle is part of the product model, not an afterthought.
 
 ## Typical bundle contents
 
@@ -14,10 +16,11 @@
 
 ## Why the bundle matters
 
-- It reduces hidden runtime dependencies inside the air gap.
-- It keeps the operator handoff concrete: a bundle can be inspected, transferred, verified, and executed.
-- It aligns with the project goal of being hermetic and self-contained.
+- it keeps offline handoff explicit
+- it reduces hidden runtime dependencies
+- it makes the procedure easier to inspect before transport
+- it supports the simple local execution model
 
 ## Core rule
 
-If an offline site needs it to execute the workflow, the safest default is to make it part of the bundle rather than assuming it already exists.
+If the site needs it to run the workflow, the safest default is to include it in the bundle rather than assume it already exists.

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -1,40 +1,43 @@
 # CLI Reference
 
-This page describes the current `deck` command surface, starting with the default local operator flow.
+The `deck` CLI is intentionally small.
+
+It supports a simple operator flow: author the workflow, validate it, build the bundle, and run locally.
 
 ## Default local flow
 
 - `init`: create starter workflow files under `workflows/`
-- `validate`: validate a workflow file against the top-level workflow schema and the relevant step schema
+- `validate`: validate a workflow file against the workflow and step schemas
 - `pack`: gather artifacts, copy workflows, embed the `deck` binary, and write `bundle.tar`
-- `diff`: inspect which apply steps would run or skip before you execute
-- `doctor`: generate a validation report for workflow inputs and referenced artifacts
+- `diff`: inspect which apply steps would run or skip before execution
+- `doctor`: generate a report for preflight-style checks and diagnostics
 - `apply`: execute the `apply` workflow locally
 
 ## Optional site-local helpers
 
-- `serve`: expose a prepared bundle root over HTTP inside the air gap when you explicitly want a shared local source
+- `serve`: expose a prepared bundle root over HTTP inside the air gap when a shared local source is useful
 - `list`: inspect available workflows from a local bundle root or an explicitly chosen server
 - `health`: check `/healthz` on an explicitly chosen server
 - `logs`: read server audit logs when you are using `deck serve`
 
-These commands support site-assisted workflows. They do not replace the default local execution path.
+These commands are additive. They do not replace the default local execution path.
 
 ## Other lifecycle commands
 
 - `bundle`: bundle lifecycle operations
 - `cache`: inspect or clean the artifact cache
 - `node`: inspect or manage the stable local `node_id`
-- `site`: manage local release/session/assignment lifecycle at the site store
+- `site`: manage local release, session, and assignment state at the site store
 
 ## Common examples
 
 ```bash
 deck init --out ./demo
 deck validate --file ./demo/workflows/apply.yaml
+deck validate --file ./demo/workflows/pack.yaml
+
+cd ./demo
 deck pack --out ./bundle.tar
-tar -xf ./bundle.tar
-cd ./bundle
 deck diff --file ./workflows/apply.yaml
 deck doctor --file ./workflows/apply.yaml --out ./reports/doctor.json
 deck apply --file ./workflows/apply.yaml
@@ -52,4 +55,5 @@ deck health --server http://127.0.0.1:8080
 
 - `pack` expects a workflow directory containing `pack.yaml`, `apply.yaml`, and `vars.yaml`.
 - `apply` defaults to the `install` phase when phases are used.
-- Prefer typed step kinds for common host changes. `RunCommand` remains available, but it is best kept for last-resort cases.
+- Prefer typed step kinds for common host changes.
+- Keep `RunCommand` for cases where the clearer typed form does not exist yet.

--- a/docs/reference/workflow-model.md
+++ b/docs/reference/workflow-model.md
@@ -1,6 +1,15 @@
 # Workflow Model
 
-`deck` uses a YAML workflow model designed to stay readable for operators who already think in manifests.
+`deck` uses a small YAML workflow model so larger procedures stay reviewable.
+
+The goal is not to invent a giant DSL. The goal is to give air-gapped operational work a clearer structure than a growing Bash script.
+
+## Why the model looks this way
+
+- procedures need visible structure when they get long
+- operators should review intent, not reverse-engineer shell
+- DevOps users should feel at home with YAML, stages, and manifest-like documents
+- common host changes should use typed steps instead of ad hoc command blocks
 
 ## Top-level fields
 
@@ -44,7 +53,26 @@ Optional execution controls:
 - `timeout`: duration string such as `30s` or `5m`
 - `register`: export step outputs into later runtime values
 
-## Supported step kinds
+## Phases
+
+Use phases when the procedure has natural boundaries.
+
+That keeps large workflows readable and lets the operator see the intended order without reading every command detail.
+
+Typical examples:
+
+- `prepare`
+- `install`
+- `verify`
+- `cleanup`
+
+## Prefer typed steps
+
+Typed steps are the center of the model.
+
+They make the workflow easier to scan, easier to validate, and easier to evolve than shell-heavy procedures.
+
+Supported step kinds include:
 
 - `CheckHost`
 - `DownloadPackages`
@@ -71,14 +99,25 @@ Optional execution controls:
 - `KubeadmInit`
 - `KubeadmJoin`
 
-## Why the model looks this way
+## When to use RunCommand
 
-- It is explicit enough for offline troubleshooting.
-- It is YAML-shaped for Kubernetes-familiar users.
-- It supports schema validation without introducing a remote orchestration dependency.
+Use `RunCommand` when no supported step kind fits yet.
+
+That is the escape hatch, not the ideal authoring path. If a workflow leans heavily on `RunCommand`, the procedure may still be too close to raw shell.
+
+## Validation model
+
+`deck validate` checks:
+
+- the top-level workflow schema
+- the schema for each referenced step kind
+- reserved runtime keys and workflow compatibility rules
+
+This is one of the main reasons to use a workflow model instead of passing around shell files.
 
 ## Related references
 
+- `../concepts/why-deck.md`
 - `schema-reference.md`
 - `bundle-layout.md`
 - `../schemas/deck-workflow.schema.json`

--- a/docs/tutorials/offline-kubernetes.md
+++ b/docs/tutorials/offline-kubernetes.md
@@ -1,6 +1,8 @@
 # Offline Kubernetes Tutorial
 
-This tutorial shows how to use `deck` for a manual-first Kubernetes maintenance session in the environment it is built for: a site with no internet, no SSH-based orchestration, no PXE, and no BMC dependencies.
+This tutorial shows how `deck` fits a Kubernetes maintenance session in the environment it is built for: no internet, no SSH-driven orchestration, and a local operator path.
+
+The reason to use `deck` here is not only offline transport. It is also that Kubernetes host-prep and bootstrap procedures grow quickly, and raw shell becomes hard to review.
 
 ## Goal
 
@@ -16,20 +18,34 @@ Relevant examples in this repository:
 - `../examples/offline-containerd-mirror.yaml`
 - `../examples/offline-verify-images.yaml`
 
-These examples are intentionally YAML-first so operators can review and adapt them before carrying anything into the site.
+These examples are meant to be read and adapted, not treated as opaque automation blobs.
 
 ## 2. Keep the two jobs separate
 
-- `pack` is the preparation step outside the air gap
-- `apply` is the execution step inside the air gap
+- `pack` gathers what the site needs before transport
+- `apply` executes the procedure locally on the node
 
-The core mental model is:
+The mental model is:
 
 ```text
 prepare artifacts -> pack bundle -> transfer bundle -> run locally on each node
 ```
 
-## 3. Prepare the bundle in the connected environment
+## 3. Model the procedure clearly
+
+Use steps and phases to show the operator what the procedure is doing.
+
+Typical boundaries in Kubernetes workflows:
+
+- host preparation
+- package or image setup
+- runtime configuration
+- kubeadm bootstrap or join
+- verification
+
+Prefer typed steps where possible. Keep `RunCommand` for the edges that are not modeled yet.
+
+## 4. Prepare the bundle in the connected environment
 
 Author a `pack` workflow that gathers the packages, container images, files, and templates your site needs.
 
@@ -41,13 +57,13 @@ deck pack --out ./bundle.tar
 
 The bundle can include `packages/`, `images/`, `files/`, `workflows/`, the `deck` binary, and `.deck/manifest.json` checksums.
 
-## 4. Move the bundle into the offline site
+## 5. Move the bundle into the offline site
 
-Transfer `bundle.tar` through the approved path for your environment: removable media, controlled gateway, or any other site-approved handoff.
+Transfer `bundle.tar` through the approved path for your environment: removable media, controlled gateway, or another site-approved handoff.
 
-`deck` assumes this transfer step is out-of-band. It does not depend on SSH automation or a remote control service.
+`deck` assumes this step is out-of-band. It does not require a remote control service.
 
-## 5. Run workflows locally on the target nodes
+## 6. Run workflows locally on the target nodes
 
 At the offline site, execute on the target machine itself:
 
@@ -55,36 +71,22 @@ At the offline site, execute on the target machine itself:
 deck apply
 ```
 
-Use the control-plane and worker examples as building blocks for kubeadm-based cluster bootstrap and follow-on maintenance.
+Use the control-plane and worker examples as starting points for kubeadm-based bootstrap and follow-on maintenance.
 
-## 6. Add site assistance only when it solves a real local problem
+## 7. Add site assistance only when it solves a local problem
 
 Some sites want a temporary shared source for bundle contents or a local place to collect session status. That can help when multiple nodes need the same release inside the same air gap.
 
-Keep that choice explicit and secondary. The operator workflow still centers on local `deck` execution on each node, not remote triggering.
+Keep that choice explicit and secondary. The operator workflow still centers on local `deck` execution on each node.
 
-## 7. When to use deck here
-
-- You are walking nodes one by one in a disconnected Kubernetes environment.
-- You need deterministic local steps for bootstrap, repair, upgrade prep, or validation.
-- You want optional site-local coordination without changing the local execution model.
-
-## 8. When not to use deck here
-
-- You want cluster-wide remote orchestration from a central controller.
-- You expect unattended execution pushed from a service.
-- You need a general online Kubernetes platform manager instead of an offline maintenance-session tool.
-
-## 9. Validate the workflow shape and artifact assumptions
-
-Before transport or execution, validate your YAML and schema compatibility:
+## 8. Validate before transport and execution
 
 ```bash
 deck validate --file ./workflows/pack.yaml
 deck validate --file ./workflows/apply.yaml
 ```
 
-For workflow planning and diagnostics, also review:
+For planning and diagnostics, also review:
 
 - `../reference/workflow-model.md`
 - `../reference/schema-reference.md`

--- a/docs/tutorials/quick-start.md
+++ b/docs/tutorials/quick-start.md
@@ -1,8 +1,14 @@
 # Quick Start
 
-This tutorial shows the default `deck` path: initialize a workspace, validate it, build a bundle, carry it into the site, and run it locally.
+This tutorial shows the default `deck` path:
 
-If you later add site-assisted execution, treat that as an explicit extension of the same local workflow, not a different product mode.
+1. create a workspace
+2. express the procedure as a workflow
+3. validate it
+4. build the bundle
+5. run it locally
+
+That small loop is the point of the tool.
 
 ## 1. Create a workspace
 
@@ -18,9 +24,9 @@ This creates:
 
 ## 2. Add or edit steps
 
-`deck init` starts with empty workflow files. Add the preparation work to `pack.yaml` and the maintenance steps to `apply.yaml`.
+`deck init` starts with empty workflow files. Put preparation work in `pack.yaml` and target-machine work in `apply.yaml`.
 
-Start with typed step kinds when they fit the job. Keep shell commands for edge cases only.
+Prefer typed steps first. The goal is to keep the procedure readable when it grows.
 
 Minimal example:
 
@@ -57,7 +63,7 @@ cd ./demo
 deck pack --out ./bundle.tar
 ```
 
-The resulting bundle is designed to be self-contained for offline transport.
+The resulting bundle is designed to be the thing you carry into the site.
 
 ## 5. Apply locally at the target site
 
@@ -65,18 +71,16 @@ The resulting bundle is designed to be self-contained for offline transport.
 deck apply
 ```
 
-`apply` executes the `apply` workflow locally. That is the base `deck` story: prepare outside the air gap, move the bundle in, then run the maintenance session on the target machine.
+`apply` executes the workflow locally. That is the default `deck` story: make the procedure understandable, package what it needs, then run it on the machine that needs the change.
 
-## 6. Optional: add site-assisted execution
+## 6. Optional: add site assistance
 
-Use a site-assisted path only when you explicitly want a temporary site-local server, shared bundle source, or session visibility inside the air gap.
+Use site-assisted features only when you explicitly want a temporary local server, shared bundle source, or session visibility inside the air gap.
 
-That choice is additive. Operators still run `deck diff`, `deck doctor`, and `deck apply` locally on the nodes that need the work.
-
-`RunCommand` is still supported, but keep it as a last resort when a clearer step kind does not fit yet.
+That path extends the same local workflow. It does not replace it.
 
 ## What to read next
 
-- `../tutorials/offline-kubernetes.md`
+- `../concepts/why-deck.md`
 - `../reference/workflow-model.md`
 - `../reference/bundle-layout.md`


### PR DESCRIPTION
## Summary
- refocus the README and docs around deck as a simple workflow tool for air-gapped, constrained environments
- add a why-deck concepts page and tighten the reference/tutorial copy around readable workflows over growing Bash procedures
- trim repeated README and docs index content so the documentation feels smaller and easier to scan