### PR TITLE
Install golangci-lint from the lint target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,8 @@ GO ?= go
 BIN_DIR ?= bin
 BIN ?= $(BIN_DIR)/deck
 GOLANGCI_LINT ?= $(BIN_DIR)/golangci-lint
+GOLANGCI_LINT_PKG ?= github.com/golangci/golangci-lint/v2/cmd/golangci-lint
+GOLANGCI_LINT_VERSION ?= latest
 
 .PHONY: build test lint
 
@@ -13,4 +15,8 @@ test:
 	$(GO) test ./...
 
 lint:
+	@if [ ! -x "$(GOLANGCI_LINT)" ]; then \
+		mkdir -p "$(BIN_DIR)"; \
+		GOBIN="$(abspath $(BIN_DIR))" $(GO) install $(GOLANGCI_LINT_PKG)@$(GOLANGCI_LINT_VERSION); \
+	fi
 	$(GOLANGCI_LINT) run


### PR DESCRIPTION
## Summary
- install `bin/golangci-lint` from `make lint` only when the binary is missing
- keep the repository's local `bin/` convention intact instead of relying on a global binary