### PR TITLE
Simplify workflow structure and fix Vagrant e2e regressions

### DIFF
--- a/internal/install/runner_test.go
+++ b/internal/install/runner_test.go
@@ -1148,8 +1148,8 @@ func TestRun_KubeadmRealModeSupportsImagePullAndConfigWrite(t *testing.T) {
 	if !strings.Contains(logText, "config images pull --kubernetes-version v1.30.14 --cri-socket unix:///run/containerd/containerd.sock") {
 		t.Fatalf("expected kubeadm image pull invocation, got %q", logText)
 	}
-	if !strings.Contains(logText, "init --config "+configPath+" --apiserver-advertise-address 10.20.30.40 --pod-network-cidr 10.244.0.0/16 --cri-socket unix:///run/containerd/containerd.sock --kubernetes-version v1.30.14 --ignore-preflight-errors Swap --skip-phases=addon/kube-proxy") {
-		t.Fatalf("expected kubeadm init args with first-class fields, got %q", logText)
+	if !strings.Contains(logText, "init --config "+configPath+" --ignore-preflight-errors Swap --skip-phases=addon/kube-proxy") {
+		t.Fatalf("expected kubeadm init args with config file only, got %q", logText)
 	}
 }
 

--- a/internal/install/steps_kubeadm.go
+++ b/internal/install/steps_kubeadm.go
@@ -135,18 +135,19 @@ func runKubeadmInitReal(parent context.Context, spec map[string]any) error {
 	args := []string{"init"}
 	if configFile != "" {
 		args = append(args, "--config", configFile)
-	}
-	if advertiseAddress != "" {
-		args = append(args, "--apiserver-advertise-address", advertiseAddress)
-	}
-	if podCIDR := stringValue(spec, "podNetworkCIDR"); podCIDR != "" {
-		args = append(args, "--pod-network-cidr", podCIDR)
-	}
-	if criSocket != "" {
-		args = append(args, "--cri-socket", criSocket)
-	}
-	if kubernetesVersion != "" {
-		args = append(args, "--kubernetes-version", kubernetesVersion)
+	} else {
+		if advertiseAddress != "" {
+			args = append(args, "--apiserver-advertise-address", advertiseAddress)
+		}
+		if podCIDR := stringValue(spec, "podNetworkCIDR"); podCIDR != "" {
+			args = append(args, "--pod-network-cidr", podCIDR)
+		}
+		if criSocket != "" {
+			args = append(args, "--cri-socket", criSocket)
+		}
+		if kubernetesVersion != "" {
+			args = append(args, "--kubernetes-version", kubernetesVersion)
+		}
 	}
 	if ignore := stringSlice(spec["ignorePreflightErrors"]); len(ignore) > 0 {
 		args = append(args, "--ignore-preflight-errors", strings.Join(ignore, ","))

--- a/internal/install/steps_system.go
+++ b/internal/install/steps_system.go
@@ -30,7 +30,17 @@ func runSysctl(spec map[string]any) error {
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
 		return err
 	}
-	return os.WriteFile(path, []byte(strings.Join(lines, "\n")+"\n"), 0o644)
+	if err := os.WriteFile(path, []byte(strings.Join(lines, "\n")+"\n"), 0o644); err != nil {
+		return err
+	}
+	if boolValue(spec, "apply") {
+		applySpec := map[string]any{"file": path}
+		if timeout := stringValue(spec, "timeout"); timeout != "" {
+			applySpec["timeout"] = timeout
+		}
+		return runSysctlApply(applySpec)
+	}
+	return nil
 }
 
 func runService(spec map[string]any) error {

--- a/test/e2e/scenario-hooks/control-plane-bootstrap.sh
+++ b/test/e2e/scenario-hooks/control-plane-bootstrap.sh
@@ -67,7 +67,7 @@ bootstrap_apply_control_plane_workflow() {
   CONTROL_PLANE_WORKFLOW_URL="${SERVER_URL}/workflows/scenarios/control-plane-bootstrap.yaml"
   local server_no_scheme="${SERVER_URL#http://}"
   server_no_scheme="${server_no_scheme#https://}"
-  sudo -n "${DECK_BIN}" apply --file "${CONTROL_PLANE_WORKFLOW_URL}" --phase install \
+  sudo -n "${DECK_BIN}" apply --file "${CONTROL_PLANE_WORKFLOW_URL}" \
     --var "serverURL=${server_no_scheme}" \
     --var "registryHost=${server_no_scheme}" \
     --var "release=${OFFLINE_RELEASE_CONTROL_PLANE}" \

--- a/test/e2e/scenario-hooks/node-reset.sh
+++ b/test/e2e/scenario-hooks/node-reset.sh
@@ -90,7 +90,7 @@ node_reset_apply_worker_join_once() {
   local server_no_scheme="$4"
   local log_path="$5"
   clear_install_state
-  sudo -n "${DECK_BIN}" apply --file "${workflow_url}" --phase install \
+  sudo -n "${DECK_BIN}" apply --file "${workflow_url}" \
     --var "serverURL=${server_no_scheme}" \
     --var "registryHost=${server_no_scheme}" \
     --var "release=${release}" \
@@ -138,7 +138,7 @@ node_reset_apply_worker_lifecycle() {
   node_reset_apply_worker_join_once "${workflow_url}" "${release}" "${os_family}" "${server_no_scheme}" "${CASE_DIR}/05-apply-${ROLE}.log"
   printf '%s\n' "ok" > "${ART_DIR}/${ROLE}-apply-done.txt"
   clear_install_state
-  sudo -n "${DECK_BIN}" apply --file "${node_reset_url}" --phase install \
+  sudo -n "${DECK_BIN}" apply --file "${node_reset_url}" \
     --var "allowDestructive=true" \
     --var "resetReason=${reset_reason}" \
     --var "resetStatePath=${REPORT_DIR}/reset-state.txt" > "${CASE_DIR}/05-reset-${ROLE}.log" 2>&1

--- a/test/e2e/scenario-hooks/worker-join.sh
+++ b/test/e2e/scenario-hooks/worker-join.sh
@@ -7,7 +7,7 @@ worker_join_apply_once() {
   local server_no_scheme="$4"
   local log_path="$5"
   clear_install_state
-  sudo -n "${DECK_BIN}" apply --file "${workflow_url}" --phase install \
+  sudo -n "${DECK_BIN}" apply --file "${workflow_url}" \
     --var "serverURL=${server_no_scheme}" \
     --var "registryHost=${server_no_scheme}" \
     --var "release=${release}" \

--- a/test/e2e/vagrant/common.sh
+++ b/test/e2e/vagrant/common.sh
@@ -455,10 +455,11 @@ prepare_shared_bundle_cache() {
   rm -rf "${PREPARED_BUNDLE_WORK_ABS}" "${PREPARED_BUNDLE_STAGE_ABS}"
   mkdir -p "${PREPARED_BUNDLE_WORKFLOW_DIR}" "${PREPARED_BUNDLE_FRAGMENT_DIR}"
   deck_vagrant_prepare_workflow_bundle
-  (cd "${PREPARED_BUNDLE_PACK_ROOT}" && "${host_bin}" prepare --out "${PREPARED_BUNDLE_TAR}" \
+  (cd "${PREPARED_BUNDLE_PACK_ROOT}" && "${host_bin}" prepare --root outputs \
     --var "kubernetesVersion=v1.30.1" \
     --var "arch=${arch}" \
     --var "backendRuntime=${backend_runtime}")
+  (cd "${PREPARED_BUNDLE_PACK_ROOT}" && "${host_bin}" bundle build --root . --out "${PREPARED_BUNDLE_TAR}")
 
   mkdir -p "${PREPARED_BUNDLE_STAGE_ABS}"
   tar -xf "${PREPARED_BUNDLE_TAR}" -C "${PREPARED_BUNDLE_STAGE_ABS}" --strip-components=1
@@ -477,6 +478,7 @@ prepare_rsync_stage_root() {
   local dispatcher_stage_path="${DECK_VAGRANT_VM_DISPATCHER_STAGED_PATH:-test/e2e/vagrant/run-scenario-vm.sh}"
   local dispatcher_scenario_helper_source="${ROOT_DIR}/test/e2e/vagrant/run-scenario-vm-scenario.sh"
   local dispatcher_scenario_helper_stage_path="test/e2e/vagrant/run-scenario-vm-scenario.sh"
+  local include_legacy_workflows="0"
   local rsync_key=""
 
   rsync_key="$(python3 - <<'PY' "${ROOT_DIR}" "${deck_bin_source}" "${DECK_VAGRANT_VM_SCENARIO_SCRIPT}" "${dispatcher_source}" "${dispatcher_scenario_helper_source}" "${PREPARED_BUNDLE_ABS}"

--- a/test/e2e/vagrant/render-workflows.sh
+++ b/test/e2e/vagrant/render-workflows.sh
@@ -1,6 +1,15 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+if [[ "${1:-}" == "--help" || "${1:-}" == "-h" ]]; then
+  cat <<'EOF'
+Usage: test/e2e/vagrant/render-workflows.sh <root-dir> <target-dir>
+
+Copy the canonical workflow tree from test/workflows/ into a target workspace.
+EOF
+  exit 0
+fi
+
 ROOT_DIR="${1:?root dir required}"
 TARGET_DIR="${2:?target dir required}"
 

--- a/test/e2e/vagrant/run-scenario-vm-scenario.sh
+++ b/test/e2e/vagrant/run-scenario-vm-scenario.sh
@@ -317,7 +317,7 @@ apply_control_plane_workflow() {
   CONTROL_PLANE_WORKFLOW_URL="${SERVER_URL}/workflows/scenarios/control-plane-bootstrap.yaml"
   local server_no_scheme="${SERVER_URL#http://}"
   server_no_scheme="${server_no_scheme#https://}"
-  sudo -n "${DECK_BIN}" apply --file "${CONTROL_PLANE_WORKFLOW_URL}" --phase install \
+  sudo -n "${DECK_BIN}" apply --file "${CONTROL_PLANE_WORKFLOW_URL}" \
     --var "serverURL=${server_no_scheme}" \
     --var "registryHost=${server_no_scheme}" \
     --var "release=${OFFLINE_RELEASE_CONTROL_PLANE}" \
@@ -448,7 +448,7 @@ apply_worker_join_once() {
   local server_no_scheme="$4"
   local log_path="$5"
   clear_install_state
-  sudo -n "${DECK_BIN}" apply --file "${workflow_url}" --phase install \
+  sudo -n "${DECK_BIN}" apply --file "${workflow_url}" \
     --var "serverURL=${server_no_scheme}" \
     --var "registryHost=${server_no_scheme}" \
     --var "release=${release}" \
@@ -504,7 +504,7 @@ apply_node_reset_worker_lifecycle() {
   printf '%s\n' "ok" > "${ART_DIR}/${ROLE}-apply-done.txt"
 
   clear_install_state
-  sudo -n "${DECK_BIN}" apply --file "${node_reset_url}" --phase install \
+  sudo -n "${DECK_BIN}" apply --file "${node_reset_url}" \
     --var "allowDestructive=true" \
     --var "resetReason=${reset_reason}" \
     --var "resetStatePath=${REPORT_DIR}/reset-state.txt" > "${CASE_DIR}/05-reset-${ROLE}.log" 2>&1
@@ -615,9 +615,9 @@ scenario_action_prepare() {
   require_supported_scenario
   source_scenario_vm_helper
   case "${E2E_SCENARIO}" in
-    k8s-control-plane-bootstrap) bootstrap_prepare ;;
-    k8s-worker-join) worker_join_prepare ;;
-    k8s-node-reset) node_reset_prepare ;;
+    control-plane-bootstrap|k8s-control-plane-bootstrap) bootstrap_prepare ;;
+    worker-join|k8s-worker-join) worker_join_prepare ;;
+    node-reset|k8s-node-reset) node_reset_prepare ;;
   esac
 }
 
@@ -625,9 +625,9 @@ scenario_action_apply() {
   require_supported_scenario
   source_scenario_vm_helper
   case "${E2E_SCENARIO}" in
-    k8s-control-plane-bootstrap) bootstrap_apply ;;
-    k8s-worker-join) worker_join_apply ;;
-    k8s-node-reset) node_reset_apply ;;
+    control-plane-bootstrap|k8s-control-plane-bootstrap) bootstrap_apply ;;
+    worker-join|k8s-worker-join) worker_join_apply ;;
+    node-reset|k8s-node-reset) node_reset_apply ;;
   esac
 }
 
@@ -637,8 +637,8 @@ scenario_action_verify() {
   local stage
   stage="$(resolve_verify_stage "${1:-}")"
   case "${E2E_SCENARIO}" in
-    k8s-control-plane-bootstrap) bootstrap_verify "${stage}" ;;
-    k8s-worker-join) worker_join_verify "${stage}" ;;
-    k8s-node-reset) node_reset_verify "${stage}" ;;
+    control-plane-bootstrap|k8s-control-plane-bootstrap) bootstrap_verify "${stage}" ;;
+    worker-join|k8s-worker-join) worker_join_verify "${stage}" ;;
+    node-reset|k8s-node-reset) node_reset_verify "${stage}" ;;
   esac
 }

