### PR TITLE
Propagate install fetch context and classify step timeouts

### DIFF
--- a/internal/fetch/resolver.go
+++ b/internal/fetch/resolver.go
@@ -1,6 +1,7 @@
 package fetch
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"net/http"
@@ -27,7 +28,10 @@ const (
 	defaultHTTPTimeout  = 30 * time.Second
 )
 
-func ResolveBytes(relPath string, sources []SourceConfig, opts ResolveOptions) ([]byte, error) {
+func ResolveBytes(ctx context.Context, relPath string, sources []SourceConfig, opts ResolveOptions) ([]byte, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
 	if strings.TrimSpace(relPath) == "" {
 		return nil, fmt.Errorf("relative path is empty")
 	}
@@ -60,7 +64,7 @@ func ResolveBytes(relPath string, sources []SourceConfig, opts ResolveOptions) (
 				continue
 			}
 			targetURL := strings.TrimRight(baseURL, "/") + "/" + strings.TrimLeft(filepath.ToSlash(relPath), "/")
-			raw, err := readHTTP(targetURL, opts)
+			raw, err := readHTTP(ctx, targetURL, opts)
 			if err == nil {
 				return raw, nil
 			}
@@ -77,7 +81,10 @@ func ResolveBytes(relPath string, sources []SourceConfig, opts ResolveOptions) (
 	return nil, fmt.Errorf("all fetch sources failed for %s: %s", relPath, strings.Join(attempts, ", "))
 }
 
-func readHTTP(url string, opts ResolveOptions) ([]byte, error) {
+func readHTTP(ctx context.Context, url string, opts ResolveOptions) ([]byte, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
 	maxBytes := opts.MaxBytes
 	if maxBytes <= 0 {
 		maxBytes = defaultHTTPMaxBytes
@@ -88,7 +95,7 @@ func readHTTP(url string, opts ResolveOptions) ([]byte, error) {
 	}
 
 	client := &http.Client{Timeout: timeout}
-	req, err := http.NewRequest(http.MethodGet, url, nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/fetch/resolver_test.go
+++ b/internal/fetch/resolver_test.go
@@ -1,6 +1,7 @@
 package fetch
 
 import (
+	"context"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -20,7 +21,7 @@ func TestResolveBytes(t *testing.T) {
 			t.Fatalf("write local file: %v", err)
 		}
 
-		raw, err := ResolveBytes("files/a.txt", []SourceConfig{{Type: "local", Path: local}}, ResolveOptions{})
+		raw, err := ResolveBytes(context.Background(), "files/a.txt", []SourceConfig{{Type: "local", Path: local}}, ResolveOptions{})
 		if err != nil {
 			t.Fatalf("resolve bytes: %v", err)
 		}
@@ -44,7 +45,7 @@ func TestResolveBytes(t *testing.T) {
 		}))
 		defer online.Close()
 
-		raw, err := ResolveBytes("files/a.txt", []SourceConfig{
+		raw, err := ResolveBytes(context.Background(), "files/a.txt", []SourceConfig{
 			{Type: "repo", URL: repo.URL},
 			{Type: "online", URL: online.URL},
 		}, ResolveOptions{})
@@ -57,7 +58,7 @@ func TestResolveBytes(t *testing.T) {
 	})
 
 	t.Run("returns deterministic miss error", func(t *testing.T) {
-		_, err := ResolveBytes("files/missing.txt", []SourceConfig{{Type: "local", Path: t.TempDir()}}, ResolveOptions{})
+		_, err := ResolveBytes(context.Background(), "files/missing.txt", []SourceConfig{{Type: "local", Path: t.TempDir()}}, ResolveOptions{})
 		if err == nil {
 			t.Fatalf("expected resolve error")
 		}
@@ -72,7 +73,7 @@ func TestResolveBytes(t *testing.T) {
 		}))
 		defer online.Close()
 
-		_, err := ResolveBytes("files/a.txt", []SourceConfig{{Type: "online", URL: online.URL}}, ResolveOptions{OfflineOnly: true})
+		_, err := ResolveBytes(context.Background(), "files/a.txt", []SourceConfig{{Type: "online", URL: online.URL}}, ResolveOptions{OfflineOnly: true})
 		if err == nil {
 			t.Fatalf("expected offline policy error")
 		}
@@ -87,12 +88,31 @@ func TestResolveBytes(t *testing.T) {
 		}))
 		defer srv.Close()
 
-		_, err := ResolveBytes("files/a.txt", []SourceConfig{{Type: "online", URL: srv.URL}}, ResolveOptions{MaxBytes: 10, Timeout: time.Second})
+		_, err := ResolveBytes(context.Background(), "files/a.txt", []SourceConfig{{Type: "online", URL: srv.URL}}, ResolveOptions{MaxBytes: 10, Timeout: time.Second})
 		if err == nil {
 			t.Fatalf("expected max-bytes error")
 		}
 		if !strings.Contains(err.Error(), "exceeds max bytes") {
 			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("returns context cancellation when parent is done", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			time.Sleep(250 * time.Millisecond)
+			_, _ = w.Write([]byte("online"))
+		}))
+		defer srv.Close()
+
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Millisecond)
+		defer cancel()
+
+		_, err := ResolveBytes(ctx, "files/a.txt", []SourceConfig{{Type: "online", URL: srv.URL}}, ResolveOptions{Timeout: time.Second})
+		if err == nil {
+			t.Fatalf("expected cancellation error")
+		}
+		if !strings.Contains(err.Error(), context.DeadlineExceeded.Error()) {
+			t.Fatalf("expected context deadline exceeded text, got %v", err)
 		}
 	})
 }

