### PR TITLE
test: rely on containerd mirror for bootstrap images

### DIFF
--- a/test/workflows/components/bootstrap.yaml
+++ b/test/workflows/components/bootstrap.yaml
@@ -57,11 +57,6 @@ steps:
       name: kubelet
       enabled: true
       state: started
-  - id: bootstrap-load-control-plane-images
-    kind: LoadImage
-    spec:
-      sourceDir: /tmp/deck/server-root/outputs/images/control-plane
-      images: "{{ .vars.controlPlaneImages }}"
   - id: bootstrap-init
     kind: InitKubeadm
     timeout: 20m


### PR DESCRIPTION
## Summary
- remove the control-plane `LoadImage` step from the bootstrap workflow so the test path uses the configured containerd registry mirror
- keep `WriteContainerdRegistryHosts` as the image resolution path for bootstrap image pulls through the deck server registry API
- validate the updated control-plane and worker workflow entrypoints with `deck lint`

## Verification
- `make build`
- `./bin/deck lint --file test/workflows/scenarios/control-plane-bootstrap.yaml`
- `./bin/deck lint --file test/workflows/scenarios/worker-join.yaml`