### PR TITLE
docs: qualify homebrew install command

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -57,7 +57,7 @@ deck apply
 ```bash
 # Homebrew tap
 brew tap Airgap-Castaways/tap
-brew install deck
+brew install Airgap-Castaways/tap/deck
 ```
 
 릴리즈 자산은 `https://github.com/Airgap-Castaways/deck/releases`에서 내려받을 수 있습니다.

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Release downloads are published on the GitHub Releases page. Homebrew installs a
 ```bash
 # Homebrew tap
 brew tap Airgap-Castaways/tap
-brew install deck
+brew install Airgap-Castaways/tap/deck
 ```
 
 Release assets are available at `https://github.com/Airgap-Castaways/deck/releases`.


### PR DESCRIPTION
## Summary
- update the English README to install `deck` from the Airgap Castaways tap using the fully qualified Homebrew formula name
- update the Korean README with the same qualified brew install command to avoid conflicts with other `deck` formulas