--- a/test/vagrant/build-deck-binaries.sh
+++ b/test/vagrant/build-deck-binaries.sh
@@ -14,6 +14,10 @@ mkdir -p "${BIN_DIR}"
 desired_stamp=""
 if [[ -d "${ROOT_DIR}/.git" ]]; then
   desired_stamp="git:$(git -C "${ROOT_DIR}" rev-parse HEAD 2>/dev/null || true)"
+  dirty_stamp="$(git -C "${ROOT_DIR}" status --porcelain 2>/dev/null || true)"
+  if [[ -n "${dirty_stamp}" ]]; then
+    desired_stamp+="-dirty:$(printf '%s' "${dirty_stamp}" | sha256sum | cut -d' ' -f1)"
+  fi
 fi
 if [[ -z "${desired_stamp}" ]]; then
   desired_stamp="time:$(date +%Y%m%d%H%M%S)"


### PR DESCRIPTION
## Summary
- simplify workflow authoring by making imports phase-only, converting `workflows/components/` into `steps:` fragments, and removing special install-phase assumptions
- rename the public workflow surface to clearer terms with `Checks`, `File { action: write }`, and `Image { action: verify }`, updating schemas, generated docs, examples, and fixtures
- fix canonical Vagrant e2e regressions in bundle preparation, scenario dispatch, kubeadm init invocation, sysctl application, and dirty-worktree binary rebuilds

## Verification
- `go test ./...`
- `bash test/e2e/vagrant/run-scenario.sh --scenario control-plane-bootstrap --fresh-cache --cleanup --art-dir test/artifacts/runs/control-plane-bootstrap/manual`
- `bash test/e2e/vagrant/run-scenario.sh --scenario worker-join --fresh-cache --cleanup --art-dir test/artifacts/runs/worker-join/manual`
- `bash test/e2e/vagrant/run-scenario.sh --scenario node-reset --fresh-cache --cleanup --art-dir test/artifacts/runs/node-reset/manual`