### PR TITLE
Improve CLI help structure

### DIFF
--- a/cmd/deck/cmd_apply.go
+++ b/cmd/deck/cmd_apply.go
@@ -6,7 +6,6 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"errors"
-	"flag"
 	"fmt"
 	"io"
 	"net/http"
@@ -25,8 +24,7 @@ import (
 )
 
 func runDiff(args []string) error {
-	fs := flag.NewFlagSet("diff", flag.ContinueOnError)
-	fs.SetOutput(os.Stderr)
+	fs := newHelpFlagSet("diff")
 	var file string
 	registerFileFlags(fs, &file, "path to workflow file")
 	server := ""
@@ -38,7 +36,7 @@ func runDiff(args []string) error {
 	registerOutputFormatFlags(fs, &output, "text")
 	vars := &varFlag{}
 	fs.Var(vars, "var", "set variable override (key=value), repeatable")
-	if err := fs.Parse(args); err != nil {
+	if err := parseFlags(fs, args, diffHelpText()); err != nil {
 		return err
 	}
 
@@ -160,8 +158,7 @@ type doctorCheck struct {
 }
 
 func runDoctor(args []string) error {
-	fs := flag.NewFlagSet("doctor", flag.ContinueOnError)
-	fs.SetOutput(os.Stderr)
+	fs := newHelpFlagSet("doctor")
 	var file string
 	registerFileFlags(fs, &file, "path or URL to workflow file")
 	server := ""
@@ -171,7 +168,7 @@ func runDoctor(args []string) error {
 	out := fs.String("out", "", "output report path (required)")
 	vars := &varFlag{}
 	fs.Var(vars, "var", "set variable override (key=value), repeatable")
-	if err := fs.Parse(args); err != nil {
+	if err := parseFlags(fs, args, doctorHelpText()); err != nil {
 		return err
 	}
 
@@ -521,8 +518,7 @@ func findWorkflowPhaseByName(wf *config.Workflow, name string) (config.Phase, bo
 }
 
 func runApply(args []string) error {
-	fs := flag.NewFlagSet("apply", flag.ContinueOnError)
-	fs.SetOutput(os.Stderr)
+	fs := newHelpFlagSet("apply")
 	var file string
 	registerFileFlags(fs, &file, "path or URL to workflow file")
 	server := ""
@@ -534,7 +530,7 @@ func runApply(args []string) error {
 	dryRun := fs.Bool("dry-run", false, "print apply plan without executing steps")
 	vars := &varFlag{}
 	fs.Var(vars, "var", "set variable override (key=value), repeatable")
-	if err := fs.Parse(args); err != nil {
+	if err := parseFlags(fs, args, applyHelpText()); err != nil {
 		return err
 	}
 	if fs.NArg() > 2 {
@@ -1007,14 +1003,13 @@ func discoverApplyWorkflow(bundleRoot string) (string, error) {
 	return matches[0], nil
 }
 func runValidate(args []string) error {
-	fs := flag.NewFlagSet("validate", flag.ContinueOnError)
-	fs.SetOutput(os.Stderr)
+	fs := newHelpFlagSet("validate")
 
 	var file string
 	registerFileFlags(fs, &file, "path or URL to workflow file")
 	vars := &varFlag{}
 	fs.Var(vars, "var", "set variable override (key=value), repeatable")
-	if err := fs.Parse(args); err != nil {
+	if err := parseFlags(fs, args, validateHelpText()); err != nil {
 		return err
 	}
 

--- a/cmd/deck/cmd_bundle.go
+++ b/cmd/deck/cmd_bundle.go
@@ -3,7 +3,6 @@ package main
 import (
 	"encoding/json"
 	"errors"
-	"flag"
 	"fmt"
 	"github.com/taedi90/deck/internal/bundle"
 	"os"
@@ -13,14 +12,13 @@ import (
 )
 
 func runWorkflowInit(args []string) error {
-	fs := flag.NewFlagSet("workflow init", flag.ContinueOnError)
-	fs.SetOutput(os.Stderr)
+	fs := newHelpFlagSet("workflow init")
 	output := fs.String("out", ".", "output directory")
-	if err := fs.Parse(args); err != nil {
+	if err := parseFlags(fs, args, initHelpText()); err != nil {
 		return err
 	}
 	if fs.NArg() != 0 {
-		return errors.New("usage: deck init [--out <dir>]")
+		return errors.New(initHelpText())
 	}
 	resolvedOutput := strings.TrimSpace(*output)
 	if resolvedOutput == "" {
@@ -91,13 +89,15 @@ func initTemplateFiles() map[string]string {
 }
 func runWorkflowBundle(args []string) error {
 	if len(args) == 0 {
-		return errors.New("usage: bundle verify <path> | bundle inspect <path> [--output text|json] | bundle import --file <bundle.tar> --dest <dir> | bundle collect --root <dir> --out <bundle.tar> | bundle merge <bundle.tar> --to <dir> [--dry-run]")
+		return errors.New(bundleHelpText())
+	}
+	if wantsHelp(args) {
+		return errors.New(bundleHelpText())
 	}
 
 	switch args[0] {
 	case "verify":
-		fs := flag.NewFlagSet("workflow bundle verify", flag.ContinueOnError)
-		fs.SetOutput(os.Stderr)
+		fs := newHelpFlagSet("workflow bundle verify")
 		bundlePath := fs.String("file", "", "bundle path (directory or bundle.tar)")
 		parseArgs := append([]string{}, args[1:]...)
 		positionalPath := ""
@@ -105,7 +105,7 @@ func runWorkflowBundle(args []string) error {
 			positionalPath = strings.TrimSpace(parseArgs[0])
 			parseArgs = parseArgs[1:]
 		}
-		if err := fs.Parse(parseArgs); err != nil {
+		if err := parseFlags(fs, parseArgs, bundleVerifyHelpText()); err != nil {
 			return err
 		}
 		if fs.NArg() > 0 {
@@ -127,8 +127,7 @@ func runWorkflowBundle(args []string) error {
 		return nil
 
 	case "inspect":
-		fs := flag.NewFlagSet("workflow bundle inspect", flag.ContinueOnError)
-		fs.SetOutput(os.Stderr)
+		fs := newHelpFlagSet("workflow bundle inspect")
 		bundlePath := fs.String("file", "", "bundle path (directory or bundle.tar)")
 		output := ""
 		registerOutputFormatFlags(fs, &output, "text")
@@ -138,7 +137,7 @@ func runWorkflowBundle(args []string) error {
 			positionalPath = strings.TrimSpace(parseArgs[0])
 			parseArgs = parseArgs[1:]
 		}
-		if err := fs.Parse(parseArgs); err != nil {
+		if err := parseFlags(fs, parseArgs, bundleInspectHelpText()); err != nil {
 			return err
 		}
 		if fs.NArg() > 0 {
@@ -171,11 +170,10 @@ func runWorkflowBundle(args []string) error {
 		return nil
 
 	case "import":
-		fs := flag.NewFlagSet("workflow bundle import", flag.ContinueOnError)
-		fs.SetOutput(os.Stderr)
+		fs := newHelpFlagSet("workflow bundle import")
 		archiveFile := fs.String("file", "", "bundle archive file path")
 		destDir := fs.String("dest", "", "destination directory")
-		if err := fs.Parse(args[1:]); err != nil {
+		if err := parseFlags(fs, args[1:], bundleImportHelpText()); err != nil {
 			return err
 		}
 		if *archiveFile == "" {
@@ -193,11 +191,10 @@ func runWorkflowBundle(args []string) error {
 		return nil
 
 	case "collect":
-		fs := flag.NewFlagSet("workflow bundle collect", flag.ContinueOnError)
-		fs.SetOutput(os.Stderr)
+		fs := newHelpFlagSet("workflow bundle collect")
 		bundleDir := fs.String("root", "", "bundle directory")
 		outputFile := fs.String("out", "", "output tar archive path")
-		if err := fs.Parse(args[1:]); err != nil {
+		if err := parseFlags(fs, args[1:], bundleCollectHelpText()); err != nil {
 			return err
 		}
 		if *bundleDir == "" {
@@ -215,8 +212,7 @@ func runWorkflowBundle(args []string) error {
 		return nil
 
 	case "merge":
-		fs := flag.NewFlagSet("workflow bundle merge", flag.ContinueOnError)
-		fs.SetOutput(os.Stderr)
+		fs := newHelpFlagSet("workflow bundle merge")
 		to := fs.String("to", "", "merge destination (local directory)")
 		dryRun := fs.Bool("dry-run", false, "print merge plan without writing")
 		parseArgs := append([]string{}, args[1:]...)
@@ -225,7 +221,7 @@ func runWorkflowBundle(args []string) error {
 			archivePath = strings.TrimSpace(parseArgs[0])
 			parseArgs = parseArgs[1:]
 		}
-		if err := fs.Parse(parseArgs); err != nil {
+		if err := parseFlags(fs, parseArgs, bundleMergeHelpText()); err != nil {
 			return err
 		}
 		if archivePath == "" {

--- a/cmd/deck/cmd_cache.go
+++ b/cmd/deck/cmd_cache.go
@@ -3,7 +3,6 @@ package main
 import (
 	"encoding/json"
 	"errors"
-	"flag"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -15,10 +14,10 @@ import (
 
 func runCache(args []string) error {
 	if len(args) == 0 {
-		return errors.New("usage: deck cache list|clean [flags]")
+		return errors.New(cacheHelpText())
 	}
-	if args[0] == "-h" || args[0] == "--help" || args[0] == "help" {
-		return errors.New("usage: deck cache list|clean [flags]")
+	if wantsHelp(args) {
+		return errors.New(cacheHelpText())
 	}
 
 	switch args[0] {
@@ -38,11 +37,10 @@ type cacheEntry struct {
 }
 
 func runCacheList(args []string) error {
-	fs := flag.NewFlagSet("cache list", flag.ContinueOnError)
-	fs.SetOutput(os.Stderr)
+	fs := newHelpFlagSet("cache list")
 	output := ""
 	registerOutputFormatFlags(fs, &output, "text")
-	if err := fs.Parse(args); err != nil {
+	if err := parseFlags(fs, args, cacheListHelpText()); err != nil {
 		return err
 	}
 	if output != "text" && output != "json" {
@@ -68,11 +66,10 @@ func runCacheList(args []string) error {
 }
 
 func runCacheClean(args []string) error {
-	fs := flag.NewFlagSet("cache clean", flag.ContinueOnError)
-	fs.SetOutput(os.Stderr)
+	fs := newHelpFlagSet("cache clean")
 	olderThan := fs.String("older-than", "", "delete entries not modified within this duration (e.g. 30d, 24h)")
 	dryRun := fs.Bool("dry-run", false, "print deletion plan without deleting")
-	if err := fs.Parse(args); err != nil {
+	if err := parseFlags(fs, args, cacheCleanHelpText()); err != nil {
 		return err
 	}
 

--- a/cmd/deck/cmd_node.go
+++ b/cmd/deck/cmd_node.go
@@ -3,7 +3,6 @@ package main
 import (
 	"encoding/json"
 	"errors"
-	"flag"
 	"fmt"
 	"github.com/taedi90/deck/internal/nodeid"
 	"os"
@@ -12,10 +11,10 @@ import (
 
 func runNode(args []string) error {
 	if len(args) == 0 {
-		return errors.New("usage: deck node <id|assignment> [flags]")
+		return errors.New(nodeHelpText())
 	}
-	if args[0] == "-h" || args[0] == "--help" || args[0] == "help" {
-		return errors.New("usage: deck node <id|assignment> [flags]")
+	if wantsHelp(args) {
+		return errors.New(nodeHelpText())
 	}
 	switch args[0] {
 	case "id":
@@ -29,7 +28,10 @@ func runNode(args []string) error {
 
 func runNodeID(args []string) error {
 	if len(args) == 0 {
-		return errors.New("usage: deck node id <show|set|init>")
+		return errors.New(nodeIDHelpText())
+	}
+	if wantsHelp(args) {
+		return errors.New(nodeIDHelpText())
 	}
 	switch args[0] {
 	case "show":
@@ -44,13 +46,12 @@ func runNodeID(args []string) error {
 }
 
 func runNodeIDShow(args []string) error {
-	fs := flag.NewFlagSet("node id show", flag.ContinueOnError)
-	fs.SetOutput(os.Stderr)
-	if err := fs.Parse(args); err != nil {
+	fs := newHelpFlagSet("node id show")
+	if err := parseFlags(fs, args, nodeIDShowHelpText()); err != nil {
 		return err
 	}
 	if fs.NArg() != 0 {
-		return errors.New("usage: deck node id show")
+		return errors.New(nodeIDShowHelpText())
 	}
 
 	result, err := nodeid.Resolve(resolveNodeIDPathsFromEnv())
@@ -62,13 +63,12 @@ func runNodeIDShow(args []string) error {
 }
 
 func runNodeIDSet(args []string) error {
-	fs := flag.NewFlagSet("node id set", flag.ContinueOnError)
-	fs.SetOutput(os.Stderr)
-	if err := fs.Parse(args); err != nil {
+	fs := newHelpFlagSet("node id set")
+	if err := parseFlags(fs, args, nodeIDSetHelpText()); err != nil {
 		return err
 	}
 	if fs.NArg() != 1 {
-		return errors.New("usage: deck node id set <node-id>")
+		return errors.New(nodeIDSetHelpText())
 	}
 
 	result, err := nodeid.SetOperator(resolveNodeIDPathsFromEnv(), strings.TrimSpace(fs.Arg(0)))
@@ -81,13 +81,12 @@ func runNodeIDSet(args []string) error {
 }
 
 func runNodeIDInit(args []string) error {
-	fs := flag.NewFlagSet("node id init", flag.ContinueOnError)
-	fs.SetOutput(os.Stderr)
-	if err := fs.Parse(args); err != nil {
+	fs := newHelpFlagSet("node id init")
+	if err := parseFlags(fs, args, nodeIDInitHelpText()); err != nil {
 		return err
 	}
 	if fs.NArg() != 0 {
-		return errors.New("usage: deck node id init")
+		return errors.New(nodeIDInitHelpText())
 	}
 
 	result, err := nodeid.Init(resolveNodeIDPathsFromEnv())
@@ -127,7 +126,10 @@ func printNodeIDResult(result nodeid.Result) {
 
 func runNodeAssignment(args []string) error {
 	if len(args) == 0 {
-		return errors.New("usage: deck node assignment show [flags]")
+		return errors.New(nodeAssignmentHelpText())
+	}
+	if wantsHelp(args) {
+		return errors.New(nodeAssignmentHelpText())
 	}
 	switch args[0] {
 	case "show":
@@ -138,18 +140,17 @@ func runNodeAssignment(args []string) error {
 }
 
 func runNodeAssignmentShow(args []string) error {
-	fs := flag.NewFlagSet("node assignment show", flag.ContinueOnError)
-	fs.SetOutput(os.Stderr)
+	fs := newHelpFlagSet("node assignment show")
 	root := fs.String("root", ".", "site server root")
 	sessionID := fs.String("session", "", "session id")
 	action := fs.String("action", "apply", "assignment action (diff|doctor|apply)")
 	output := ""
 	registerOutputFormatFlags(fs, &output, "text")
-	if err := fs.Parse(args); err != nil {
+	if err := parseFlags(fs, args, nodeAssignmentHelpText()); err != nil {
 		return err
 	}
 	if fs.NArg() != 0 {
-		return errors.New("usage: deck node assignment show --session <session-id> [--action diff|doctor|apply] [--root <dir>] [--output text|json]")
+		return errors.New(nodeAssignmentHelpText())
 	}
 	resolvedSessionID := strings.TrimSpace(*sessionID)
 	if resolvedSessionID == "" {

--- a/cmd/deck/cmd_pack.go
+++ b/cmd/deck/cmd_pack.go
@@ -6,7 +6,6 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"errors"
-	"flag"
 	"fmt"
 	"github.com/taedi90/deck/internal/bundle"
 	"github.com/taedi90/deck/internal/config"
@@ -18,19 +17,18 @@ import (
 )
 
 func runPack(args []string) error {
-	if len(args) > 0 && (args[0] == "-h" || args[0] == "--help" || args[0] == "help") {
-		return errors.New("usage: deck pack [flags]")
+	if wantsHelp(args) {
+		return errors.New(packHelpText())
 	}
 
-	fs := flag.NewFlagSet("pack", flag.ContinueOnError)
-	fs.SetOutput(os.Stderr)
+	fs := newHelpFlagSet("pack")
 	outPath := fs.String("out", "", "output tar archive path")
 	dryRun := fs.Bool("dry-run", false, "print pack plan without writing files")
 	cacheDir := fs.String("cache-dir", "", "artifact cache directory")
 	noCache := fs.Bool("no-cache", false, "disable artifact cache reuse")
 	vars := &varFlag{}
 	fs.Var(vars, "var", "set variable override (key=value), repeatable")
-	if err := fs.Parse(args); err != nil {
+	if err := parseFlags(fs, args, packHelpText()); err != nil {
 		return err
 	}
 	resolvedOut := strings.TrimSpace(*outPath)

--- a/cmd/deck/cmd_serve.go
+++ b/cmd/deck/cmd_serve.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"flag"
 	"fmt"
 	"net/http"
 	"os"
@@ -23,24 +22,19 @@ import (
 )
 
 func runServe(args []string) error {
-	if len(args) > 0 && (args[0] == "-h" || args[0] == "--help" || args[0] == "help") {
-		return errors.New("usage: deck serve [flags]")
+	if wantsHelp(args) {
+		return errors.New(serveHelpText())
 	}
 	return runServer(append([]string{"start"}, args...))
 }
 
 func runList(args []string) error {
-	if len(args) > 0 && (args[0] == "-h" || args[0] == "--help" || args[0] == "help") {
-		return errors.New("usage: deck list [flags]")
-	}
-
-	fs := flag.NewFlagSet("list", flag.ContinueOnError)
-	fs.SetOutput(os.Stderr)
+	fs := newHelpFlagSet("list")
 	var server string
 	var output string
 	fs.StringVar(&server, "server", "", "server URL for index (optional; defaults to local workflows/)")
 	registerOutputFormatFlags(fs, &output, "text")
-	if err := fs.Parse(args); err != nil {
+	if err := parseFlags(fs, args, listHelpText()); err != nil {
 		return err
 	}
 	if output != "text" && output != "json" {
@@ -148,10 +142,9 @@ func discoverLocalWorkflowList(root string) ([]string, error) {
 	return items, nil
 }
 func runHealth(args []string) error {
-	fs := flag.NewFlagSet("health", flag.ContinueOnError)
-	fs.SetOutput(os.Stderr)
+	fs := newHelpFlagSet("health")
 	server := fs.String("server", "", "server base URL (required)")
-	if err := fs.Parse(args); err != nil {
+	if err := parseFlags(fs, args, healthHelpText()); err != nil {
 		return err
 	}
 	resolvedServer := strings.TrimSpace(*server)
@@ -178,15 +171,14 @@ func runHealth(args []string) error {
 	return nil
 }
 func runLogs(args []string) error {
-	fs := flag.NewFlagSet("logs", flag.ContinueOnError)
-	fs.SetOutput(os.Stderr)
+	fs := newHelpFlagSet("logs")
 	root := fs.String("root", ".", "serve root directory")
 	source := fs.String("source", "file", "log source (file|journal|both)")
 	path := fs.String("path", "", "explicit audit log file path")
 	unit := fs.String("unit", "", "systemd unit for journal logs")
 	output := ""
 	registerOutputFormatFlags(fs, &output, "text")
-	if err := fs.Parse(args); err != nil {
+	if err := parseFlags(fs, args, logsHelpText()); err != nil {
 		return err
 	}
 	resolvedSource := strings.ToLower(strings.TrimSpace(*source))
@@ -342,11 +334,10 @@ func isPermissionError(msg string) bool {
 }
 func runServer(args []string) error {
 	if len(args) == 0 || args[0] != "start" {
-		return errors.New("usage: deck serve --root <dir> --addr <host:port> [--api-token <token>] [--report-max <n>] [--audit-max-size-mb <n>] [--audit-max-files <n>] [--tls-cert <crt> --tls-key <key> | --tls-self-signed]")
+		return errors.New(serveHelpText())
 	}
 
-	fs := flag.NewFlagSet("server start", flag.ContinueOnError)
-	fs.SetOutput(os.Stderr)
+	fs := newHelpFlagSet("server start")
 	root := fs.String("root", "./bundle", "server content root")
 	addr := fs.String("addr", ":8080", "server listen address")
 	apiToken := fs.String("api-token", "deck-site-v1", "bearer token required for /api/site/v1 endpoints")
@@ -356,7 +347,7 @@ func runServer(args []string) error {
 	tlsCert := fs.String("tls-cert", "", "TLS certificate path")
 	tlsKey := fs.String("tls-key", "", "TLS private key path")
 	tlsSelfSigned := fs.Bool("tls-self-signed", false, "auto-generate and use self-signed TLS cert")
-	if err := fs.Parse(args[1:]); err != nil {
+	if err := parseFlags(fs, args[1:], serveHelpText()); err != nil {
 		return err
 	}
 

--- a/cmd/deck/cmd_site.go
+++ b/cmd/deck/cmd_site.go
@@ -382,10 +382,10 @@ func assistedReleaseBundleRoot(releaseID string) string {
 }
 func runSite(args []string) error {
 	if len(args) == 0 {
-		return errors.New("usage: deck site <release|session|assign|status> [flags]")
+		return errors.New(siteHelpText())
 	}
-	if args[0] == "-h" || args[0] == "--help" || args[0] == "help" {
-		return errors.New("usage: deck site <release|session|assign|status> [flags]")
+	if wantsHelp(args) {
+		return errors.New(siteHelpText())
 	}
 
 	switch args[0] {
@@ -404,7 +404,10 @@ func runSite(args []string) error {
 
 func runSiteRelease(args []string) error {
 	if len(args) == 0 {
-		return errors.New("usage: deck site release <import|list> [flags]")
+		return errors.New(siteReleaseHelpText())
+	}
+	if wantsHelp(args) {
+		return errors.New(siteReleaseHelpText())
 	}
 	switch args[0] {
 	case "import":
@@ -417,17 +420,16 @@ func runSiteRelease(args []string) error {
 }
 
 func runSiteReleaseImport(args []string) error {
-	fs := flag.NewFlagSet("site release import", flag.ContinueOnError)
-	fs.SetOutput(os.Stderr)
+	fs := newHelpFlagSet("site release import")
 	root := fs.String("root", ".", "site server root")
 	releaseID := fs.String("id", "", "release id")
 	bundlePath := fs.String("bundle", "", "local bundle archive path")
 	createdAt := fs.String("created-at", "", "release timestamp (RFC3339, optional)")
-	if err := fs.Parse(args); err != nil {
+	if err := parseFlags(fs, args, siteReleaseImportHelpText()); err != nil {
 		return err
 	}
 	if fs.NArg() != 0 {
-		return errors.New("usage: deck site release import --id <release-id> --bundle <bundle.tar> [--root <dir>]")
+		return errors.New(siteReleaseImportHelpText())
 	}
 
 	resolvedReleaseID := strings.TrimSpace(*releaseID)
@@ -480,16 +482,15 @@ func runSiteReleaseImport(args []string) error {
 }
 
 func runSiteReleaseList(args []string) error {
-	fs := flag.NewFlagSet("site release list", flag.ContinueOnError)
-	fs.SetOutput(os.Stderr)
+	fs := newHelpFlagSet("site release list")
 	root := fs.String("root", ".", "site server root")
 	output := ""
 	registerOutputFormatFlags(fs, &output, "text")
-	if err := fs.Parse(args); err != nil {
+	if err := parseFlags(fs, args, siteReleaseListHelpText()); err != nil {
 		return err
 	}
 	if fs.NArg() != 0 {
-		return errors.New("usage: deck site release list [--root <dir>] [--output text|json]")
+		return errors.New(siteReleaseListHelpText())
 	}
 	if output != "text" && output != "json" {
 		return errors.New("--output must be text or json")
@@ -517,7 +518,10 @@ func runSiteReleaseList(args []string) error {
 
 func runSiteSession(args []string) error {
 	if len(args) == 0 {
-		return errors.New("usage: deck site session <create|close> [flags]")
+		return errors.New(siteSessionHelpText())
+	}
+	if wantsHelp(args) {
+		return errors.New(siteSessionHelpText())
 	}
 	switch args[0] {
 	case "create":
@@ -530,17 +534,16 @@ func runSiteSession(args []string) error {
 }
 
 func runSiteSessionCreate(args []string) error {
-	fs := flag.NewFlagSet("site session create", flag.ContinueOnError)
-	fs.SetOutput(os.Stderr)
+	fs := newHelpFlagSet("site session create")
 	root := fs.String("root", ".", "site server root")
 	sessionID := fs.String("id", "", "session id")
 	releaseID := fs.String("release", "", "release id")
 	startedAt := fs.String("started-at", "", "session start timestamp (RFC3339, optional)")
-	if err := fs.Parse(args); err != nil {
+	if err := parseFlags(fs, args, siteSessionCreateHelpText()); err != nil {
 		return err
 	}
 	if fs.NArg() != 0 {
-		return errors.New("usage: deck site session create --id <session-id> --release <release-id> [--root <dir>]")
+		return errors.New(siteSessionCreateHelpText())
 	}
 
 	resolvedSessionID := strings.TrimSpace(*sessionID)
@@ -577,16 +580,15 @@ func runSiteSessionCreate(args []string) error {
 }
 
 func runSiteSessionClose(args []string) error {
-	fs := flag.NewFlagSet("site session close", flag.ContinueOnError)
-	fs.SetOutput(os.Stderr)
+	fs := newHelpFlagSet("site session close")
 	root := fs.String("root", ".", "site server root")
 	sessionID := fs.String("id", "", "session id")
 	closedAt := fs.String("closed-at", "", "session close timestamp (RFC3339, optional)")
-	if err := fs.Parse(args); err != nil {
+	if err := parseFlags(fs, args, siteSessionCloseHelpText()); err != nil {
 		return err
 	}
 	if fs.NArg() != 0 {
-		return errors.New("usage: deck site session close --id <session-id> [--root <dir>]")
+		return errors.New(siteSessionCloseHelpText())
 	}
 
 	resolvedSessionID := strings.TrimSpace(*sessionID)
@@ -613,7 +615,10 @@ func runSiteSessionClose(args []string) error {
 
 func runSiteAssign(args []string) error {
 	if len(args) == 0 {
-		return errors.New("usage: deck site assign <role|node> [flags]")
+		return errors.New(siteAssignHelpText())
+	}
+	if wantsHelp(args) {
+		return errors.New(siteAssignHelpText())
 	}
 	switch args[0] {
 	case "role":
@@ -626,18 +631,17 @@ func runSiteAssign(args []string) error {
 }
 
 func runSiteAssignRole(args []string) error {
-	fs := flag.NewFlagSet("site assign role", flag.ContinueOnError)
-	fs.SetOutput(os.Stderr)
+	fs := newHelpFlagSet("site assign role")
 	root := fs.String("root", ".", "site server root")
 	sessionID := fs.String("session", "", "session id")
 	assignmentID := fs.String("assignment", "", "assignment id")
 	role := fs.String("role", "", "role")
 	workflow := fs.String("workflow", "", "workflow path inside release bundle")
-	if err := fs.Parse(args); err != nil {
+	if err := parseFlags(fs, args, siteAssignRoleHelpText()); err != nil {
 		return err
 	}
 	if fs.NArg() != 0 {
-		return errors.New("usage: deck site assign role --session <session-id> --assignment <assignment-id> --role <role> --workflow <path> [--root <dir>]")
+		return errors.New(siteAssignRoleHelpText())
 	}
 
 	resolvedSessionID := strings.TrimSpace(*sessionID)
@@ -680,19 +684,18 @@ func runSiteAssignRole(args []string) error {
 }
 
 func runSiteAssignNode(args []string) error {
-	fs := flag.NewFlagSet("site assign node", flag.ContinueOnError)
-	fs.SetOutput(os.Stderr)
+	fs := newHelpFlagSet("site assign node")
 	root := fs.String("root", ".", "site server root")
 	sessionID := fs.String("session", "", "session id")
 	assignmentID := fs.String("assignment", "", "assignment id")
 	nodeID := fs.String("node", "", "node id")
 	role := fs.String("role", "", "role (optional)")
 	workflow := fs.String("workflow", "", "workflow path inside release bundle")
-	if err := fs.Parse(args); err != nil {
+	if err := parseFlags(fs, args, siteAssignNodeHelpText()); err != nil {
 		return err
 	}
 	if fs.NArg() != 0 {
-		return errors.New("usage: deck site assign node --session <session-id> --assignment <assignment-id> --node <node-id> --workflow <path> [--role <role>] [--root <dir>]")
+		return errors.New(siteAssignNodeHelpText())
 	}
 
 	resolvedSessionID := strings.TrimSpace(*sessionID)
@@ -755,16 +758,15 @@ type siteStatusOutput struct {
 }
 
 func runSiteStatus(args []string) error {
-	fs := flag.NewFlagSet("site status", flag.ContinueOnError)
-	fs.SetOutput(os.Stderr)
+	fs := newHelpFlagSet("site status")
 	root := fs.String("root", ".", "site server root")
 	output := ""
 	registerOutputFormatFlags(fs, &output, "text")
-	if err := fs.Parse(args); err != nil {
+	if err := parseFlags(fs, args, siteStatusHelpText()); err != nil {
 		return err
 	}
 	if fs.NArg() != 0 {
-		return errors.New("usage: deck site status [--root <dir>] [--output text|json]")
+		return errors.New(siteStatusHelpText())
 	}
 	if output != "text" && output != "json" {
 		return errors.New("--output must be text or json")

--- a/cmd/deck/help.go
+++ b/cmd/deck/help.go
@@ -1,0 +1,651 @@
+package main
+
+import (
+	"errors"
+	"flag"
+	"io"
+	"strings"
+)
+
+type helpSection struct {
+	Title string
+	Lines []string
+}
+
+func wantsHelp(args []string) bool {
+	if len(args) == 0 {
+		return false
+	}
+	return args[0] == "-h" || args[0] == "--help" || args[0] == "help"
+}
+
+func newHelpFlagSet(name string) *flag.FlagSet {
+	fs := flag.NewFlagSet(name, flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	fs.Usage = func() {}
+	return fs
+}
+
+func parseFlags(fs *flag.FlagSet, args []string, helpText string) error {
+	if err := fs.Parse(args); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return errors.New(helpText)
+		}
+		return err
+	}
+	return nil
+}
+
+func formatHelp(usage string, what string, sections ...helpSection) string {
+	var b strings.Builder
+	b.WriteString("Usage:\n  ")
+	b.WriteString(usage)
+	b.WriteString("\n\n")
+	b.WriteString(what)
+	for _, section := range sections {
+		if len(section.Lines) == 0 {
+			continue
+		}
+		b.WriteString("\n\n")
+		b.WriteString(section.Title)
+		b.WriteString(":\n")
+		for _, line := range section.Lines {
+			b.WriteString("  ")
+			b.WriteString(line)
+			b.WriteString("\n")
+		}
+	}
+	return strings.TrimRight(b.String(), "\n")
+}
+
+func mainHelpText() string {
+	return formatHelp(
+		"deck <command> [flags]",
+		"Run deck bundle, apply, site, and server commands.",
+		helpSection{Title: "Commands", Lines: []string{
+			"pack       Build an offline bundle from local deck files",
+			"apply      Execute an apply file against a bundle",
+			"serve      Start the bundle server",
+			"bundle     Verify, inspect, import, collect, or merge bundles",
+			"list       List available deck files from a local bundle or server",
+			"validate   Validate a deck file",
+			"diff       Show the planned install step execution",
+			"doctor     Check referenced artifact inputs before apply",
+			"health     Probe a running deck server",
+			"logs       Read server audit logs from file or journal",
+			"cache      Inspect or clean deck cache data",
+			"node       Resolve or manage node identity data",
+			"site       Manage site releases, sessions, and assignments",
+			"init       Scaffold starter deck files",
+		}},
+		helpSection{Title: "Examples", Lines: []string{
+			"deck pack --out ./bundle.tar",
+			"deck apply ./apply.yaml ./bundle",
+			"deck serve --root ./bundle --addr :8080",
+		}},
+	)
+}
+
+func packHelpText() string {
+	return formatHelp(
+		"deck pack --out <bundle.tar> [--var key=value] [--cache-dir <dir>] [--no-cache]",
+		"Build an offline bundle from workflows in ./workflows.",
+		helpSection{Title: "Required files", Lines: []string{
+			"workflows/pack.yaml",
+			"workflows/apply.yaml",
+			"workflows/vars.yaml",
+		}},
+		helpSection{Title: "Flags", Lines: []string{
+			"--out         Output bundle tar path",
+			"--dry-run     Print the planned bundle contents without writing files",
+			"--cache-dir   Reuse downloaded artifacts from this directory",
+			"--no-cache    Force redownload of artifacts",
+			"--var         Set a workflow variable override (repeatable)",
+		}},
+		helpSection{Title: "Examples", Lines: []string{
+			"deck pack --out ./bundle.tar",
+			"deck pack --out ./bundle.tar --var kubeVersion=v1.31.0",
+			"deck pack --out ./bundle.tar --cache-dir ~/.deck/cache/artifacts",
+		}},
+	)
+}
+
+func applyHelpText() string {
+	return formatHelp(
+		"deck apply [workflow] [bundle] [--phase <name>] [--prefetch] [--dry-run] [--var key=value]",
+		"Run an apply workflow, optionally prefetching DownloadFile steps first.",
+		helpSection{Title: "Flags", Lines: []string{
+			"--file, -f    Path or URL to the workflow file",
+			"--phase       Phase name to execute (default: install)",
+			"--prefetch    Run DownloadFile steps before the selected phase",
+			"--dry-run     Print the planned install step execution without applying",
+			"--var         Set a workflow variable override (repeatable)",
+			"--server      Run in assisted mode against a site server",
+			"--session     Session id for assisted mode",
+			"--api-token   Bearer token for assisted mode APIs",
+		}},
+		helpSection{Title: "Examples", Lines: []string{
+			"deck apply ./workflows/apply.yaml ./bundle",
+			"deck apply --file https://example.invalid/workflows/apply.yaml --dry-run",
+			"deck apply ./bundle --prefetch --var joinFile=/tmp/join.txt",
+		}},
+	)
+}
+
+func diffHelpText() string {
+	return formatHelp(
+		"deck diff --file <workflow> [--phase <name>] [--output text|json] [--var key=value]",
+		"Show which install steps would run, skip, or reuse from saved state.",
+		helpSection{Title: "Flags", Lines: []string{
+			"--file, -f    Path to the workflow file",
+			"--phase       Phase name to diff (default: install)",
+			"--output      Output format: text or json",
+			"--var         Set a workflow variable override (repeatable)",
+			"--server      Run in assisted mode against a site server",
+			"--session     Session id for assisted mode",
+			"--api-token   Bearer token for assisted mode APIs",
+		}},
+		helpSection{Title: "Examples", Lines: []string{
+			"deck diff --file ./workflows/apply.yaml",
+			"deck diff --file ./workflows/apply.yaml --output json",
+			"deck diff --file ./workflows/apply.yaml --var region=lab",
+		}},
+	)
+}
+
+func doctorHelpText() string {
+	return formatHelp(
+		"deck doctor --file <workflow> --out <report.json> [--var key=value]",
+		"Check workflow artifact references and write a doctor report before apply.",
+		helpSection{Title: "Flags", Lines: []string{
+			"--file, -f    Path or URL to the workflow file",
+			"--out         Output report path",
+			"--var         Set a workflow variable override (repeatable)",
+			"--server      Run in assisted mode against a site server",
+			"--session     Session id for assisted mode",
+			"--api-token   Bearer token for assisted mode APIs",
+		}},
+		helpSection{Title: "Examples", Lines: []string{
+			"deck doctor --file ./workflows/apply.yaml --out ./doctor.json",
+			"deck doctor --file ./workflows/apply.yaml --out ./doctor.json --var registry=repo.local",
+		}},
+	)
+}
+
+func serveHelpText() string {
+	return formatHelp(
+		"deck serve --root <dir> --addr <host:port> [--api-token <token>] [--tls-cert <crt> --tls-key <key> | --tls-self-signed]",
+		"Start the deck content server for workflows, artifacts, registry access, and site APIs.",
+		helpSection{Title: "Flags", Lines: []string{
+			"--root                Server content root (default: ./bundle)",
+			"--addr                Listen address (default: :8080)",
+			"--api-token           Bearer token required for /api/site/v1 endpoints",
+			"--report-max          Max retained in-memory reports",
+			"--audit-max-size-mb   Max audit log size before rotation",
+			"--audit-max-files     Max retained rotated audit files",
+			"--tls-cert            TLS certificate path",
+			"--tls-key             TLS private key path",
+			"--tls-self-signed     Generate and use a self-signed certificate",
+		}},
+		helpSection{Title: "Examples", Lines: []string{
+			"deck serve --root ./bundle --addr :8080",
+			"deck serve --root ./bundle --addr :8443 --tls-self-signed",
+			"deck serve --root ./bundle --addr :8443 --tls-cert server.crt --tls-key server.key",
+		}},
+	)
+}
+
+func listHelpText() string {
+	return formatHelp(
+		"deck list [--server <url>] [--output text|json]",
+		"List workflows from the local ./workflows directory or from a running server index.",
+		helpSection{Title: "Flags", Lines: []string{
+			"--server      Server URL for workflow index lookup",
+			"--output, -o  Output format: text or json",
+		}},
+		helpSection{Title: "Examples", Lines: []string{
+			"deck list",
+			"deck list --server http://127.0.0.1:8080",
+			"deck list --server http://127.0.0.1:8080 --output json",
+		}},
+	)
+}
+
+func validateHelpText() string {
+	return formatHelp(
+		"deck validate --file <workflow> [--var key=value]",
+		"Validate a workflow file against the deck schema and step schemas.",
+		helpSection{Title: "Flags", Lines: []string{
+			"--file, -f    Path or URL to the workflow file",
+			"--var         Set a workflow variable override (repeatable)",
+		}},
+		helpSection{Title: "Examples", Lines: []string{
+			"deck validate --file ./workflows/apply.yaml",
+			"deck validate --file https://example.invalid/workflows/apply.yaml",
+		}},
+	)
+}
+
+func initHelpText() string {
+	return formatHelp(
+		"deck init [--out <dir>]",
+		"Create starter workflow files under a workflows directory.",
+		helpSection{Title: "Flags", Lines: []string{
+			"--out         Output directory root (default: .)",
+		}},
+		helpSection{Title: "Examples", Lines: []string{
+			"deck init",
+			"deck init --out ./demo",
+		}},
+	)
+}
+
+func healthHelpText() string {
+	return formatHelp(
+		"deck health --server <url>",
+		"Probe the /healthz endpoint of a running deck server.",
+		helpSection{Title: "Flags", Lines: []string{
+			"--server      Server base URL to probe",
+		}},
+		helpSection{Title: "Examples", Lines: []string{
+			"deck health --server http://127.0.0.1:8080",
+			"deck health --server https://site.example",
+		}},
+	)
+}
+
+func logsHelpText() string {
+	return formatHelp(
+		"deck logs [--root <dir>] [--source file|journal|both] [--path <file>] [--unit <service>] [--output text|json]",
+		"Read deck server audit logs from the log file, the journal, or both.",
+		helpSection{Title: "Flags", Lines: []string{
+			"--root        Serve root directory used to resolve the default log path",
+			"--source      Log source: file, journal, or both",
+			"--path        Explicit audit log file path",
+			"--unit        Systemd unit name for journal logs",
+			"--output, -o  Output format: text or json",
+		}},
+		helpSection{Title: "Examples", Lines: []string{
+			"deck logs --source file --root ./bundle",
+			"deck logs --source journal --unit deck-server.service",
+			"deck logs --source both --root ./bundle --unit deck-server.service --output json",
+		}},
+	)
+}
+
+func cacheHelpText() string {
+	return formatHelp(
+		"deck cache <list|clean> [flags]",
+		"Inspect or delete cached deck artifacts under the local deck cache root.",
+		helpSection{Title: "Commands", Lines: []string{
+			"list        Show cached files",
+			"clean       Delete cached entries, optionally by age",
+		}},
+		helpSection{Title: "Examples", Lines: []string{
+			"deck cache list",
+			"deck cache clean --older-than 30d --dry-run",
+		}},
+	)
+}
+
+func nodeHelpText() string {
+	return formatHelp(
+		"deck node <id|assignment> [flags]",
+		"Resolve node identity data or inspect the site assignment chosen for this node.",
+		helpSection{Title: "Commands", Lines: []string{
+			"id           Show, set, or initialize the local node id",
+			"assignment   Show the resolved site assignment for this node",
+		}},
+		helpSection{Title: "Examples", Lines: []string{
+			"deck node id show",
+			"deck node id set rack-a-01",
+			"deck node assignment show --session bootstrap-001",
+		}},
+	)
+}
+
+func siteHelpText() string {
+	return formatHelp(
+		"deck site <release|session|assign|status> [flags]",
+		"Manage site releases, sessions, assignments, and status summaries.",
+		helpSection{Title: "Commands", Lines: []string{
+			"release      Import or list site releases",
+			"session      Create or close sessions",
+			"assign       Assign workflows by role or node",
+			"status       Show release and session status summaries",
+		}},
+		helpSection{Title: "Examples", Lines: []string{
+			"deck site release import --id rel-001 --bundle ./bundle.tar",
+			"deck site session create --id sess-001 --release rel-001",
+			"deck site status --output json",
+		}},
+	)
+}
+
+func bundleHelpText() string {
+	return formatHelp(
+		"deck bundle <verify|inspect|import|collect|merge> [flags]",
+		"Inspect or move deck bundles between directories and tar archives.",
+		helpSection{Title: "Commands", Lines: []string{
+			"verify       Verify bundle manifest integrity",
+			"inspect      List manifest entries in a bundle",
+			"import       Extract a bundle archive into a directory",
+			"collect      Create a bundle archive from a directory",
+			"merge        Merge a bundle archive into a destination directory",
+		}},
+		helpSection{Title: "Examples", Lines: []string{
+			"deck bundle verify ./bundle.tar",
+			"deck bundle inspect ./bundle --output json",
+			"deck bundle merge ./bundle.tar --to ./dest --dry-run",
+		}},
+	)
+}
+
+func cacheListHelpText() string {
+	return formatHelp(
+		"deck cache list [--output text|json]",
+		"List cached files under the default deck cache root.",
+		helpSection{Title: "Flags", Lines: []string{
+			"--output, -o  Output format: text or json",
+		}},
+		helpSection{Title: "Examples", Lines: []string{
+			"deck cache list",
+			"deck cache list --output json",
+		}},
+	)
+}
+
+func cacheCleanHelpText() string {
+	return formatHelp(
+		"deck cache clean [--older-than <duration>] [--dry-run]",
+		"Delete cached entries, optionally filtering by last modification age.",
+		helpSection{Title: "Flags", Lines: []string{
+			"--older-than  Delete entries older than a duration such as 30d or 24h",
+			"--dry-run     Print the deletion plan without removing files",
+		}},
+		helpSection{Title: "Examples", Lines: []string{
+			"deck cache clean --dry-run",
+			"deck cache clean --older-than 30d",
+		}},
+	)
+}
+
+func nodeIDHelpText() string {
+	return formatHelp(
+		"deck node id <show|set|init>",
+		"Show, set, or initialize the node id files used by deck.",
+		helpSection{Title: "Commands", Lines: []string{
+			"show        Print the resolved node id and source",
+			"set         Write the operator node id",
+			"init        Generate a node id if one is missing",
+		}},
+		helpSection{Title: "Examples", Lines: []string{
+			"deck node id show",
+			"deck node id set rack-a-01",
+			"deck node id init",
+		}},
+	)
+}
+
+func nodeIDShowHelpText() string {
+	return formatHelp(
+		"deck node id show",
+		"Print the resolved node id, source, and hostname.",
+		helpSection{Title: "Flags", Lines: []string{"(none)"}},
+		helpSection{Title: "Examples", Lines: []string{"deck node id show"}},
+	)
+}
+
+func nodeIDSetHelpText() string {
+	return formatHelp(
+		"deck node id set <node-id>",
+		"Write the operator-managed node id value.",
+		helpSection{Title: "Flags", Lines: []string{"(none)"}},
+		helpSection{Title: "Examples", Lines: []string{"deck node id set rack-a-01"}},
+	)
+}
+
+func nodeIDInitHelpText() string {
+	return formatHelp(
+		"deck node id init",
+		"Generate a node id when the generated node-id file is missing.",
+		helpSection{Title: "Flags", Lines: []string{"(none)"}},
+		helpSection{Title: "Examples", Lines: []string{"deck node id init"}},
+	)
+}
+
+func nodeAssignmentHelpText() string {
+	return formatHelp(
+		"deck node assignment show --session <session-id> [--action diff|doctor|apply] [--root <dir>] [--output text|json]",
+		"Show the site assignment selected for the current node id.",
+		helpSection{Title: "Flags", Lines: []string{
+			"--session     Session id to resolve against",
+			"--action      Assignment action: diff, doctor, or apply",
+			"--root        Site server root directory",
+			"--output, -o  Output format: text or json",
+		}},
+		helpSection{Title: "Examples", Lines: []string{
+			"deck node assignment show --session sess-001",
+			"deck node assignment show --session sess-001 --action doctor --output json",
+		}},
+	)
+}
+
+func siteReleaseHelpText() string {
+	return formatHelp(
+		"deck site release <import|list> [flags]",
+		"Import release bundles into the site store or list available releases.",
+		helpSection{Title: "Commands", Lines: []string{
+			"import      Import a bundle archive as a release",
+			"list        List stored releases",
+		}},
+		helpSection{Title: "Examples", Lines: []string{
+			"deck site release import --id rel-001 --bundle ./bundle.tar",
+			"deck site release list --output json",
+		}},
+	)
+}
+
+func siteReleaseImportHelpText() string {
+	return formatHelp(
+		"deck site release import --id <release-id> --bundle <bundle.tar> [--root <dir>] [--created-at <rfc3339>]",
+		"Import a bundle archive into the site release store.",
+		helpSection{Title: "Flags", Lines: []string{
+			"--id          Release id to create",
+			"--bundle      Local bundle archive path",
+			"--root        Site server root directory",
+			"--created-at  Release timestamp in RFC3339 format",
+		}},
+		helpSection{Title: "Examples", Lines: []string{
+			"deck site release import --id rel-001 --bundle ./bundle.tar",
+			"deck site release import --root ./site --id rel-002 --bundle ./bundle.tar",
+		}},
+	)
+}
+
+func siteReleaseListHelpText() string {
+	return formatHelp(
+		"deck site release list [--root <dir>] [--output text|json]",
+		"List site releases stored under the configured site root.",
+		helpSection{Title: "Flags", Lines: []string{
+			"--root        Site server root directory",
+			"--output, -o  Output format: text or json",
+		}},
+		helpSection{Title: "Examples", Lines: []string{
+			"deck site release list",
+			"deck site release list --root ./site --output json",
+		}},
+	)
+}
+
+func siteSessionHelpText() string {
+	return formatHelp(
+		"deck site session <create|close> [flags]",
+		"Open or close site sessions for a release rollout.",
+		helpSection{Title: "Commands", Lines: []string{
+			"create      Create a new session for a release",
+			"close       Close an existing session",
+		}},
+		helpSection{Title: "Examples", Lines: []string{
+			"deck site session create --id sess-001 --release rel-001",
+			"deck site session close --id sess-001",
+		}},
+	)
+}
+
+func siteSessionCreateHelpText() string {
+	return formatHelp(
+		"deck site session create --id <session-id> --release <release-id> [--root <dir>] [--started-at <rfc3339>]",
+		"Create an open session bound to an existing release.",
+		helpSection{Title: "Flags", Lines: []string{
+			"--id          Session id to create",
+			"--release     Existing release id",
+			"--root        Site server root directory",
+			"--started-at  Session start timestamp in RFC3339 format",
+		}},
+		helpSection{Title: "Examples", Lines: []string{
+			"deck site session create --id sess-001 --release rel-001",
+			"deck site session create --root ./site --id sess-002 --release rel-001",
+		}},
+	)
+}
+
+func siteSessionCloseHelpText() string {
+	return formatHelp(
+		"deck site session close --id <session-id> [--root <dir>] [--closed-at <rfc3339>]",
+		"Close an existing site session.",
+		helpSection{Title: "Flags", Lines: []string{
+			"--id          Session id to close",
+			"--root        Site server root directory",
+			"--closed-at   Session close timestamp in RFC3339 format",
+		}},
+		helpSection{Title: "Examples", Lines: []string{
+			"deck site session close --id sess-001",
+			"deck site session close --root ./site --id sess-001",
+		}},
+	)
+}
+
+func siteAssignHelpText() string {
+	return formatHelp(
+		"deck site assign <role|node> [flags]",
+		"Create workflow assignments by role or by specific node id.",
+		helpSection{Title: "Commands", Lines: []string{
+			"role        Assign a workflow to a role for a session",
+			"node        Override assignment for a specific node",
+		}},
+		helpSection{Title: "Examples", Lines: []string{
+			"deck site assign role --session sess-001 --assignment cp --role control-plane --workflow workflows/apply.yaml",
+			"deck site assign node --session sess-001 --assignment node-01 --node rack-a-01 --workflow workflows/apply.yaml",
+		}},
+	)
+}
+
+func siteAssignRoleHelpText() string {
+	return formatHelp(
+		"deck site assign role --session <session-id> --assignment <assignment-id> --role <role> --workflow <path> [--root <dir>]",
+		"Assign a workflow to all nodes matching a role within a session.",
+		helpSection{Title: "Flags", Lines: []string{
+			"--session     Session id",
+			"--assignment  Assignment id",
+			"--role        Role name",
+			"--workflow    Relative workflow path inside the release bundle",
+			"--root        Site server root directory",
+		}},
+		helpSection{Title: "Examples", Lines: []string{
+			"deck site assign role --session sess-001 --assignment cp --role control-plane --workflow workflows/apply.yaml",
+			"deck site assign role --root ./site --session sess-001 --assignment worker --role worker --workflow workflows/apply.yaml",
+		}},
+	)
+}
+
+func siteAssignNodeHelpText() string {
+	return formatHelp(
+		"deck site assign node --session <session-id> --assignment <assignment-id> --node <node-id> --workflow <path> [--role <role>] [--root <dir>]",
+		"Assign or override a workflow for a specific node in a session.",
+		helpSection{Title: "Flags", Lines: []string{
+			"--session     Session id",
+			"--assignment  Assignment id",
+			"--node        Node id",
+			"--workflow    Relative workflow path inside the release bundle",
+			"--role        Optional role label stored with the assignment",
+			"--root        Site server root directory",
+		}},
+		helpSection{Title: "Examples", Lines: []string{
+			"deck site assign node --session sess-001 --assignment node-01 --node rack-a-01 --workflow workflows/apply.yaml",
+			"deck site assign node --root ./site --session sess-001 --assignment node-02 --node rack-a-02 --role worker --workflow workflows/apply.yaml",
+		}},
+	)
+}
+
+func siteStatusHelpText() string {
+	return formatHelp(
+		"deck site status [--root <dir>] [--output text|json]",
+		"Summarize releases, sessions, and per-node action status for a site store.",
+		helpSection{Title: "Flags", Lines: []string{
+			"--root        Site server root directory",
+			"--output, -o  Output format: text or json",
+		}},
+		helpSection{Title: "Examples", Lines: []string{
+			"deck site status",
+			"deck site status --root ./site --output json",
+		}},
+	)
+}
+
+func bundleVerifyHelpText() string {
+	return formatHelp(
+		"deck bundle verify <path>",
+		"Verify manifest integrity for a bundle directory or bundle tar archive.",
+		helpSection{Title: "Flags", Lines: []string{"--file        Bundle path as an alternative to the positional argument"}},
+		helpSection{Title: "Examples", Lines: []string{"deck bundle verify ./bundle.tar", "deck bundle verify --file ./bundle"}},
+	)
+}
+
+func bundleInspectHelpText() string {
+	return formatHelp(
+		"deck bundle inspect <path> [--output text|json]",
+		"List manifest entries for a bundle directory or bundle archive.",
+		helpSection{Title: "Flags", Lines: []string{
+			"--file        Bundle path as an alternative to the positional argument",
+			"--output, -o  Output format: text or json",
+		}},
+		helpSection{Title: "Examples", Lines: []string{"deck bundle inspect ./bundle", "deck bundle inspect ./bundle.tar --output json"}},
+	)
+}
+
+func bundleImportHelpText() string {
+	return formatHelp(
+		"deck bundle import --file <bundle.tar> --dest <dir>",
+		"Extract a bundle tar archive into a destination directory.",
+		helpSection{Title: "Flags", Lines: []string{
+			"--file        Bundle archive path",
+			"--dest        Destination directory",
+		}},
+		helpSection{Title: "Examples", Lines: []string{"deck bundle import --file ./bundle.tar --dest ./bundle"}},
+	)
+}
+
+func bundleCollectHelpText() string {
+	return formatHelp(
+		"deck bundle collect --root <dir> --out <bundle.tar>",
+		"Create a bundle tar archive from an unpacked bundle directory.",
+		helpSection{Title: "Flags", Lines: []string{
+			"--root        Bundle directory",
+			"--out         Output archive path",
+		}},
+		helpSection{Title: "Examples", Lines: []string{"deck bundle collect --root ./bundle --out ./bundle.tar"}},
+	)
+}
+
+func bundleMergeHelpText() string {
+	return formatHelp(
+		"deck bundle merge <bundle.tar> --to <dir> [--dry-run]",
+		"Merge the contents of a bundle archive into a destination directory.",
+		helpSection{Title: "Flags", Lines: []string{
+			"--to          Merge destination directory",
+			"--dry-run     Print the merge plan without writing files",
+		}},
+		helpSection{Title: "Examples", Lines: []string{"deck bundle merge ./bundle.tar --to ./dest", "deck bundle merge ./bundle.tar --to ./dest --dry-run"}},
+	)
+}

--- a/cmd/deck/main.go
+++ b/cmd/deck/main.go
@@ -58,5 +58,5 @@ func run(args []string) error {
 }
 
 func usageError() error {
-	return errors.New("usage: deck <command> [flags]\n\ncommands:\n  pack\n  apply\n  serve\n  bundle\n  list\n  validate\n  diff\n  init\n  doctor\n  health\n  logs\n  cache\n  node\n  site")
+	return errors.New(mainHelpText())
 }

--- a/cmd/deck/main_test.go
+++ b/cmd/deck/main_test.go
@@ -72,7 +72,7 @@ func TestRunTopLevelStubUsage(t *testing.T) {
 		if err == nil {
 			t.Fatalf("expected usage error")
 		}
-		if !strings.Contains(err.Error(), "usage: deck cache list|clean") {
+		if !strings.Contains(err.Error(), "deck cache <list|clean>") {
 			t.Fatalf("unexpected error: %v", err)
 		}
 	})


### PR DESCRIPTION
## Summary
- add structured help text builders for top-level commands and subcommands with usage, purpose, flags, and examples
- reduce ad hoc `-h` handling by routing flag parsing through shared help-aware helpers
- update CLI tests to match the richer help output without changing command behavior