### PR TITLE
Refine prepare workflows and package download handling

### DIFF
--- a/docs/examples/offline-pull-control-plane.yaml
+++ b/docs/examples/offline-pull-control-plane.yaml
@@ -28,10 +28,10 @@ phases:
             clean: true
           repositories:
             - id: deck-os
-              baseurl: http://{{ .vars.serverURL }}/packages/apt/{{ .vars.release }}
+              baseurl: http://{{ .vars.serverURL }}/packages/deb/{{ .vars.release }}
               trusted: true
             - id: deck-k8s
-              baseurl: http://{{ .vars.serverURL }}/packages/apt-k8s/{{ .vars.release }}
+              baseurl: http://{{ .vars.serverURL }}/packages/deb-k8s/{{ .vars.release }}
               trusted: true
       - id: configure-offline-repo-yum
         when: vars.osFamily == "rhel"
@@ -47,12 +47,12 @@ phases:
           repositories:
             - id: deck-os
               name: deck-os
-              baseurl: http://{{ .vars.serverURL }}/packages/yum/{{ .vars.release }}
+              baseurl: http://{{ .vars.serverURL }}/packages/rpm/{{ .vars.release }}
               enabled: true
               gpgcheck: false
             - id: deck-k8s
               name: deck-k8s
-              baseurl: http://{{ .vars.serverURL }}/packages/yum-k8s/{{ .vars.release }}
+              baseurl: http://{{ .vars.serverURL }}/packages/rpm-k8s/{{ .vars.release }}
               enabled: true
               gpgcheck: false
       - id: install-k8s-deps

--- a/docs/examples/offline-pull-worker.yaml
+++ b/docs/examples/offline-pull-worker.yaml
@@ -28,10 +28,10 @@ phases:
             clean: true
           repositories:
             - id: deck-os
-              baseurl: http://{{ .vars.serverURL }}/packages/apt/{{ .vars.release }}
+              baseurl: http://{{ .vars.serverURL }}/packages/deb/{{ .vars.release }}
               trusted: true
             - id: deck-k8s
-              baseurl: http://{{ .vars.serverURL }}/packages/apt-k8s/{{ .vars.release }}
+              baseurl: http://{{ .vars.serverURL }}/packages/deb-k8s/{{ .vars.release }}
               trusted: true
       - id: configure-offline-repo-yum
         when: vars.osFamily == "rhel"
@@ -47,12 +47,12 @@ phases:
           repositories:
             - id: deck-os
               name: deck-os
-              baseurl: http://{{ .vars.serverURL }}/packages/yum/{{ .vars.release }}
+              baseurl: http://{{ .vars.serverURL }}/packages/rpm/{{ .vars.release }}
               enabled: true
               gpgcheck: false
             - id: deck-k8s
               name: deck-k8s
-              baseurl: http://{{ .vars.serverURL }}/packages/yum-k8s/{{ .vars.release }}
+              baseurl: http://{{ .vars.serverURL }}/packages/rpm-k8s/{{ .vars.release }}
               enabled: true
               gpgcheck: false
       - id: install-k8s-deps

--- a/docs/examples/offline-repo-preinstall.yaml
+++ b/docs/examples/offline-repo-preinstall.yaml
@@ -29,7 +29,7 @@ phases:
           replaceExisting: true
           repositories:
             - id: offline-repo
-              baseurl: http://{{ .vars.serverURL }}/packages/apt/{{ .vars.release }}
+              baseurl: http://{{ .vars.serverURL }}/packages/deb/{{ .vars.release }}
               trusted: true
       - id: refresh-offline-repo-cache-apt
         when: vars.osFamily == "debian"
@@ -52,7 +52,7 @@ phases:
           repositories:
             - id: offline-repo
               name: Offline repo for kubespray
-              baseurl: http://{{ .vars.serverURL }}/packages/yum/{{ .vars.release }}
+              baseurl: http://{{ .vars.serverURL }}/packages/rpm/{{ .vars.release }}
               enabled: true
               gpgcheck: false
               module_hotfixes: true