--- a/internal/install/command.go
+++ b/internal/install/command.go
@@ -12,6 +12,8 @@ import (
 	"github.com/taedi90/deck/internal/workflowexec"
 )
 
+var errStepCommandTimeout = errors.New("step command timeout")
+
 type runCommandSpec struct {
 	Command []string `json:"command"`
 	Timeout string   `json:"timeout"`
@@ -31,7 +33,7 @@ func runCommand(ctx context.Context, spec map[string]any) error {
 	if err == nil {
 		return nil
 	}
-	if errors.Is(err, context.DeadlineExceeded) {
+	if errors.Is(err, errStepCommandTimeout) {
 		return fmt.Errorf("%s: command timed out after %s", errCodeInstallCommandTimeout, commandTimeout(spec))
 	}
 	var exitErr *exec.ExitError
@@ -64,6 +66,9 @@ func runTimedCommandWithContext(parent context.Context, name string, args []stri
 	if parent == nil {
 		parent = context.Background()
 	}
+	if err := parent.Err(); err != nil {
+		return err
+	}
 	ctx, cancel := context.WithTimeout(parent, timeout)
 	defer cancel()
 
@@ -72,7 +77,16 @@ func runTimedCommandWithContext(parent context.Context, name string, args []stri
 	cmd.Stderr = os.Stderr
 	err := cmd.Run()
 	if errors.Is(ctx.Err(), context.DeadlineExceeded) {
-		return context.DeadlineExceeded
+		if parent.Err() != nil {
+			return parent.Err()
+		}
+		return errStepCommandTimeout
+	}
+	if errors.Is(ctx.Err(), context.Canceled) {
+		if parent.Err() != nil {
+			return parent.Err()
+		}
+		return context.Canceled
 	}
 	return err
 }
@@ -85,13 +99,25 @@ func runCommandOutputWithContext(parent context.Context, cmdArgs []string, timeo
 	if parent == nil {
 		parent = context.Background()
 	}
+	if err := parent.Err(); err != nil {
+		return "", err
+	}
 	ctx, cancel := context.WithTimeout(parent, timeout)
 	defer cancel()
 
 	cmd := exec.CommandContext(ctx, cmdArgs[0], cmdArgs[1:]...)
 	output, err := cmd.CombinedOutput()
 	if errors.Is(ctx.Err(), context.DeadlineExceeded) {
-		return "", fmt.Errorf("command timed out after %s", timeout)
+		if parent.Err() != nil {
+			return "", parent.Err()
+		}
+		return "", errStepCommandTimeout
+	}
+	if errors.Is(ctx.Err(), context.Canceled) {
+		if parent.Err() != nil {
+			return "", parent.Err()
+		}
+		return "", context.Canceled
 	}
 	if err != nil {
 		msg := strings.TrimSpace(string(output))

--- a/internal/install/dispatch.go
+++ b/internal/install/dispatch.go
@@ -8,10 +8,10 @@ import (
 func executeStep(ctx context.Context, kind string, spec map[string]any, bundleRoot string) error {
 	switch kind {
 	case "DownloadFile":
-		_, err := runDownloadFile(bundleRoot, spec)
+		_, err := runDownloadFile(ctx, bundleRoot, spec)
 		return err
 	case "InstallPackages":
-		return runInstallPackages(spec)
+		return runInstallPackages(ctx, spec)
 	case "WriteFile":
 		return runWriteFile(spec)
 	case "EditFile":
@@ -33,7 +33,7 @@ func executeStep(ctx context.Context, kind string, spec map[string]any, bundleRo
 	case "RepoConfig":
 		return runRepoConfig(spec)
 	case "ContainerdConfig":
-		return runContainerdConfig(spec)
+		return runContainerdConfig(ctx, spec)
 	case "Swap":
 		return runSwap(spec)
 	case "KernelModule":

--- a/internal/install/runner.go
+++ b/internal/install/runner.go
@@ -139,6 +139,10 @@ func Run(ctx context.Context, wf *config.Workflow, opts RunOptions) error {
 			attempts = 1
 		}
 		for i := 0; i < attempts; i++ {
+			if err := ctx.Err(); err != nil {
+				execErr = err
+				break
+			}
 			rendered, renderErr := workflowexec.RenderSpec(step.Spec, wf, runtimeVars, ctxData)
 			if renderErr != nil {
 				execErr = fmt.Errorf("render spec template: %w", renderErr)
@@ -156,6 +160,9 @@ func Run(ctx context.Context, wf *config.Workflow, opts RunOptions) error {
 				}
 			}
 			if execErr == nil {
+				break
+			}
+			if ctx.Err() != nil {
 				break
 			}
 		}

--- a/internal/install/runner_test.go
+++ b/internal/install/runner_test.go
@@ -5,7 +5,10 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -401,6 +404,58 @@ func TestRun_RunCommandErrorCodes(t *testing.T) {
 			t.Fatalf("expected E_INSTALL_RUNCOMMAND_TIMEOUT, got %v", err)
 		}
 	})
+
+	t.Run("timeout classification", func(t *testing.T) {
+		dir := t.TempDir()
+		bundle := filepath.Join(dir, "bundle")
+		statePath := filepath.Join(dir, "state", "state.json")
+		if err := os.MkdirAll(bundle, 0o755); err != nil {
+			t.Fatalf("mkdir bundle: %v", err)
+		}
+		artifact := filepath.Join(bundle, "files", "a.txt")
+		if err := os.MkdirAll(filepath.Dir(artifact), 0o755); err != nil {
+			t.Fatalf("mkdir files: %v", err)
+		}
+		if err := os.WriteFile(artifact, []byte("ok"), 0o644); err != nil {
+			t.Fatalf("write artifact: %v", err)
+		}
+		if err := writeManifestForTest(bundle, "files/a.txt", []byte("ok")); err != nil {
+			t.Fatalf("write manifest: %v", err)
+		}
+
+		fakeList := filepath.Join(dir, "fake-images-timeout.sh")
+		script := "#!/usr/bin/env bash\nset -euo pipefail\nsleep 1\n"
+		if err := os.WriteFile(fakeList, []byte(script), 0o755); err != nil {
+			t.Fatalf("write fake list script: %v", err)
+		}
+
+		wf := &config.Workflow{
+			Version: "v1",
+			Phases: []config.Phase{{
+				Name: "install",
+				Steps: []config.Step{{
+					ID:   "verify-images",
+					Kind: "VerifyImages",
+					Spec: map[string]any{
+						"images":  []any{"registry.k8s.io/pause:3.10.1"},
+						"command": []any{fakeList},
+						"timeout": "20ms",
+					},
+				}},
+			}},
+		}
+
+		err := Run(context.Background(), wf, RunOptions{BundleRoot: bundle, StatePath: statePath})
+		if err == nil {
+			t.Fatalf("expected verify images timeout")
+		}
+		if !strings.Contains(err.Error(), errCodeInstallImagesCmdFailed) {
+			t.Fatalf("expected verify images error code, got %v", err)
+		}
+		if !strings.Contains(err.Error(), "image verification timed out") {
+			t.Fatalf("expected timeout classification, got %v", err)
+		}
+	})
 }
 
 func TestRun_KubeadmJoinMissingFileErrorCode(t *testing.T) {
@@ -790,6 +845,274 @@ func TestRun_RetrySemantics(t *testing.T) {
 	})
 }
 
+func TestRun_RetryStopsWhenParentContextDone(t *testing.T) {
+	dir := t.TempDir()
+	bundle := filepath.Join(dir, "bundle")
+	statePath := filepath.Join(dir, "state", "state.json")
+	if err := os.MkdirAll(bundle, 0o755); err != nil {
+		t.Fatalf("mkdir bundle: %v", err)
+	}
+	artifact := filepath.Join(bundle, "files", "a.txt")
+	if err := os.MkdirAll(filepath.Dir(artifact), 0o755); err != nil {
+		t.Fatalf("mkdir files: %v", err)
+	}
+	if err := os.WriteFile(artifact, []byte("ok"), 0o644); err != nil {
+		t.Fatalf("write artifact: %v", err)
+	}
+	if err := writeManifestForTest(bundle, "files/a.txt", []byte("ok")); err != nil {
+		t.Fatalf("write manifest: %v", err)
+	}
+
+	counterPath := filepath.Join(dir, "counter")
+	scriptPath := filepath.Join(dir, "slow-fail.sh")
+	script := "#!/usr/bin/env bash\nset -euo pipefail\ncount=0\nif [[ -f \"" + counterPath + "\" ]]; then\n  count=$(cat \"" + counterPath + "\")\nfi\ncount=$((count+1))\necho \"${count}\" > \"" + counterPath + "\"\nsleep 1\nexit 1\n"
+	if err := os.WriteFile(scriptPath, []byte(script), 0o755); err != nil {
+		t.Fatalf("write script: %v", err)
+	}
+
+	wf := &config.Workflow{
+		Version: "v1",
+		Phases: []config.Phase{{
+			Name:  "install",
+			Steps: []config.Step{{ID: "retry-cmd", Kind: "RunCommand", Retry: 4, Spec: map[string]any{"command": []any{scriptPath}, "timeout": "5s"}}},
+		}},
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+	err := Run(ctx, wf, RunOptions{BundleRoot: bundle, StatePath: statePath})
+	if err == nil {
+		t.Fatalf("expected parent context cancellation")
+	}
+
+	counterRaw, readErr := os.ReadFile(counterPath)
+	if readErr != nil {
+		t.Fatalf("read counter: %v", readErr)
+	}
+	if strings.TrimSpace(string(counterRaw)) != "1" {
+		t.Fatalf("expected exactly one attempt when parent context ends, got %q", strings.TrimSpace(string(counterRaw)))
+	}
+}
+
+func TestRun_RunCommandParentCancelNotRelabeledAsTimeout(t *testing.T) {
+	dir := t.TempDir()
+	bundle := filepath.Join(dir, "bundle")
+	statePath := filepath.Join(dir, "state", "state.json")
+	if err := os.MkdirAll(bundle, 0o755); err != nil {
+		t.Fatalf("mkdir bundle: %v", err)
+	}
+	artifact := filepath.Join(bundle, "files", "a.txt")
+	if err := os.MkdirAll(filepath.Dir(artifact), 0o755); err != nil {
+		t.Fatalf("mkdir files: %v", err)
+	}
+	if err := os.WriteFile(artifact, []byte("ok"), 0o644); err != nil {
+		t.Fatalf("write artifact: %v", err)
+	}
+	if err := writeManifestForTest(bundle, "files/a.txt", []byte("ok")); err != nil {
+		t.Fatalf("write manifest: %v", err)
+	}
+
+	wf := &config.Workflow{
+		Version: "v1",
+		Phases: []config.Phase{{
+			Name:  "install",
+			Steps: []config.Step{{ID: "cmd", Kind: "RunCommand", Spec: map[string]any{"command": []any{"true"}, "timeout": "3s"}}},
+		}},
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	err := Run(ctx, wf, RunOptions{BundleRoot: bundle, StatePath: statePath})
+	if err == nil {
+		t.Fatalf("expected canceled context error")
+	}
+	if strings.Contains(err.Error(), errCodeInstallCommandTimeout) {
+		t.Fatalf("expected parent cancellation to not be mapped to timeout, got %v", err)
+	}
+	if !strings.Contains(err.Error(), context.Canceled.Error()) {
+		t.Fatalf("expected canceled context in error, got %v", err)
+	}
+}
+
+func TestRun_DownloadFileRespectsParentContext(t *testing.T) {
+	dir := t.TempDir()
+	bundle := filepath.Join(dir, "bundle")
+	statePath := filepath.Join(dir, "state", "state.json")
+	if err := os.MkdirAll(bundle, 0o755); err != nil {
+		t.Fatalf("mkdir bundle: %v", err)
+	}
+	artifact := filepath.Join(bundle, "files", "a.txt")
+	if err := os.MkdirAll(filepath.Dir(artifact), 0o755); err != nil {
+		t.Fatalf("mkdir files: %v", err)
+	}
+	if err := os.WriteFile(artifact, []byte("ok"), 0o644); err != nil {
+		t.Fatalf("write artifact: %v", err)
+	}
+	if err := writeManifestForTest(bundle, "files/a.txt", []byte("ok")); err != nil {
+		t.Fatalf("write manifest: %v", err)
+	}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(250 * time.Millisecond)
+		_, _ = w.Write([]byte("payload"))
+	}))
+	defer srv.Close()
+
+	wf := &config.Workflow{
+		Version: "v1",
+		Phases: []config.Phase{{
+			Name: "install",
+			Steps: []config.Step{{
+				ID:   "download",
+				Kind: "DownloadFile",
+				Spec: map[string]any{"source": map[string]any{"url": srv.URL + "/files/payload.txt"}, "output": map[string]any{"path": "files/payload.txt"}},
+			}},
+		}},
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Millisecond)
+	defer cancel()
+	err := Run(ctx, wf, RunOptions{BundleRoot: bundle, StatePath: statePath})
+	if err == nil {
+		t.Fatalf("expected download cancellation")
+	}
+	if !strings.Contains(err.Error(), context.DeadlineExceeded.Error()) {
+		t.Fatalf("expected deadline exceeded in error, got %v", err)
+	}
+}
+
+func TestResolveSourceBytes_PreservesContextCancellation(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(250 * time.Millisecond)
+		_, _ = w.Write([]byte("payload"))
+	}))
+	defer srv.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := resolveSourceBytes(ctx, map[string]any{
+		"fetch": map[string]any{
+			"sources": []any{map[string]any{"type": "online", "url": srv.URL}},
+		},
+	}, "files/payload.txt")
+	if err == nil {
+		t.Fatalf("expected context cancellation error")
+	}
+	if strings.Contains(err.Error(), "E_INSTALL_SOURCE_NOT_FOUND") {
+		t.Fatalf("expected cancellation to not be mapped to source-not-found, got %v", err)
+	}
+	if !strings.Contains(err.Error(), context.Canceled.Error()) {
+		t.Fatalf("expected canceled context in error, got %v", err)
+	}
+}
+
+func TestRunCommandOutputWithContext_TimeoutReturnsSentinel(t *testing.T) {
+	_, err := runCommandOutputWithContext(context.Background(), []string{"sleep", "1"}, 10*time.Millisecond)
+	if err == nil {
+		t.Fatalf("expected timeout error")
+	}
+	if !errors.Is(err, errStepCommandTimeout) {
+		t.Fatalf("expected step timeout sentinel, got %v", err)
+	}
+}
+
+func TestRun_ContainerdConfigDefaultGenerationRespectsParentContext(t *testing.T) {
+	dir := t.TempDir()
+	bundle := filepath.Join(dir, "bundle")
+	statePath := filepath.Join(dir, "state", "state.json")
+	if err := os.MkdirAll(bundle, 0o755); err != nil {
+		t.Fatalf("mkdir bundle: %v", err)
+	}
+	artifact := filepath.Join(bundle, "files", "a.txt")
+	if err := os.MkdirAll(filepath.Dir(artifact), 0o755); err != nil {
+		t.Fatalf("mkdir files: %v", err)
+	}
+	if err := os.WriteFile(artifact, []byte("ok"), 0o644); err != nil {
+		t.Fatalf("write artifact: %v", err)
+	}
+	if err := writeManifestForTest(bundle, "files/a.txt", []byte("ok")); err != nil {
+		t.Fatalf("write manifest: %v", err)
+	}
+
+	binDir := filepath.Join(dir, "bin")
+	if err := os.MkdirAll(binDir, 0o755); err != nil {
+		t.Fatalf("mkdir bin: %v", err)
+	}
+	fakeContainerd := filepath.Join(binDir, "containerd")
+	script := "#!/usr/bin/env bash\nset -euo pipefail\nif [[ \"${1:-}\" == \"config\" && \"${2:-}\" == \"default\" ]]; then\n  sleep 1\n  echo 'version = 2'\n  exit 0\nfi\nexit 1\n"
+	if err := os.WriteFile(fakeContainerd, []byte(script), 0o755); err != nil {
+		t.Fatalf("write fake containerd: %v", err)
+	}
+	t.Setenv("PATH", fmt.Sprintf("%s:%s", binDir, os.Getenv("PATH")))
+
+	target := filepath.Join(dir, "containerd", "config.toml")
+	wf := &config.Workflow{
+		Version: "v1",
+		Phases: []config.Phase{{
+			Name:  "install",
+			Steps: []config.Step{{ID: "containerd-config", Kind: "ContainerdConfig", Spec: map[string]any{"path": target, "timeout": "5s"}}},
+		}},
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+	err := Run(ctx, wf, RunOptions{BundleRoot: bundle, StatePath: statePath})
+	if err == nil {
+		t.Fatalf("expected canceled containerd config generation")
+	}
+	if !strings.Contains(err.Error(), context.DeadlineExceeded.Error()) {
+		t.Fatalf("expected deadline exceeded in error, got %v", err)
+	}
+}
+
+func TestRun_ContainerdConfigDefaultGenerationTimeoutUsesTimeoutClassification(t *testing.T) {
+	dir := t.TempDir()
+	bundle := filepath.Join(dir, "bundle")
+	statePath := filepath.Join(dir, "state", "state.json")
+	if err := os.MkdirAll(bundle, 0o755); err != nil {
+		t.Fatalf("mkdir bundle: %v", err)
+	}
+	artifact := filepath.Join(bundle, "files", "a.txt")
+	if err := os.MkdirAll(filepath.Dir(artifact), 0o755); err != nil {
+		t.Fatalf("mkdir files: %v", err)
+	}
+	if err := os.WriteFile(artifact, []byte("ok"), 0o644); err != nil {
+		t.Fatalf("write artifact: %v", err)
+	}
+	if err := writeManifestForTest(bundle, "files/a.txt", []byte("ok")); err != nil {
+		t.Fatalf("write manifest: %v", err)
+	}
+
+	binDir := filepath.Join(dir, "bin")
+	if err := os.MkdirAll(binDir, 0o755); err != nil {
+		t.Fatalf("mkdir bin: %v", err)
+	}
+	fakeContainerd := filepath.Join(binDir, "containerd")
+	script := "#!/usr/bin/env bash\nset -euo pipefail\nif [[ \"${1:-}\" == \"config\" && \"${2:-}\" == \"default\" ]]; then\n  sleep 1\n  echo 'version = 2'\n  exit 0\nfi\nexit 1\n"
+	if err := os.WriteFile(fakeContainerd, []byte(script), 0o755); err != nil {
+		t.Fatalf("write fake containerd: %v", err)
+	}
+	t.Setenv("PATH", fmt.Sprintf("%s:%s", binDir, os.Getenv("PATH")))
+
+	target := filepath.Join(dir, "containerd", "config.toml")
+	wf := &config.Workflow{
+		Version: "v1",
+		Phases: []config.Phase{{
+			Name:  "install",
+			Steps: []config.Step{{ID: "containerd-config", Kind: "ContainerdConfig", Spec: map[string]any{"path": target, "timeout": "20ms"}}},
+		}},
+	}
+
+	err := Run(context.Background(), wf, RunOptions{BundleRoot: bundle, StatePath: statePath})
+	if err == nil {
+		t.Fatalf("expected containerd config timeout")
+	}
+	if !strings.Contains(err.Error(), "containerd config default generation timed out") {
+		t.Fatalf("expected timeout classification, got %v", err)
+	}
+}
+
 func TestRun_WhenInvalidExpression(t *testing.T) {
 	dir := t.TempDir()
 	bundle := filepath.Join(dir, "bundle")
@@ -1043,6 +1366,64 @@ func TestRun_InstallPackagesInstallsFromLocalRepo(t *testing.T) {
 	}
 	if !strings.Contains(args, debA) || !strings.Contains(args, debB) {
 		t.Fatalf("local deb artifacts were not passed to apt-get: %q", args)
+	}
+}
+
+func TestRun_InstallPackagesTimeoutUsesTimeoutClassification(t *testing.T) {
+	dir := t.TempDir()
+	bundle := filepath.Join(dir, "bundle")
+	statePath := filepath.Join(dir, "state", "state.json")
+	if err := os.MkdirAll(bundle, 0o755); err != nil {
+		t.Fatalf("mkdir bundle: %v", err)
+	}
+	artifact := filepath.Join(bundle, "files", "a.txt")
+	if err := os.MkdirAll(filepath.Dir(artifact), 0o755); err != nil {
+		t.Fatalf("mkdir files: %v", err)
+	}
+	if err := os.WriteFile(artifact, []byte("ok"), 0o644); err != nil {
+		t.Fatalf("write artifact: %v", err)
+	}
+	if err := writeManifestForTest(bundle, "files/a.txt", []byte("ok")); err != nil {
+		t.Fatalf("write manifest: %v", err)
+	}
+
+	binDir := filepath.Join(dir, "bin")
+	if err := os.MkdirAll(binDir, 0o755); err != nil {
+		t.Fatalf("mkdir bin: %v", err)
+	}
+	fakeApt := filepath.Join(binDir, "apt-get")
+	script := "#!/usr/bin/env bash\nset -euo pipefail\nsleep 1\n"
+	if err := os.WriteFile(fakeApt, []byte(script), 0o755); err != nil {
+		t.Fatalf("write fake apt-get: %v", err)
+	}
+	originalPath := os.Getenv("PATH")
+	t.Setenv("PATH", fmt.Sprintf("%s:%s", binDir, originalPath))
+
+	wf := &config.Workflow{
+		Version: "v1",
+		Phases: []config.Phase{{
+			Name: "install",
+			Steps: []config.Step{{
+				ID:      "install-pkgs",
+				Kind:    "InstallPackages",
+				Timeout: "20ms",
+				Spec:    map[string]any{"packages": []any{"containerd"}},
+			}},
+		}},
+	}
+
+	err := Run(context.Background(), wf, RunOptions{BundleRoot: bundle, StatePath: statePath})
+	if err == nil {
+		t.Fatalf("expected install packages timeout")
+	}
+	if !strings.Contains(err.Error(), errCodeInstallPkgFailed) {
+		t.Fatalf("expected package install error code, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "timed out") {
+		t.Fatalf("expected timeout classification, got %v", err)
+	}
+	if strings.Contains(err.Error(), "package installation failed") {
+		t.Fatalf("expected timeout path instead of generic failure, got %v", err)
 	}
 }
 
@@ -1397,7 +1778,7 @@ func TestContainerdConfigStep(t *testing.T) {
 		t.Fatalf("write initial config: %v", err)
 	}
 	spec := map[string]any{"path": target, "configPath": "/etc/containerd/certs.d", "systemdCgroup": true}
-	if err := runContainerdConfig(spec); err != nil {
+	if err := runContainerdConfig(context.Background(), spec); err != nil {
 		t.Fatalf("runContainerdConfig failed: %v", err)
 	}
 	raw, err := os.ReadFile(target)

--- a/internal/install/steps_containerd.go
+++ b/internal/install/steps_containerd.go
@@ -2,6 +2,7 @@ package install
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -10,7 +11,7 @@ import (
 	"time"
 )
 
-func runContainerdConfig(spec map[string]any) error {
+func runContainerdConfig(ctx context.Context, spec map[string]any) error {
 	path := stringValue(spec, "path")
 	if path == "" {
 		path = "/etc/containerd/config.toml"
@@ -27,8 +28,11 @@ func runContainerdConfig(spec map[string]any) error {
 		if createDefault, ok := spec["createDefault"].(bool); ok && !createDefault {
 			content = []byte{}
 		} else {
-			generated, genErr := runCommandOutputWithContext(context.Background(), []string{"containerd", "config", "default"}, commandTimeoutWithDefault(spec, 30*time.Second))
+			generated, genErr := runCommandOutputWithContext(ctx, []string{"containerd", "config", "default"}, commandTimeoutWithDefault(spec, 30*time.Second))
 			if genErr != nil {
+				if errors.Is(genErr, errStepCommandTimeout) || errors.Is(genErr, context.DeadlineExceeded) {
+					return fmt.Errorf("containerd config default generation timed out: %w", genErr)
+				}
 				return genErr
 			}
 			content = []byte(generated)

--- a/internal/install/steps_download.go
+++ b/internal/install/steps_download.go
@@ -1,8 +1,10 @@
 package install
 
 import (
+	"context"
 	"crypto/sha256"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -15,7 +17,10 @@ import (
 	"github.com/taedi90/deck/internal/fetch"
 )
 
-func runDownloadFile(bundleRoot string, spec map[string]any) (string, error) {
+func runDownloadFile(ctx context.Context, bundleRoot string, spec map[string]any) (string, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
 	source := mapValue(spec, "source")
 	output := mapValue(spec, "output")
 	fetchCfg := mapValue(spec, "fetch")
@@ -36,7 +41,7 @@ func runDownloadFile(bundleRoot string, spec map[string]any) (string, error) {
 		return "", fmt.Errorf("create output directory: %w", err)
 	}
 
-	reuse, err := canReuseDownloadFile(spec, target)
+	reuse, err := canReuseDownloadFile(ctx, spec, target)
 	if err != nil {
 		return "", err
 	}
@@ -51,7 +56,7 @@ func runDownloadFile(bundleRoot string, spec map[string]any) (string, error) {
 	defer func() { _ = f.Close() }()
 
 	if sourcePath != "" {
-		raw, resolveErr := resolveSourceBytes(spec, sourcePath)
+		raw, resolveErr := resolveSourceBytes(ctx, spec, sourcePath)
 		if resolveErr == nil {
 			if _, err := f.Write(raw); err != nil {
 				return "", fmt.Errorf("write output file: %w", err)
@@ -69,7 +74,7 @@ func runDownloadFile(bundleRoot string, spec map[string]any) (string, error) {
 			if err := f.Truncate(0); err != nil {
 				return "", fmt.Errorf("truncate output file: %w", err)
 			}
-			if err := downloadURLToFile(f, url, commandTimeout(spec)); err != nil {
+			if err := downloadURLToFile(ctx, f, url, commandTimeout(spec)); err != nil {
 				return "", err
 			}
 		}
@@ -77,7 +82,7 @@ func runDownloadFile(bundleRoot string, spec map[string]any) (string, error) {
 		if offlineOnly {
 			return "", fmt.Errorf("%s: source.url blocked by offline policy", errCodeInstallOfflineBlocked)
 		}
-		if err := downloadURLToFile(f, url, commandTimeout(spec)); err != nil {
+		if err := downloadURLToFile(ctx, f, url, commandTimeout(spec)); err != nil {
 			return "", err
 		}
 	}
@@ -101,9 +106,16 @@ func runDownloadFile(bundleRoot string, spec map[string]any) (string, error) {
 	return outPath, nil
 }
 
-func downloadURLToFile(target *os.File, url string, timeout time.Duration) error {
+func downloadURLToFile(ctx context.Context, target *os.File, url string, timeout time.Duration) error {
+	if ctx == nil {
+		ctx = context.Background()
+	}
 	client := &http.Client{Timeout: timeout}
-	resp, err := client.Get(url)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return fmt.Errorf("download %s: %w", url, err)
+	}
+	resp, err := client.Do(req)
 	if err != nil {
 		return fmt.Errorf("download %s: %w", url, err)
 	}
@@ -117,7 +129,7 @@ func downloadURLToFile(target *os.File, url string, timeout time.Duration) error
 	return nil
 }
 
-func resolveSourceBytes(spec map[string]any, sourcePath string) ([]byte, error) {
+func resolveSourceBytes(ctx context.Context, spec map[string]any, sourcePath string) ([]byte, error) {
 	fetchCfg := mapValue(spec, "fetch")
 	sourcesRaw, ok := fetchCfg["sources"].([]any)
 	offlineOnly := boolValue(fetchCfg, "offlineOnly")
@@ -137,9 +149,15 @@ func resolveSourceBytes(spec map[string]any, sourcePath string) ([]byte, error) 
 		if len(sources) == 0 {
 			return nil, fmt.Errorf("%s: source.path %s not found in configured fetch sources", errCodeInstallSourceNotFound, sourcePath)
 		}
-		raw, err := fetch.ResolveBytes(sourcePath, sources, fetch.ResolveOptions{OfflineOnly: offlineOnly})
+		raw, err := fetch.ResolveBytes(ctx, sourcePath, sources, fetch.ResolveOptions{OfflineOnly: offlineOnly})
 		if err == nil {
 			return raw, nil
+		}
+		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+			return nil, err
+		}
+		if ctx != nil && ctx.Err() != nil {
+			return nil, ctx.Err()
 		}
 		return nil, fmt.Errorf("%s: source.path %s not found in configured fetch sources", errCodeInstallSourceNotFound, sourcePath)
 	}
@@ -164,7 +182,7 @@ func verifyFileSHA256(path, expected string) error {
 	return nil
 }
 
-func canReuseDownloadFile(spec map[string]any, target string) (bool, error) {
+func canReuseDownloadFile(ctx context.Context, spec map[string]any, target string) (bool, error) {
 	info, err := os.Stat(target)
 	if err != nil {
 		if os.IsNotExist(err) {
@@ -189,7 +207,7 @@ func canReuseDownloadFile(spec map[string]any, target string) (bool, error) {
 	if sourcePath == "" {
 		return false, nil
 	}
-	raw, err := resolveSourceBytes(spec, sourcePath)
+	raw, err := resolveSourceBytes(ctx, spec, sourcePath)
 	if err != nil {
 		return false, nil
 	}

--- a/internal/install/steps_kubeadm.go
+++ b/internal/install/steps_kubeadm.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strings"
 	"time"
@@ -89,27 +88,21 @@ func runKubeadmInitReal(parent context.Context, spec map[string]any) error {
 	}
 
 	if err := runTimedCommandWithContext(parent, "kubeadm", args, commandTimeoutWithDefault(spec, 10*time.Minute)); err != nil {
-		if errors.Is(err, context.DeadlineExceeded) {
+		if errors.Is(err, errStepCommandTimeout) {
 			return fmt.Errorf("%s: kubeadm init timed out: %w", errCodeInstallInitFailed, err)
 		}
 		return fmt.Errorf("%s: kubeadm init failed: %w", errCodeInstallInitFailed, err)
 	}
 
 	joinArgs := []string{"token", "create", "--print-join-command"}
-	if parent == nil {
-		parent = context.Background()
-	}
-	ctx, cancel := context.WithTimeout(parent, commandTimeoutWithDefault(spec, 10*time.Minute))
-	defer cancel()
-	cmd := exec.CommandContext(ctx, "kubeadm", joinArgs...)
-	joinOut, err := cmd.Output()
+	joinOut, err := runCommandOutputWithContext(parent, append([]string{"kubeadm"}, joinArgs...), commandTimeoutWithDefault(spec, 10*time.Minute))
 	if err != nil {
-		if errors.Is(ctx.Err(), context.DeadlineExceeded) {
+		if errors.Is(err, errStepCommandTimeout) {
 			return fmt.Errorf("%s: kubeadm token create timed out", errCodeInstallInitFailed)
 		}
 		return fmt.Errorf("%s: kubeadm token create failed: %w", errCodeInstallInitFailed, err)
 	}
-	joinCmd := strings.TrimSpace(string(joinOut))
+	joinCmd := strings.TrimSpace(joinOut)
 	if joinCmd == "" {
 		return fmt.Errorf("%s: empty kubeadm join command output", errCodeInstallInitFailed)
 	}
@@ -142,7 +135,7 @@ func runKubeadmJoinReal(ctx context.Context, spec map[string]any) error {
 	}
 
 	if err := runTimedCommandWithContext(ctx, args[0], args[1:], commandTimeoutWithDefault(spec, 5*time.Minute)); err != nil {
-		if errors.Is(err, context.DeadlineExceeded) {
+		if errors.Is(err, errStepCommandTimeout) {
 			return fmt.Errorf("%s: kubeadm join timed out: %w", errCodeInstallJoinFailed, err)
 		}
 		return fmt.Errorf("%s: kubeadm join failed: %w", errCodeInstallJoinFailed, err)

--- a/internal/install/steps_packages.go
+++ b/internal/install/steps_packages.go
@@ -12,7 +12,11 @@ import (
 	"time"
 )
 
-func runInstallPackages(spec map[string]any) error {
+func runInstallPackages(ctx context.Context, spec map[string]any) error {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
 	pkgs := stringSlice(spec["packages"])
 	if len(pkgs) == 0 {
 		return fmt.Errorf("%s: InstallPackages requires packages", errCodeInstallPackagesRequired)
@@ -51,8 +55,8 @@ func runInstallPackages(spec map[string]any) error {
 			}
 			args := []string{"install", "-y"}
 			args = append(args, artifacts...)
-			if err := runTimedCommand("apt-get", args, commandTimeoutWithDefault(spec, 10*time.Minute)); err != nil {
-				if errors.Is(err, context.DeadlineExceeded) {
+			if err := runTimedCommandWithContext(ctx, "apt-get", args, commandTimeoutWithDefault(spec, 10*time.Minute)); err != nil {
+				if errors.Is(err, errStepCommandTimeout) || errors.Is(err, context.DeadlineExceeded) {
 					return fmt.Errorf("%s: package installation timed out: %w", errCodeInstallPkgFailed, err)
 				}
 				return fmt.Errorf("%s: package installation failed: %w", errCodeInstallPkgFailed, err)
@@ -66,8 +70,8 @@ func runInstallPackages(spec map[string]any) error {
 		}
 		args := []string{"install", "-y"}
 		args = append(args, artifacts...)
-		if err := runTimedCommand("dnf", args, commandTimeoutWithDefault(spec, 10*time.Minute)); err != nil {
-			if errors.Is(err, context.DeadlineExceeded) {
+		if err := runTimedCommandWithContext(ctx, "dnf", args, commandTimeoutWithDefault(spec, 10*time.Minute)); err != nil {
+			if errors.Is(err, errStepCommandTimeout) || errors.Is(err, context.DeadlineExceeded) {
 				return fmt.Errorf("%s: package installation timed out: %w", errCodeInstallPkgFailed, err)
 			}
 			return fmt.Errorf("%s: package installation failed: %w", errCodeInstallPkgFailed, err)
@@ -77,8 +81,8 @@ func runInstallPackages(spec map[string]any) error {
 
 	args := []string{"install", "-y"}
 	args = append(args, pkgs...)
-	if err := runTimedCommand(installer, args, commandTimeoutWithDefault(spec, 10*time.Minute)); err != nil {
-		if errors.Is(err, context.DeadlineExceeded) {
+	if err := runTimedCommandWithContext(ctx, installer, args, commandTimeoutWithDefault(spec, 10*time.Minute)); err != nil {
+		if errors.Is(err, errStepCommandTimeout) || errors.Is(err, context.DeadlineExceeded) {
 			return fmt.Errorf("%s: package installation timed out: %w", errCodeInstallPkgFailed, err)
 		}
 		return fmt.Errorf("%s: package installation failed: %w", errCodeInstallPkgFailed, err)

--- a/internal/install/steps_verify.go
+++ b/internal/install/steps_verify.go
@@ -2,6 +2,7 @@ package install
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -28,6 +29,9 @@ func runVerifyImages(ctx context.Context, spec map[string]any) error {
 
 	output, err := runCommandOutputWithContext(ctx, cmdArgs, timeout)
 	if err != nil {
+		if errors.Is(err, errStepCommandTimeout) || errors.Is(err, context.DeadlineExceeded) {
+			return fmt.Errorf("%s: image verification timed out: %w", errCodeInstallImagesCmdFailed, err)
+		}
 		return fmt.Errorf("%s: %w", errCodeInstallImagesCmdFailed, err)
 	}
 


### PR DESCRIPTION
## Summary
- thread install and fetch execution through the caller context instead of starting fresh background contexts
- classify step-local timeouts consistently for install commands, downloads, image verification, and containerd default generation
- lock the new behavior down with focused install and fetch regression tests