--- a/internal/bundle/verify.go
+++ b/internal/bundle/verify.go
@@ -351,16 +351,16 @@ func isManifestTrackedPath(rel string) bool {
 }
 
 func verifyOfflineArtifactCoverage(bundleRoot string, manifestPaths map[string]struct{}) error {
-	if err := verifyAPTRepoCoverage(bundleRoot, manifestPaths, filepath.Join("packages", "apt")); err != nil {
+	if err := verifyAPTRepoCoverage(bundleRoot, manifestPaths, filepath.Join("packages", "deb")); err != nil {
 		return err
 	}
-	if err := verifyAPTRepoCoverage(bundleRoot, manifestPaths, filepath.Join("packages", "apt-k8s")); err != nil {
+	if err := verifyAPTRepoCoverage(bundleRoot, manifestPaths, filepath.Join("packages", "deb-k8s")); err != nil {
 		return err
 	}
-	if err := verifyYUMRepoCoverage(bundleRoot, manifestPaths, filepath.Join("packages", "yum")); err != nil {
+	if err := verifyYUMRepoCoverage(bundleRoot, manifestPaths, filepath.Join("packages", "rpm")); err != nil {
 		return err
 	}
-	if err := verifyYUMRepoCoverage(bundleRoot, manifestPaths, filepath.Join("packages", "yum-k8s")); err != nil {
+	if err := verifyYUMRepoCoverage(bundleRoot, manifestPaths, filepath.Join("packages", "rpm-k8s")); err != nil {
 		return err
 	}
 
@@ -368,16 +368,16 @@ func verifyOfflineArtifactCoverage(bundleRoot string, manifestPaths map[string]s
 }
 
 func verifyOfflineArtifactCoverageFromTar(files map[string]tarFileInfo, dirs map[string]struct{}, manifestPaths map[string]struct{}) error {
-	if err := verifyAPTRepoCoverageFromTar(files, dirs, manifestPaths, path.Join("packages", "apt")); err != nil {
+	if err := verifyAPTRepoCoverageFromTar(files, dirs, manifestPaths, path.Join("packages", "deb")); err != nil {
 		return err
 	}
-	if err := verifyAPTRepoCoverageFromTar(files, dirs, manifestPaths, path.Join("packages", "apt-k8s")); err != nil {
+	if err := verifyAPTRepoCoverageFromTar(files, dirs, manifestPaths, path.Join("packages", "deb-k8s")); err != nil {
 		return err
 	}
-	if err := verifyYUMRepoCoverageFromTar(files, dirs, manifestPaths, path.Join("packages", "yum")); err != nil {
+	if err := verifyYUMRepoCoverageFromTar(files, dirs, manifestPaths, path.Join("packages", "rpm")); err != nil {
 		return err
 	}
-	if err := verifyYUMRepoCoverageFromTar(files, dirs, manifestPaths, path.Join("packages", "yum-k8s")); err != nil {
+	if err := verifyYUMRepoCoverageFromTar(files, dirs, manifestPaths, path.Join("packages", "rpm-k8s")); err != nil {
 		return err
 	}
 

--- a/internal/bundle/verify_test.go
+++ b/internal/bundle/verify_test.go
@@ -79,10 +79,10 @@ func TestVerifyManifest(t *testing.T) {
 
 	t.Run("fails when apt metadata missing from manifest", func(t *testing.T) {
 		root := t.TempDir()
-		writeBundleFile(t, root, "packages/apt/jammy/Release", []byte("release"))
-		writeBundleFile(t, root, "packages/apt/jammy/Packages.gz", []byte("packages"))
+		writeBundleFile(t, root, "packages/deb/jammy/Release", []byte("release"))
+		writeBundleFile(t, root, "packages/deb/jammy/Packages.gz", []byte("packages"))
 
-		if err := writeManifestForPaths(root, "packages/apt/jammy/Packages.gz"); err != nil {
+		if err := writeManifestForPaths(root, "packages/deb/jammy/Packages.gz"); err != nil {
 			t.Fatalf("write manifest: %v", err)
 		}
 
@@ -93,7 +93,7 @@ func TestVerifyManifest(t *testing.T) {
 		if !strings.Contains(err.Error(), "required offline artifact missing from manifest") {
 			t.Fatalf("unexpected error: %v", err)
 		}
-		if !strings.Contains(err.Error(), "packages/apt/jammy/Release") {
+		if !strings.Contains(err.Error(), "packages/deb/jammy/Release") {
 			t.Fatalf("expected missing Release path, got %v", err)
 		}
 	})
@@ -101,7 +101,7 @@ func TestVerifyManifest(t *testing.T) {
 	t.Run("fails when yum metadata missing from manifest", func(t *testing.T) {
 		root := t.TempDir()
 		writeBundleFile(t, root, "files/a.txt", []byte("ok"))
-		writeBundleFile(t, root, "packages/yum/el8/repodata/repomd.xml", []byte("repomd"))
+		writeBundleFile(t, root, "packages/rpm/el8/repodata/repomd.xml", []byte("repomd"))
 
 		if err := writeManifestForPaths(root, "files/a.txt"); err != nil {
 			t.Fatalf("write manifest: %v", err)
@@ -114,7 +114,7 @@ func TestVerifyManifest(t *testing.T) {
 		if !strings.Contains(err.Error(), "required offline artifact missing from manifest") {
 			t.Fatalf("unexpected error: %v", err)
 		}
-		if !strings.Contains(err.Error(), "packages/yum/el8/repodata/repomd.xml") {
+		if !strings.Contains(err.Error(), "packages/rpm/el8/repodata/repomd.xml") {
 			t.Fatalf("expected missing repomd path, got %v", err)
 		}
 	})
@@ -143,12 +143,12 @@ func TestVerifyManifest(t *testing.T) {
 	t.Run("passes when offline artifacts are included in manifest", func(t *testing.T) {
 		root := t.TempDir()
 		paths := []string{
-			"packages/apt/noble/Release",
-			"packages/apt/noble/Packages.gz",
-			"packages/apt-k8s/v1.32/Release",
-			"packages/apt-k8s/v1.32/Packages.gz",
-			"packages/yum/el9/repodata/repomd.xml",
-			"packages/yum-k8s/el9-k8s/repodata/repomd.xml",
+			"packages/deb/noble/Release",
+			"packages/deb/noble/Packages.gz",
+			"packages/deb-k8s/v1.32/Release",
+			"packages/deb-k8s/v1.32/Packages.gz",
+			"packages/rpm/el9/repodata/repomd.xml",
+			"packages/rpm-k8s/el9-k8s/repodata/repomd.xml",
 			"images/pause.tar",
 		}
 		for i, p := range paths {

--- a/internal/prepare/download_packages.go
+++ b/internal/prepare/download_packages.go
@@ -59,9 +59,9 @@ func runPackagesDownload(ctx context.Context, runner CommandRunner, bundleRoot s
 			var repoRoot string
 			switch repoType {
 			case "apt-flat":
-				repoRoot = filepath.ToSlash(filepath.Join("packages", "apt", release))
+				repoRoot = filepath.ToSlash(filepath.Join("packages", "deb", release))
 			case "yum":
-				repoRoot = filepath.ToSlash(filepath.Join("packages", "yum", release))
+				repoRoot = filepath.ToSlash(filepath.Join("packages", "rpm", release))
 			default:
 				return nil, fmt.Errorf("packages action download repo.type must be apt-flat or yum")
 			}

--- a/internal/prepare/runner_test.go
+++ b/internal/prepare/runner_test.go
@@ -974,13 +974,13 @@ func TestRun_PackagesRepoModeAptFlatGeneratesMetadata(t *testing.T) {
 		t.Fatalf("Run failed: %v", err)
 	}
 
-	if _, err := os.Stat(filepath.Join(bundle, "packages", "apt", "ubuntu2204", "pkgs", "mock-package.deb")); err != nil {
+	if _, err := os.Stat(filepath.Join(bundle, "packages", "deb", "ubuntu2204", "pkgs", "mock-package.deb")); err != nil {
 		t.Fatalf("expected mock deb artifact: %v", err)
 	}
-	if _, err := os.Stat(filepath.Join(bundle, "packages", "apt", "ubuntu2204", "Packages.gz")); err != nil {
+	if _, err := os.Stat(filepath.Join(bundle, "packages", "deb", "ubuntu2204", "Packages.gz")); err != nil {
 		t.Fatalf("expected Packages.gz: %v", err)
 	}
-	if _, err := os.Stat(filepath.Join(bundle, "packages", "apt", "ubuntu2204", "Release")); err != nil {
+	if _, err := os.Stat(filepath.Join(bundle, "packages", "deb", "ubuntu2204", "Release")); err != nil {
 		t.Fatalf("expected Release: %v", err)
 	}
 }
@@ -1019,7 +1019,7 @@ func TestRun_PackagesRepoModeYumGeneratesRepodata(t *testing.T) {
 		t.Fatalf("Run failed: %v", err)
 	}
 
-	if _, err := os.Stat(filepath.Join(bundle, "packages", "yum", "rhel9", "repodata", "repomd.xml")); err != nil {
+	if _, err := os.Stat(filepath.Join(bundle, "packages", "rpm", "rhel9", "repodata", "repomd.xml")); err != nil {
 		t.Fatalf("expected repodata/repomd.xml: %v", err)
 	}
 }
@@ -1180,7 +1180,7 @@ func (f *fakeRunner) Run(_ context.Context, name string, args ...string) error {
 					return err
 				}
 				// repo-mode simulation: create minimal artifacts + metadata
-				if strings.Contains(host, string(filepath.Separator)+"packages"+string(filepath.Separator)+"apt"+string(filepath.Separator)) {
+				if strings.Contains(host, string(filepath.Separator)+"packages"+string(filepath.Separator)+"deb"+string(filepath.Separator)) {
 					pkgs := filepath.Join(host, "pkgs")
 					if err := os.MkdirAll(pkgs, 0o755); err != nil {
 						return err
@@ -1199,7 +1199,7 @@ func (f *fakeRunner) Run(_ context.Context, name string, args ...string) error {
 					}
 					continue
 				}
-				if strings.Contains(host, string(filepath.Separator)+"packages"+string(filepath.Separator)+"yum"+string(filepath.Separator)) {
+				if strings.Contains(host, string(filepath.Separator)+"packages"+string(filepath.Separator)+"rpm"+string(filepath.Separator)) {
 					repodata := filepath.Join(host, "repodata")
 					if err := os.MkdirAll(repodata, 0o755); err != nil {
 						return err

--- a/test/workflows/components/repo/offline-repo-debian.yaml
+++ b/test/workflows/components/repo/offline-repo-debian.yaml
@@ -14,7 +14,7 @@ phases:
           repositories:
             - type: deb
               trusted: true
-              baseurl: http://{{ .vars.serverURL  }}/packages/apt/{{ .vars.release  }}
+              baseurl: http://{{ .vars.serverURL  }}/packages/deb/{{ .vars.release  }}
               suite: ./
       - id: refresh-apt-package-cache
         apiVersion: deck/v1alpha1

--- a/test/workflows/components/repo/offline-repo-rhel.yaml
+++ b/test/workflows/components/repo/offline-repo-rhel.yaml
@@ -14,7 +14,7 @@ phases:
           repositories:
             - id: deck-os
               name: deck-os
-              baseurl: http://{{ .vars.serverURL  }}/packages/yum/{{ .vars.release  }}
+              baseurl: http://{{ .vars.serverURL  }}/packages/rpm/{{ .vars.release  }}
               enabled: true
               gpgcheck: false
       - id: refresh-dnf-package-cache


### PR DESCRIPTION
## Summary
- redesign the prepare workflow model around declarative artifact downloads, updated typed step schemas, and the related CLI/docs/test coverage
- fix container-backed `packages.download` so artifacts are copied back with the invoking user's ownership while reusing shared package-manager caches under `~/.deck/cache/packages/...`
- rename offline package bundle repo paths from `packages/apt|yum` to `packages/deb|rpm` and update verification, examples, and workflow fixtures accordingly