### PR TITLE
fix: restore generated schema doc examples

### DIFF
--- a/docs/reference/schema/tools/file.md
+++ b/docs/reference/schema/tools/file.md
@@ -41,6 +41,8 @@ kind: DownloadFile
 spec:
   source:
     url: https://mirror.example.com/runc
+    sha256: abc123...
+  outputPath: files/bin/runc
   mode: "0755"
 ```
 
@@ -48,11 +50,11 @@ spec:
 
 | Key | Type | Required | Default | Enum | Description | Example |
 |---|---|---:|---|---|---|---|
-| `spec.fetch` | `object` | no | `` | `` | Optional download transport settings applied to `DownloadFile` fetches. | `{offlineOnly:true}` |
-| `spec.items` | `array<object>` | no | `` | `` |  | `[{...}]` |
-| `spec.mode` | `string` | no | `` | `` | File permissions in octal notation applied after `write`, `copy`, `edit`, or `extractArchive` completes. | `0644` |
-| `spec.outputPath` | `string` | no | `` | `` | Optional prepare-side output path for a downloaded file written into bundle storage. Omit this to use `files/<basename>` based on the source file name, or set it when later steps need a stable custom path. | `files/bin/runc` |
-| `spec.source` | `object` | no | `` | `` | Structured source descriptor for download, copy, or archive extraction. `path`, `bundle`, or `url` may be used depending on the step. | `{url:https://example.invalid/file.tar.gz}` |
+| `spec.fetch` | `object` | no | `` | `` | Optional download transport settings used when the source may need to be fetched. | `{offlineOnly:true}` |
+| `spec.items` | `array<object>` | no | `` | `` | Optional list form for batching multiple download items in one step. | `[{source:{url:https://mirror.example.com/runc},outputPath:files/bin/runc,mode:0755}]` |
+| `spec.mode` | `string` | no | `` | `` | File permissions in octal notation applied after the step completes. | `0644` |
+| `spec.outputPath` | `string` | no | `` | `` | Bundle-relative output path for the downloaded artifact. | `files/bin/runc` |
+| `spec.source` | `object` | no | `` | `` | Structured source descriptor for the download. | `{url:https://mirror.example.com/runc,sha256:abc123...}` |
 
 ### Nested Objects
 
@@ -60,47 +62,47 @@ spec:
 
 | Key | Type | Required | Default | Enum | Description | Example |
 |---|---|---:|---|---|---|---|
-| `spec.fetch.offlineOnly` | `boolean` | no | `` | `` |  | `true` |
-| `spec.fetch.sources` | `array<object>` | no | `` | `` |  | `[{...}]` |
+| `spec.fetch.offlineOnly` | `boolean` | no | `` | `` | Restrict fetches to offline-safe sources only. | `true` |
+| `spec.fetch.sources` | `array<object>` | no | `` | `` | Ordered list of fetch source candidates tried for the transfer. | `[{type:url,url:https://mirror.example.com/runc}]` |
 
 ### `spec.items[].fetch`
 
 | Key | Type | Required | Default | Enum | Description | Example |
 |---|---|---:|---|---|---|---|
-| `spec.items[].fetch.offlineOnly` | `boolean` | no | `` | `` |  | `true` |
-| `spec.items[].fetch.sources` | `array<object>` | no | `` | `` |  | `[{...}]` |
+| `spec.items[].fetch.offlineOnly` | `boolean` | no | `` | `` | Restrict this item to offline-safe sources only. | `true` |
+| `spec.items[].fetch.sources` | `array<object>` | no | `` | `` | Ordered list of source candidates for this item. | `[{type:url,url:https://mirror.example.com/runc}]` |
 
 ### `spec.items[].source`
 
 | Key | Type | Required | Default | Enum | Description | Example |
 |---|---|---:|---|---|---|---|
-| `spec.items[].source.bundle` | `object` | no | `` | `` |  | `{...}` |
-| `spec.items[].source.path` | `string` | no | `` | `` |  | `example` |
-| `spec.items[].source.sha256` | `string` | no | `` | `` |  | `example` |
-| `spec.items[].source.url` | `string` | no | `` | `` |  | `example` |
+| `spec.items[].source.bundle` | `object` | no | `` | `` | Bundle reference source for this item. | `{root:files,path:bin/linux/amd64/runc}` |
+| `spec.items[].source.path` | `string` | no | `` | `` | Local path source for this item. | `/opt/cache/runc` |
+| `spec.items[].source.sha256` | `string` | no | `` | `` | Expected SHA-256 checksum for this item. | `abc123...` |
+| `spec.items[].source.url` | `string` | no | `` | `` | URL to fetch for this item. | `https://mirror.example.com/runc` |
 
 ### `spec.items[].source.bundle`
 
 | Key | Type | Required | Default | Enum | Description | Example |
 |---|---|---:|---|---|---|---|
-| `spec.items[].source.bundle.path` | `string` | yes | `` | `` |  | `example` |
-| `spec.items[].source.bundle.root` | `string` | yes | `` | `files, images, packages` |  | `files` |
+| `spec.items[].source.bundle.path` | `string` | yes | `` | `` | Relative path within the selected bundle root for this item. | `bin/linux/amd64/runc` |
+| `spec.items[].source.bundle.root` | `string` | yes | `` | `files, images, packages` | Bundle root category for this item. | `files` |
 
 ### `spec.source`
 
 | Key | Type | Required | Default | Enum | Description | Example |
 |---|---|---:|---|---|---|---|
-| `spec.source.bundle` | `object` | no | `` | `` | Reference to a file already inside the bundle. Used to stage a bundle-resident file into a new output location. | `{root:files,path:bin/linux/amd64/runc}` |
-| `spec.source.path` | `string` | no | `` | `` | Local filesystem path to use as the source. Applies to prepare downloads and apply-time copy or extraction when the source is already on disk. | `/opt/cache/runc` |
-| `spec.source.sha256` | `string` | no | `` | `` | Expected SHA-256 checksum. Fails the step if the fetched file does not match. | `abc123...` |
+| `spec.source.bundle` | `object` | no | `` | `` | Reference to a file already stored in the prepared bundle. | `{root:files,path:bin/linux/amd64/runc}` |
+| `spec.source.path` | `string` | no | `` | `` | Local filesystem path to use as the source. | `/opt/cache/runc` |
+| `spec.source.sha256` | `string` | no | `` | `` | Expected SHA-256 checksum for the fetched file. | `abc123...` |
 | `spec.source.url` | `string` | no | `` | `` | URL to fetch the file from during prepare. | `https://mirror.example.com/runc` |
 
 ### `spec.source.bundle`
 
 | Key | Type | Required | Default | Enum | Description | Example |
 |---|---|---:|---|---|---|---|
-| `spec.source.bundle.path` | `string` | yes | `` | `` | Relative path within the bundle root to the source file. | `bin/linux/amd64/runc` |
-| `spec.source.bundle.root` | `string` | yes | `` | `files, images, packages` | Bundle root category to read from (`files`, `images`, or `packages`). | `files` |
+| `spec.source.bundle.path` | `string` | yes | `` | `` | Relative path within the selected bundle root. | `bin/linux/amd64/runc` |
+| `spec.source.bundle.root` | `string` | yes | `` | `files, images, packages` | Bundle root category to read from. | `files` |
 
 
 ### Validation Rules
@@ -109,10 +111,9 @@ spec:
 
 ### Notes
 
-- `DownloadFile` writes into prepared bundle storage through `outputPath`, while `WriteFile`, `CopyFile`, `EditFile`, and `ExtractArchive` operate on node paths through `path`.
-- Omit `outputPath` unless you need a specific bundle location; deck defaults to `files/<basename>` for single-file downloads.
-- Use `source.path` when the input is a simple local path and `source.bundle` or `source.url` when the source is structured or external.
-- Use `template` instead of `content` when the body includes variable substitution.
+- `DownloadFile` writes into prepared bundle storage through `outputPath` rather than a node path.
+- Omit `outputPath` unless later steps need a stable custom prepared location.
+- Use `template` instead of `content` only for `WriteFile`; `DownloadFile` always uses explicit sources.
 
 ## `WriteFile`
 
@@ -141,10 +142,10 @@ spec:
 
 | Key | Type | Required | Default | Enum | Description | Example |
 |---|---|---:|---|---|---|---|
-| `spec.content` | `string` | no | `` | `` | Inline file content written verbatim to `path`. Used with `write`. | `[offline-base]<br>baseurl=http://repo.local` |
-| `spec.mode` | `string` | no | `` | `` | File permissions in octal notation applied after `write`, `copy`, `edit`, or `extractArchive` completes. | `0644` |
-| `spec.path` | `string` | yes | `` | `` | Destination path on the node. Used by `write`, `copy`, `edit`, and `extractArchive`. | `/etc/containerd/config.toml` |
-| `spec.template` | `string` | no | `` | `` | Inline multi-line content rendered with the current vars before writing. Use this instead of `content` when the body includes template expressions such as `{{ .vars.* }}`. | `[Service]<br>Environment=ROLE={{ .vars.role }}` |
+| `spec.content` | `string` | no | `` | `` | Inline file content written verbatim to `path`. | `[offline-base]<br>baseurl=http://repo.local` |
+| `spec.mode` | `string` | no | `` | `` | File permissions in octal notation applied after the write completes. | `0644` |
+| `spec.path` | `string` | yes | `` | `` | Destination path on the node. | `/etc/containerd/config.toml` |
+| `spec.template` | `string` | no | `` | `` | Inline multi-line content rendered with current vars before writing. | `[Service]<br>Environment=ROLE={{ .vars.role }}` |
 
 ### Validation Rules
 
@@ -152,10 +153,7 @@ spec:
 
 ### Notes
 
-- `DownloadFile` writes into prepared bundle storage through `outputPath`, while `WriteFile`, `CopyFile`, `EditFile`, and `ExtractArchive` operate on node paths through `path`.
-- Omit `outputPath` unless you need a specific bundle location; deck defaults to `files/<basename>` for single-file downloads.
-- Use `source.path` when the input is a simple local path and `source.bundle` or `source.url` when the source is structured or external.
-- Use `template` instead of `content` when the body includes variable substitution.
+- Use `template` instead of `content` when the body needs variable interpolation.
 
 ## `CopyFile`
 
@@ -183,10 +181,10 @@ spec:
 
 | Key | Type | Required | Default | Enum | Description | Example |
 |---|---|---:|---|---|---|---|
-| `spec.fetch` | `object` | no | `` | `` | Optional download transport settings applied to `DownloadFile` fetches. | `{offlineOnly:true}` |
-| `spec.mode` | `string` | no | `` | `` | File permissions in octal notation applied after `write`, `copy`, `edit`, or `extractArchive` completes. | `0644` |
-| `spec.path` | `string` | yes | `` | `` | Destination path on the node. Used by `write`, `copy`, `edit`, and `extractArchive`. | `/etc/containerd/config.toml` |
-| `spec.source` | `object` | yes | `` | `` | Structured source descriptor for download, copy, or archive extraction. `path`, `bundle`, or `url` may be used depending on the step. | `{url:https://example.invalid/file.tar.gz}` |
+| `spec.fetch` | `object` | no | `` | `` | Optional download transport settings used when the source may need to be fetched. | `{offlineOnly:true}` |
+| `spec.mode` | `string` | no | `` | `` | File permissions in octal notation applied after the copy completes. | `0644` |
+| `spec.path` | `string` | yes | `` | `` | Destination path on the node. | `/home/vagrant/.kube/config` |
+| `spec.source` | `object` | yes | `` | `` | Structured source descriptor for copy or extraction operations. | `{path:/etc/kubernetes/admin.conf}` |
 
 ### Nested Objects
 
@@ -194,32 +192,29 @@ spec:
 
 | Key | Type | Required | Default | Enum | Description | Example |
 |---|---|---:|---|---|---|---|
-| `spec.fetch.offlineOnly` | `boolean` | no | `` | `` |  | `true` |
-| `spec.fetch.sources` | `array<object>` | no | `` | `` |  | `[{...}]` |
+| `spec.fetch.offlineOnly` | `boolean` | no | `` | `` | Restrict fetches to offline-safe sources only. | `true` |
+| `spec.fetch.sources` | `array<object>` | no | `` | `` | Ordered list of fetch source candidates tried for the transfer. | `[{type:url,url:https://mirror.example.com/runc}]` |
 
 ### `spec.source`
 
 | Key | Type | Required | Default | Enum | Description | Example |
 |---|---|---:|---|---|---|---|
-| `spec.source.bundle` | `object` | no | `` | `` | Reference to a file already inside the bundle. Used to stage a bundle-resident file into a new output location. | `{root:files,path:bin/linux/amd64/runc}` |
-| `spec.source.path` | `string` | no | `` | `` | Local filesystem path to use as the source. Applies to prepare downloads and apply-time copy or extraction when the source is already on disk. | `/opt/cache/runc` |
-| `spec.source.sha256` | `string` | no | `` | `` | Expected SHA-256 checksum. Fails the step if the fetched file does not match. | `abc123...` |
+| `spec.source.bundle` | `object` | no | `` | `` | Reference to a file already stored in the prepared bundle. | `{root:files,path:bin/linux/amd64/runc}` |
+| `spec.source.path` | `string` | no | `` | `` | Local filesystem path to use as the source. | `/opt/cache/runc` |
+| `spec.source.sha256` | `string` | no | `` | `` | Expected SHA-256 checksum for the fetched file. | `abc123...` |
 | `spec.source.url` | `string` | no | `` | `` | URL to fetch the file from during prepare. | `https://mirror.example.com/runc` |
 
 ### `spec.source.bundle`
 
 | Key | Type | Required | Default | Enum | Description | Example |
 |---|---|---:|---|---|---|---|
-| `spec.source.bundle.path` | `string` | yes | `` | `` | Relative path within the bundle root to the source file. | `bin/linux/amd64/runc` |
-| `spec.source.bundle.root` | `string` | yes | `` | `files, images, packages` | Bundle root category to read from (`files`, `images`, or `packages`). | `files` |
+| `spec.source.bundle.path` | `string` | yes | `` | `` | Relative path within the selected bundle root. | `bin/linux/amd64/runc` |
+| `spec.source.bundle.root` | `string` | yes | `` | `files, images, packages` | Bundle root category to read from. | `files` |
 
 
 ### Notes
 
-- `DownloadFile` writes into prepared bundle storage through `outputPath`, while `WriteFile`, `CopyFile`, `EditFile`, and `ExtractArchive` operate on node paths through `path`.
-- Omit `outputPath` unless you need a specific bundle location; deck defaults to `files/<basename>` for single-file downloads.
-- Use `source.path` when the input is a simple local path and `source.bundle` or `source.url` when the source is structured or external.
-- Use `template` instead of `content` when the body includes variable substitution.
+- Use `source.path` for simple local paths and `source.bundle` or `source.url` when the source is structured or external.
 
 ## `EditFile`
 
@@ -248,16 +243,13 @@ spec:
 | Key | Type | Required | Default | Enum | Description | Example |
 |---|---|---:|---|---|---|---|
 | `spec.backup` | `boolean` | no | `` | `` | Create a `.bak` copy of the original file before overwriting it. | `true` |
-| `spec.edits` | `array<object>` | yes | `` | `` | Ordered list of match/replace rules applied sequentially to the file. Required for `edit`. | `[{match:SystemdCgroup = false,replaceWith:SystemdCgroup = true}]` |
-| `spec.mode` | `string` | no | `` | `` | File permissions in octal notation applied after `write`, `copy`, `edit`, or `extractArchive` completes. | `0644` |
-| `spec.path` | `string` | yes | `` | `` | Destination path on the node. Used by `write`, `copy`, `edit`, and `extractArchive`. | `/etc/containerd/config.toml` |
+| `spec.edits` | `array<object>` | yes | `` | `` | Ordered list of match/replace rules applied sequentially to the file. | `[{match:SystemdCgroup = false,replaceWith:SystemdCgroup = true}]` |
+| `spec.mode` | `string` | no | `` | `` | File permissions in octal notation applied after the edit completes. | `0644` |
+| `spec.path` | `string` | yes | `` | `` | File path to edit in place. | `/etc/containerd/config.toml` |
 
 ### Notes
 
-- `DownloadFile` writes into prepared bundle storage through `outputPath`, while `WriteFile`, `CopyFile`, `EditFile`, and `ExtractArchive` operate on node paths through `path`.
-- Omit `outputPath` unless you need a specific bundle location; deck defaults to `files/<basename>` for single-file downloads.
-- Use `source.path` when the input is a simple local path and `source.bundle` or `source.url` when the source is structured or external.
-- Use `template` instead of `content` when the body includes variable substitution.
+- Use `EditTOML`, `EditYAML`, or `EditJSON` when structured edits are available and less brittle.
 
 ## `EditTOML`
 
@@ -286,7 +278,7 @@ spec:
 
 | Key | Type | Required | Default | Enum | Description | Example |
 |---|---|---:|---|---|---|---|
-| `spec.createIfMissing` | `boolean` | no | `false` | `` | Create a new empty TOML document when the file does not exist. Defaults to `false`. | `true` |
+| `spec.createIfMissing` | `boolean` | no | `false` | `` | Create a new empty TOML document when the file does not exist. | `true` |
 | `spec.edits` | `array<object>` | yes | `` | `` | Ordered list of structured edits applied sequentially to the TOML document. | `[{op:set,rawPath:plugins."io.containerd.grpc.v1.cri".registry.config_path,value:/etc/containerd/certs.d}]` |
 | `spec.mode` | `string` | no | `` | `` | Optional file permissions to apply after the edit completes. | `0644` |
 | `spec.path` | `string` | yes | `` | `` | TOML file path to edit in place. | `/etc/containerd/config.toml` |
@@ -322,14 +314,13 @@ spec:
 
 | Key | Type | Required | Default | Enum | Description | Example |
 |---|---|---:|---|---|---|---|
-| `spec.createIfMissing` | `boolean` | no | `false` | `` | Create a new empty YAML document when the file does not exist. Defaults to `false`. | `true` |
+| `spec.createIfMissing` | `boolean` | no | `false` | `` | Create a new empty YAML document when the file does not exist. | `true` |
 | `spec.edits` | `array<object>` | yes | `` | `` | Ordered list of structured edits applied sequentially to the YAML document. | `[{op:set,rawPath:spec.template.spec.containers.0.image,value:registry.local/app:v1}]` |
 | `spec.mode` | `string` | no | `` | `` | Optional file permissions to apply after the edit completes. | `0644` |
 | `spec.path` | `string` | yes | `` | `` | YAML file path to edit in place. | `/etc/kubernetes/kubeadm-config.yaml` |
 
 ### Notes
 
-- YAML support targets common map/list documents rather than advanced YAML features.
 - Comment placement, anchors, aliases, merge keys, and style preservation are not guaranteed.
 
 ## `EditJSON`
@@ -359,14 +350,10 @@ spec:
 
 | Key | Type | Required | Default | Enum | Description | Example |
 |---|---|---:|---|---|---|---|
-| `spec.createIfMissing` | `boolean` | no | `false` | `` | Create a new empty JSON object when the file does not exist. Defaults to `false`. | `true` |
+| `spec.createIfMissing` | `boolean` | no | `false` | `` | Create a new empty JSON object when the file does not exist. | `true` |
 | `spec.edits` | `array<object>` | yes | `` | `` | Ordered list of structured edits applied sequentially to the JSON document. | `[{op:set,rawPath:plugins.0.type,value:bridge}]` |
 | `spec.mode` | `string` | no | `` | `` | Optional file permissions to apply after the edit completes. | `0644` |
 | `spec.path` | `string` | yes | `` | `` | JSON file path to edit in place. | `/etc/cni/net.d/10-custom.conflist` |
-
-### Notes
-
-- Use this when JSON configuration should be updated by path rather than rewritten entirely.
 
 ## `ExtractArchive`
 
@@ -394,11 +381,11 @@ spec:
 
 | Key | Type | Required | Default | Enum | Description | Example |
 |---|---|---:|---|---|---|---|
-| `spec.fetch` | `object` | no | `` | `` | Optional download transport settings applied to `DownloadFile` fetches. | `{offlineOnly:true}` |
-| `spec.include` | `array<string>` | no | `` | `` | Optional archive members to extract when using `ExtractArchive`. Extract all members when omitted. | `[bridge,loopback]` |
-| `spec.mode` | `string` | no | `` | `` | File permissions in octal notation applied after `write`, `copy`, `edit`, or `extractArchive` completes. | `0644` |
-| `spec.path` | `string` | yes | `` | `` | Destination path on the node. Used by `write`, `copy`, `edit`, and `extractArchive`. | `/etc/containerd/config.toml` |
-| `spec.source` | `object` | yes | `` | `` | Structured source descriptor for download, copy, or archive extraction. `path`, `bundle`, or `url` may be used depending on the step. | `{url:https://example.invalid/file.tar.gz}` |
+| `spec.fetch` | `object` | no | `` | `` | Optional download transport settings used when the source may need to be fetched. | `{offlineOnly:true}` |
+| `spec.include` | `array<string>` | no | `` | `` | Optional archive members to extract. Extract all members when omitted. | `[bridge,loopback]` |
+| `spec.mode` | `string` | no | `` | `` | File permissions applied to extracted files when supported. | `0755` |
+| `spec.path` | `string` | yes | `` | `` | Destination directory on the node. | `/opt/cni/bin` |
+| `spec.source` | `object` | yes | `` | `` | Structured source descriptor for copy or extraction operations. | `{path:/etc/kubernetes/admin.conf}` |
 
 ### Nested Objects
 
@@ -406,32 +393,29 @@ spec:
 
 | Key | Type | Required | Default | Enum | Description | Example |
 |---|---|---:|---|---|---|---|
-| `spec.fetch.offlineOnly` | `boolean` | no | `` | `` |  | `true` |
-| `spec.fetch.sources` | `array<object>` | no | `` | `` |  | `[{...}]` |
+| `spec.fetch.offlineOnly` | `boolean` | no | `` | `` | Restrict fetches to offline-safe sources only. | `true` |
+| `spec.fetch.sources` | `array<object>` | no | `` | `` | Ordered list of fetch source candidates tried for the transfer. | `[{type:url,url:https://mirror.example.com/runc}]` |
 
 ### `spec.source`
 
 | Key | Type | Required | Default | Enum | Description | Example |
 |---|---|---:|---|---|---|---|
-| `spec.source.bundle` | `object` | no | `` | `` | Reference to a file already inside the bundle. Used to stage a bundle-resident file into a new output location. | `{root:files,path:bin/linux/amd64/runc}` |
-| `spec.source.path` | `string` | no | `` | `` | Local filesystem path to use as the source. Applies to prepare downloads and apply-time copy or extraction when the source is already on disk. | `/opt/cache/runc` |
-| `spec.source.sha256` | `string` | no | `` | `` | Expected SHA-256 checksum. Fails the step if the fetched file does not match. | `abc123...` |
+| `spec.source.bundle` | `object` | no | `` | `` | Reference to a file already stored in the prepared bundle. | `{root:files,path:bin/linux/amd64/runc}` |
+| `spec.source.path` | `string` | no | `` | `` | Local filesystem path to use as the source. | `/opt/cache/runc` |
+| `spec.source.sha256` | `string` | no | `` | `` | Expected SHA-256 checksum for the fetched file. | `abc123...` |
 | `spec.source.url` | `string` | no | `` | `` | URL to fetch the file from during prepare. | `https://mirror.example.com/runc` |
 
 ### `spec.source.bundle`
 
 | Key | Type | Required | Default | Enum | Description | Example |
 |---|---|---:|---|---|---|---|
-| `spec.source.bundle.path` | `string` | yes | `` | `` | Relative path within the bundle root to the source file. | `bin/linux/amd64/runc` |
-| `spec.source.bundle.root` | `string` | yes | `` | `files, images, packages` | Bundle root category to read from (`files`, `images`, or `packages`). | `files` |
+| `spec.source.bundle.path` | `string` | yes | `` | `` | Relative path within the selected bundle root. | `bin/linux/amd64/runc` |
+| `spec.source.bundle.root` | `string` | yes | `` | `files, images, packages` | Bundle root category to read from. | `files` |
 
 
 ### Notes
 
-- `DownloadFile` writes into prepared bundle storage through `outputPath`, while `WriteFile`, `CopyFile`, `EditFile`, and `ExtractArchive` operate on node paths through `path`.
-- Omit `outputPath` unless you need a specific bundle location; deck defaults to `files/<basename>` for single-file downloads.
-- Use `source.path` when the input is a simple local path and `source.bundle` or `source.url` when the source is structured or external.
-- Use `template` instead of `content` when the body includes variable substitution.
+- Extract all archive members when `include` is omitted.
 
 ## Related
 

--- a/docs/reference/schema/tools/image.md
+++ b/docs/reference/schema/tools/image.md
@@ -48,10 +48,10 @@ spec:
 
 | Key | Type | Required | Default | Enum | Description | Example |
 |---|---|---:|---|---|---|---|
-| `spec.auth` | `array<object>` | no | `` | `` | Optional registry authentication entries for `download`. Match each private registry with credentials while leaving public registries to the default keychain. | `[{registry:registry.example.com,basic:{username:robot,password:${REGISTRY_PASSWORD}}}]` |
-| `spec.backend` | `object` | no | `` | `` | Backend-specific download settings such as image transfer engine configuration. Applies to `DownloadImage` only. | `{engine:go-containerregistry}` |
-| `spec.images` | `array<string>` | yes | `` | `` | Fully qualified image references to download, load, or verify. | `[registry.k8s.io/pause:3.9]` |
-| `spec.outputDir` | `string` | no | `` | `` | Optional bundle-relative directory where per-image tar archives are written during `DownloadImage`. Omit this to write under the default `images` root, or set it when you want a dedicated image subdirectory such as `images/control-plane`. | `images/control-plane` |
+| `spec.auth` | `array<object>` | no | `` | `` | Optional registry authentication entries used during download. | `[{registry:registry.example.com,basic:{username:robot,password:${REGISTRY_PASSWORD}}}]` |
+| `spec.backend` | `object` | no | `` | `` | Backend-specific download settings. Applies to `DownloadImage` only. | `{engine:go-containerregistry}` |
+| `spec.images` | `array<string>` | yes | `` | `` | Fully qualified image references to download. | `[registry.k8s.io/pause:3.9]` |
+| `spec.outputDir` | `string` | no | `` | `` | Optional bundle-relative directory where per-image tar archives are written. | `images/control-plane` |
 
 ### Nested Objects
 
@@ -66,15 +66,14 @@ spec:
 
 | Key | Type | Required | Default | Enum | Description | Example |
 |---|---|---:|---|---|---|---|
-| `spec.backend.engine` | `string` | no | `` | `go-containerregistry` | Image download engine. Currently only `go-containerregistry` is supported. | `go-containerregistry` |
+| `spec.backend.engine` | `string` | no | `` | `go-containerregistry` | Image download engine. | `go-containerregistry` |
 
 
 ### Notes
 
-- Use `DownloadImage` during prepare, `LoadImage` during apply when archives must be imported, and `VerifyImage` when the runtime should already contain the required images.
+- Use `DownloadImage` during prepare to collect required images for offline use.
 - Omit `outputDir` unless you need a custom bundle subdirectory; deck writes to `images/` by default.
-- Use explicit image tags or digests to keep prepared bundles reproducible.
-- `spec.auth` is optional and only applies to `DownloadImage`; when omitted, deck falls back to the environment's default registry keychain.
+- `spec.auth` is optional and only applies to `DownloadImage`.
 
 ## `LoadImage`
 
@@ -101,17 +100,14 @@ spec:
 
 | Key | Type | Required | Default | Enum | Description | Example |
 |---|---|---:|---|---|---|---|
-| `spec.command` | `array<string>` | no | `` | `` | Optional runtime command override. For `VerifyImage`, this is the image-listing command. For `LoadImage`, this command may include `{archive}` placeholders that deck substitutes per image archive. | `[ctr,-n,k8s.io,images,list,-q]` |
-| `spec.images` | `array<string>` | yes | `` | `` | Fully qualified image references to download, load, or verify. | `[registry.k8s.io/pause:3.9]` |
-| `spec.runtime` | `string` | no | `` | `auto, ctr, docker, podman` | Runtime loader used by `LoadImage`. `auto` picks the default runtime integration; explicit values include `ctr`, `docker`, and `podman`. | `ctr` |
-| `spec.sourceDir` | `string` | no | `` | `` | Directory containing prepared image archives to load into the runtime. Defaults to `images` when omitted. | `images/control-plane` |
+| `spec.command` | `array<string>` | no | `` | `` | Optional runtime command override. This command may include `{archive}` placeholders that deck substitutes per image archive. | `[ctr,-n,k8s.io,images,import,{archive}]` |
+| `spec.images` | `array<string>` | yes | `` | `` | Fully qualified image references to load. | `[registry.k8s.io/pause:3.9]` |
+| `spec.runtime` | `string` | no | `` | `auto, ctr, docker, podman` | Runtime loader used by `LoadImage`. | `ctr` |
+| `spec.sourceDir` | `string` | no | `` | `` | Directory containing prepared image archives to load into the runtime. | `images/control-plane` |
 
 ### Notes
 
-- Use `DownloadImage` during prepare, `LoadImage` during apply when archives must be imported, and `VerifyImage` when the runtime should already contain the required images.
-- Omit `outputDir` unless you need a custom bundle subdirectory; deck writes to `images/` by default.
-- Use explicit image tags or digests to keep prepared bundles reproducible.
-- `spec.auth` is optional and only applies to `DownloadImage`; when omitted, deck falls back to the environment's default registry keychain.
+- Use `LoadImage` during apply when archives must be imported into the runtime.
 
 ## `VerifyImage`
 
@@ -137,15 +133,12 @@ spec:
 
 | Key | Type | Required | Default | Enum | Description | Example |
 |---|---|---:|---|---|---|---|
-| `spec.command` | `array<string>` | no | `` | `` | Optional runtime command override. For `VerifyImage`, this is the image-listing command. For `LoadImage`, this command may include `{archive}` placeholders that deck substitutes per image archive. | `[ctr,-n,k8s.io,images,list,-q]` |
-| `spec.images` | `array<string>` | yes | `` | `` | Fully qualified image references to download, load, or verify. | `[registry.k8s.io/pause:3.9]` |
+| `spec.command` | `array<string>` | no | `` | `` | Optional image-listing command override. | `[ctr,-n,k8s.io,images,list,-q]` |
+| `spec.images` | `array<string>` | yes | `` | `` | Fully qualified image references that must already exist on the node. | `[registry.k8s.io/pause:3.9]` |
 
 ### Notes
 
-- Use `DownloadImage` during prepare, `LoadImage` during apply when archives must be imported, and `VerifyImage` when the runtime should already contain the required images.
-- Omit `outputDir` unless you need a custom bundle subdirectory; deck writes to `images/` by default.
-- Use explicit image tags or digests to keep prepared bundles reproducible.
-- `spec.auth` is optional and only applies to `DownloadImage`; when omitted, deck falls back to the environment's default registry keychain.
+- Use `VerifyImage` when the runtime should already contain the required images and only verification is needed.
 
 ## Related
 

--- a/docs/reference/schema/tools/package.md
+++ b/docs/reference/schema/tools/package.md
@@ -52,11 +52,11 @@ spec:
 
 | Key | Type | Required | Default | Enum | Description | Example |
 |---|---|---:|---|---|---|---|
-| `spec.backend` | `object` | no | `` | `` | Container-based download backend for `DownloadPackage`. When provided, `backend.mode=container` and `backend.image` are required. | `{mode:container,runtime:docker,image:rockylinux:9}` |
-| `spec.distro` | `object` | no | `` | `` | Target distribution hint used by `DownloadPackage` to select the correct package manager and resolver backend. | `{family:rhel,release:rocky9}` |
-| `spec.outputDir` | `string` | no | `` | `` | Optional bundle-relative directory used by `DownloadPackage` for downloaded package artifacts. Omit this to use `packages/` by default. When `repo.type` is set, deck instead writes to a repo layout under `packages/deb/<release>` or `packages/rpm/<release>`. Set `outputDir` only when apply workflows need a stable custom path outside those defaults. | `packages/kubernetes` |
-| `spec.packages` | `array<string>` | yes | `` | `` | Package names to download or install. Use the same list in both `download` and `install` steps to keep offline parity. | `[kubelet,kubeadm,kubectl]` |
-| `spec.repo` | `object` | no | `` | `` | Package repository settings applied before `DownloadPackage`, including repo layout generation and RPM module streams. | `{type:rpm,modules:[...]}` |
+| `spec.backend` | `object` | no | `` | `` | Container-based download backend configuration. | `{mode:container,runtime:docker,image:rockylinux:9}` |
+| `spec.distro` | `object` | no | `` | `` | Target distribution hint used to select resolver behavior. | `{family:rhel,release:rocky9}` |
+| `spec.outputDir` | `string` | no | `` | `` | Optional bundle-relative output directory for downloaded package artifacts. | `packages/kubernetes` |
+| `spec.packages` | `array<string>` | yes | `` | `` | Package names to download. | `[kubelet,kubeadm,kubectl]` |
+| `spec.repo` | `object` | no | `` | `` | Repository settings applied before download. | `{type:rpm,modules:[{name:container-tools,stream:4.0}]}` |
 
 ### Nested Objects
 
@@ -64,37 +64,32 @@ spec:
 
 | Key | Type | Required | Default | Enum | Description | Example |
 |---|---|---:|---|---|---|---|
-| `spec.backend.image` | `string` | yes | `` | `` | Container image used for package resolution in `download` mode. Required when `backend` is set. | `rockylinux:9` |
-| `spec.backend.mode` | `string` | yes | `` | `container` | Download backend mode. Currently only `container` is supported. | `container` |
-| `spec.backend.runtime` | `string` | no | `` | `auto, docker, podman` | Preferred container runtime for the download helper container. Supported values are `docker`, `podman`, or `auto`. | `docker` |
+| `spec.backend.image` | `string` | yes | `` | `` | Container image used for package resolution in download mode. | `rockylinux:9` |
+| `spec.backend.mode` | `string` | yes | `` | `container` | Download backend mode. | `container` |
+| `spec.backend.runtime` | `string` | no | `` | `auto, docker, podman` | Preferred container runtime for the download helper container. | `docker` |
 
 ### `spec.distro`
 
 | Key | Type | Required | Default | Enum | Description | Example |
 |---|---|---:|---|---|---|---|
-| `spec.distro.family` | `string` | no | `` | `` |  | `example` |
-| `spec.distro.release` | `string` | no | `` | `` |  | `example` |
+| `spec.distro.family` | `string` | no | `` | `` | Distribution family used to resolve package tooling. | `rhel` |
+| `spec.distro.release` | `string` | no | `` | `` | Distribution release used for resolver and repo layout selection. | `rocky9` |
 
 ### `spec.repo`
 
 | Key | Type | Required | Default | Enum | Description | Example |
 |---|---|---:|---|---|---|---|
-| `spec.repo.generate` | `boolean` | no | `` | `` | When `true`, generate repository metadata after the package payload is collected. Used with `repo.type` in download repo mode. | `true` |
-| `spec.repo.modules` | `array<object>` | no | `` | `` | RPM module streams to enable before resolving downloads on RHEL-family systems. | `[{name:container-tools,stream:4.0}]` |
-| `spec.repo.pkgsDir` | `string` | no | `` | `` | Subdirectory under the generated repo root where package payloads are written. Defaults to `pkgs`. | `pkgs` |
-| `spec.repo.type` | `string` | no | `` | `deb-flat, rpm` | Repository output type for `DownloadPackage` repo mode. Supported values are `deb-flat` and `rpm`. | `rpm` |
+| `spec.repo.generate` | `boolean` | no | `` | `` | Generate repository metadata after collecting packages. | `true` |
+| `spec.repo.modules` | `array<object>` | no | `` | `` | RPM module streams to enable before resolving downloads. | `[{name:container-tools,stream:4.0}]` |
+| `spec.repo.pkgsDir` | `string` | no | `` | `` | Subdirectory under the generated repo root where packages are written. | `pkgs` |
+| `spec.repo.type` | `string` | no | `` | `deb-flat, rpm` | Repository output type for download repo mode. | `rpm` |
 
 
 ### Notes
 
-- Use `DownloadPackage` and `InstallPackage` with `ConfigureRepository` and `RefreshRepository` for a complete typed package-management flow.
-- Omit `outputDir` unless you need a custom package location; deck uses `packages/` by default, or `packages/deb/<release>` and `packages/rpm/<release>` when `repo.type` is set.
-- Keeping the same package list across `download` and `install` helps maintain offline parity.
-- Use `restrictToRepos` on the `InstallPackage` step to prevent the node's default online repos from being consulted during an offline apply.
-- When `repo` is set for `DownloadPackage`, deck expects `repo.type` and `distro.release` so it can build a `deb-flat` or `rpm` repository layout.
-- Container-backed `DownloadPackage` exports completed artifacts into a host-owned cache and does not bind-mount deb/rpm package-manager cache directories.
-- Older releases may have left root-owned content under legacy package cache paths; clean those directories manually after upgrading if needed.
-- Without a container download backend, `download` currently writes placeholder package markers instead of resolving real packages.
+- Use `DownloadPackage` during prepare to stage offline package-manager content.
+- Omit `outputDir` unless you need a custom package location.
+- Container-backed `DownloadPackage` exports completed artifacts into a host-owned cache and does not bind-mount package-manager cache directories.
 
 ## `InstallPackage`
 
@@ -121,10 +116,10 @@ spec:
 
 | Key | Type | Required | Default | Enum | Description | Example |
 |---|---|---:|---|---|---|---|
-| `spec.excludeRepos` | `array<string>` | no | `` | `` | For `InstallPackage`, repository selectors to exclude from package resolution. For deb-family systems, selectors match repo file paths; for rpm-family systems, they match repo IDs. | `[updates]` |
-| `spec.packages` | `array<string>` | yes | `` | `` | Package names to download or install. Use the same list in both `download` and `install` steps to keep offline parity. | `[kubelet,kubeadm,kubectl]` |
-| `spec.restrictToRepos` | `array<string>` | no | `` | `` | For `InstallPackage`, limit package manager visibility to these repository selectors. For deb-family systems, use repo file paths or globs; for rpm-family systems, use repo IDs. | `[offline-kubernetes]` |
-| `spec.source` | `object` | no | `` | `` | Local repository source for `InstallPackage`. Points to a pre-prepared on-disk package repo instead of relying on configured package manager sources. | `{type:local-repo,path:/opt/deck/repos/kubernetes}` |
+| `spec.excludeRepos` | `array<string>` | no | `` | `` | Repository selectors to exclude from package resolution. | `[updates]` |
+| `spec.packages` | `array<string>` | yes | `` | `` | Package names to install. | `[kubelet,kubeadm,kubectl]` |
+| `spec.restrictToRepos` | `array<string>` | no | `` | `` | Limit package manager visibility to these repository selectors. | `[offline-kubernetes]` |
+| `spec.source` | `object` | no | `` | `` | Local repository source used for the installation. | `{type:local-repo,path:/opt/deck/repos/kubernetes}` |
 
 ### Nested Objects
 
@@ -138,14 +133,7 @@ spec:
 
 ### Notes
 
-- Use `DownloadPackage` and `InstallPackage` with `ConfigureRepository` and `RefreshRepository` for a complete typed package-management flow.
-- Omit `outputDir` unless you need a custom package location; deck uses `packages/` by default, or `packages/deb/<release>` and `packages/rpm/<release>` when `repo.type` is set.
-- Keeping the same package list across `download` and `install` helps maintain offline parity.
-- Use `restrictToRepos` on the `InstallPackage` step to prevent the node's default online repos from being consulted during an offline apply.
-- When `repo` is set for `DownloadPackage`, deck expects `repo.type` and `distro.release` so it can build a `deb-flat` or `rpm` repository layout.
-- Container-backed `DownloadPackage` exports completed artifacts into a host-owned cache and does not bind-mount deb/rpm package-manager cache directories.
-- Older releases may have left root-owned content under legacy package cache paths; clean those directories manually after upgrading if needed.
-- Without a container download backend, `download` currently writes placeholder package markers instead of resolving real packages.
+- Use `InstallPackage` during apply to install packages from configured local or mirrored repositories.
 
 ## Related
 

--- a/docs/reference/schema/tools/repository.md
+++ b/docs/reference/schema/tools/repository.md
@@ -44,19 +44,19 @@ spec:
 
 | Key | Type | Required | Default | Enum | Description | Example |
 |---|---|---:|---|---|---|---|
-| `spec.backupPaths` | `array<string>` | no | `` | `` | Paths to back up before modifying. Backed-up files are saved with a `.bak` suffix. | `[/etc/apt/sources.list]` |
+| `spec.backupPaths` | `array<string>` | no | `` | `` | Paths to back up before modifying. | `[/etc/apt/sources.list]` |
 | `spec.cleanupPaths` | `array<string>` | no | `` | `` | Paths to remove before writing the new repository definition. | `[/etc/apt/sources.list.d/ubuntu.list]` |
-| `spec.disableExisting` | `boolean` | no | `` | `` | Disable all existing repository definitions before writing the new one. Prevents conflicts from online repos during offline installs. | `true` |
-| `spec.format` | `string` | no | `` | `auto, deb, rpm` | Repository file format to write. `auto` detects from the host family, `deb` produces a sources.list style entry, and `rpm` produces a `.repo` file. | `deb` |
+| `spec.disableExisting` | `boolean` | no | `` | `` | Disable all existing repository definitions before writing the new one. | `true` |
+| `spec.format` | `string` | no | `` | `auto, deb, rpm` | Repository file format to write. | `deb` |
 | `spec.mode` | `string` | no | `` | `` | File permissions applied to the generated repository file in octal notation. | `0644` |
-| `spec.path` | `string` | no | `` | `` | Explicit output path for the generated repository file. Defaults to `/etc/apt/sources.list.d/deck-offline.list` for deb-family systems or `/etc/yum.repos.d/deck-offline.repo` for rpm-family systems when omitted. | `/etc/apt/sources.list.d/offline.list` |
+| `spec.path` | `string` | no | `` | `` | Explicit output path for the generated repository file. | `/etc/apt/sources.list.d/offline.list` |
 | `spec.replaceExisting` | `boolean` | no | `` | `` | Replace an existing repository file at the target path before writing the new definition. | `true` |
-| `spec.repositories` | `array<object>` | yes | `` | `` | Repository entries to write. deb entries use fields like `baseurl`, `suite`, `component`, and optional `trusted`; rpm entries use fields like `id`, `name`, `baseurl`, and optional `extra` for additional repo keys. | `[{baseurl:http://repo.local/debian,trusted:true}]` |
+| `spec.repositories` | `array<object>` | yes | `` | `` | Repository entries to write. | `[{baseurl:http://repo.local/debian,trusted:true}]` |
 
 ### Notes
 
-- `ConfigureRepository` only writes repository definition files. Use `RefreshRepository` when the package manager needs an explicit metadata refresh.
-- Keep repository definitions mirror-specific rather than mutating the host's default online sources.
+- `ConfigureRepository` only writes repository definition files.
+- Use `RefreshRepository` when the package manager needs an explicit metadata refresh.
 
 ## `RefreshRepository`
 
@@ -84,16 +84,20 @@ spec:
 
 | Key | Type | Required | Default | Enum | Description | Example |
 |---|---|---:|---|---|---|---|
-| `spec.clean` | `boolean` | no | `` | `` | Run a cache clean before updating metadata (`apt clean` / `dnf clean all`). | `true` |
-| `spec.excludeRepos` | `array<string>` | no | `` | `` | Repository selectors to skip during metadata update. For apt, selectors match repo file paths; for dnf, they match repo IDs. | `[updates]` |
-| `spec.manager` | `string` | no | `` | `auto, apt, dnf` | Package manager to use. `auto` detects from the host OS. Supports `apt` and `dnf`. | `apt` |
-| `spec.restrictToRepos` | `array<string>` | no | `` | `` | Limit the metadata update to these repository selectors. For apt, use repo file paths or globs; for dnf, use repo IDs. Prevents fetching from online repos during an offline install. | `[/etc/apt/sources.list.d/offline.list]` |
-| `spec.update` | `boolean` | no | `` | `` | Fetch fresh package metadata from the configured repositories (`apt update` / `dnf makecache`). | `true` |
+| `spec.clean` | `boolean` | no | `` | `` | Run a cache clean before updating metadata. | `true` |
+| `spec.excludeRepos` | `array<string>` | no | `` | `` | Repository selectors to skip during metadata update. | `[updates]` |
+| `spec.manager` | `string` | no | `` | `auto, apt, dnf` | Package manager to use for repository metadata refresh. | `apt` |
+| `spec.restrictToRepos` | `array<string>` | no | `` | `` | Limit the metadata update to these repository selectors. | `[/etc/apt/sources.list.d/offline.list]` |
+| `spec.update` | `boolean` | no | `` | `` | Fetch fresh package metadata from the configured repositories. | `true` |
 
 ### Validation Rules
 
 - At least one of `spec.clean` or `spec.update` must be set.
 - At least one of the listed branches must match.
+
+### Notes
+
+- Use `RefreshRepository` after writing repo definitions and before package installs that depend on fresh metadata.
 
 ## Related
 

--- a/docs/reference/schema/tools/wait.md
+++ b/docs/reference/schema/tools/wait.md
@@ -45,9 +45,9 @@ spec:
 
 | Key | Type | Required | Default | Enum | Description | Example |
 |---|---|---:|---|---|---|---|
-| `spec.initialDelay` | `string` | no | `` | `` | Duration to wait before the first poll attempt. Useful when a service needs a moment before it becomes checkable. | `1s` |
-| `spec.interval` | `string` | no | `` | `` | Duration between poll attempts. Accepts Go duration strings. | `2s` |
-| `spec.name` | `string` | yes | `` | `` | Service name to check. Required for `WaitForService`. | `containerd` |
+| `spec.initialDelay` | `string` | no | `` | `` | Duration to wait before the first poll attempt. | `1s` |
+| `spec.interval` | `string` | no | `` | `` | Duration between poll attempts. | `2s` |
+| `spec.name` | `string` | yes | `` | `` | Service name to check. | `containerd` |
 | `spec.pollInterval` | `string` | no | `` | `` | Deprecated alias for `interval`. Use `interval` instead. | `2s` |
 | `spec.timeout` | `string` | no | `` | `` | Maximum total duration to wait before failing the step. | `5m` |
 
@@ -70,21 +70,20 @@ Use this when a dependent step should wait for a local command-based condition t
 ### Example
 
 ```yaml
-apiVersion: deck/v1alpha1
-id: example-waitforcommand
 kind: WaitForCommand
 spec:
-    command:
-        - example
+  command: [test, -f, /etc/kubernetes/admin.conf]
+  interval: 2s
+  timeout: 2m
 ```
 
 ### Spec Fields
 
 | Key | Type | Required | Default | Enum | Description | Example |
 |---|---|---:|---|---|---|---|
-| `spec.command` | `array<string>` | yes | `` | `` | Command vector to run on each poll attempt. Required for `WaitForCommand`. The step succeeds when the command exits 0. | `[test,-f,/etc/kubernetes/admin.conf]` |
-| `spec.initialDelay` | `string` | no | `` | `` | Duration to wait before the first poll attempt. Useful when a service needs a moment before it becomes checkable. | `1s` |
-| `spec.interval` | `string` | no | `` | `` | Duration between poll attempts. Accepts Go duration strings. | `2s` |
+| `spec.command` | `array<string>` | yes | `` | `` | Command vector to run on each poll attempt. The step succeeds when the command exits 0. | `[test,-f,/etc/kubernetes/admin.conf]` |
+| `spec.initialDelay` | `string` | no | `` | `` | Duration to wait before the first poll attempt. | `1s` |
+| `spec.interval` | `string` | no | `` | `` | Duration between poll attempts. | `2s` |
 | `spec.pollInterval` | `string` | no | `` | `` | Deprecated alias for `interval`. Use `interval` instead. | `2s` |
 | `spec.timeout` | `string` | no | `` | `` | Maximum total duration to wait before failing the step. | `5m` |
 
@@ -120,19 +119,19 @@ spec:
 
 | Key | Type | Required | Default | Enum | Description | Example |
 |---|---|---:|---|---|---|---|
-| `spec.initialDelay` | `string` | no | `` | `` | Duration to wait before the first poll attempt. Useful when a service needs a moment before it becomes checkable. | `1s` |
-| `spec.interval` | `string` | no | `` | `` | Duration between poll attempts. Accepts Go duration strings. | `2s` |
-| `spec.nonEmpty` | `boolean` | no | `` | `` | For `WaitForFile`, also assert that the file has non-zero size. Useful when waiting for a file that is written progressively. | `true` |
-| `spec.path` | `string` | yes | `` | `` | Filesystem path to check. Required for `WaitForFile` and `WaitForMissingFile`. | `/etc/kubernetes/admin.conf` |
+| `spec.initialDelay` | `string` | no | `` | `` | Duration to wait before the first poll attempt. | `1s` |
+| `spec.interval` | `string` | no | `` | `` | Duration between poll attempts. | `2s` |
+| `spec.nonEmpty` | `boolean` | no | `` | `` | Require the matched file to have non-zero size. | `true` |
+| `spec.path` | `string` | yes | `` | `` | Filesystem path to check. | `/etc/kubernetes/admin.conf` |
 | `spec.pollInterval` | `string` | no | `` | `` | Deprecated alias for `interval`. Use `interval` instead. | `2s` |
 | `spec.timeout` | `string` | no | `` | `` | Maximum total duration to wait before failing the step. | `5m` |
-| `spec.type` | `string` | no | `` | `any, file, dir` | Restricts the path check to a specific filesystem entry type. `file` matches regular files only, `dir` matches directories, `any` matches either. Defaults to `any`. | `file` |
+| `spec.type` | `string` | no | `` | `any, file, dir` | Filesystem entry type restriction for path checks. | `file` |
 
 ### Notes
 
 - `Wait` bridges convergence gaps between steps. It should not replace the configuration action itself.
 - Keep waits specific so failures identify exactly which dependency did not become ready within the timeout.
-- Use `initialDelay` when a service emits a transient non-active state immediately after being started.
+- Use `nonEmpty` when waiting on a file that is written progressively.
 
 ## `WaitForMissingFile`
 
@@ -158,14 +157,14 @@ spec:
 
 | Key | Type | Required | Default | Enum | Description | Example |
 |---|---|---:|---|---|---|---|
-| `spec.glob` | `string` | no | `` | `` | For `WaitForMissingFile`, require the glob to resolve to zero matches before the step succeeds. | `/etc/kubernetes/manifests/*.yaml` |
-| `spec.initialDelay` | `string` | no | `` | `` | Duration to wait before the first poll attempt. Useful when a service needs a moment before it becomes checkable. | `1s` |
-| `spec.interval` | `string` | no | `` | `` | Duration between poll attempts. Accepts Go duration strings. | `2s` |
-| `spec.path` | `string` | no | `` | `` | Filesystem path to check. Required for `WaitForFile` and `WaitForMissingFile`. | `/etc/kubernetes/admin.conf` |
-| `spec.paths` | `array<string>` | no | `` | `` | For `WaitForMissingFile`, require every listed path to be absent before the step succeeds. | `[/etc/kubernetes/manifests/a.yaml,/etc/kubernetes/manifests/b.yaml]` |
+| `spec.glob` | `string` | no | `` | `` | Glob pattern that must resolve to zero matches before the step succeeds. | `/etc/kubernetes/manifests/*.yaml` |
+| `spec.initialDelay` | `string` | no | `` | `` | Duration to wait before the first poll attempt. | `1s` |
+| `spec.interval` | `string` | no | `` | `` | Duration between poll attempts. | `2s` |
+| `spec.path` | `string` | no | `` | `` | Filesystem path to check. | `/etc/kubernetes/admin.conf` |
+| `spec.paths` | `array<string>` | no | `` | `` | List of paths that must all be absent before the step succeeds. | `[/etc/kubernetes/manifests/a.yaml,/etc/kubernetes/manifests/b.yaml]` |
 | `spec.pollInterval` | `string` | no | `` | `` | Deprecated alias for `interval`. Use `interval` instead. | `2s` |
 | `spec.timeout` | `string` | no | `` | `` | Maximum total duration to wait before failing the step. | `5m` |
-| `spec.type` | `string` | no | `` | `any, file, dir` | Restricts the path check to a specific filesystem entry type. `file` matches regular files only, `dir` matches directories, `any` matches either. Defaults to `any`. | `file` |
+| `spec.type` | `string` | no | `` | `any, file, dir` | Filesystem entry type restriction for path checks. | `file` |
 
 ### Validation Rules
 
@@ -173,9 +172,7 @@ spec:
 
 ### Notes
 
-- `Wait` bridges convergence gaps between steps. It should not replace the configuration action itself.
-- Keep waits specific so failures identify exactly which dependency did not become ready within the timeout.
-- Use `initialDelay` when a service emits a transient non-active state immediately after being started.
+- Use `paths` or `glob` when multiple files must disappear before the step can succeed.
 
 ## `WaitForTCPPort`
 
@@ -201,18 +198,17 @@ spec:
 
 | Key | Type | Required | Default | Enum | Description | Example |
 |---|---|---:|---|---|---|---|
-| `spec.address` | `string` | no | `` | `` | Host or IP address for TCP port checks. Defaults to `127.0.0.1` when omitted. | `127.0.0.1` |
-| `spec.initialDelay` | `string` | no | `` | `` | Duration to wait before the first poll attempt. Useful when a service needs a moment before it becomes checkable. | `1s` |
-| `spec.interval` | `string` | no | `` | `` | Duration between poll attempts. Accepts Go duration strings. | `2s` |
+| `spec.address` | `string` | no | `` | `` | Host or IP address for TCP port checks. | `127.0.0.1` |
+| `spec.initialDelay` | `string` | no | `` | `` | Duration to wait before the first poll attempt. | `1s` |
+| `spec.interval` | `string` | no | `` | `` | Duration between poll attempts. | `2s` |
 | `spec.pollInterval` | `string` | no | `` | `` | Deprecated alias for `interval`. Use `interval` instead. | `2s` |
-| `spec.port` | `string` | yes | `` | `` | TCP port number to check. Required for `WaitForTCPPort` and `WaitForMissingTCPPort`. | `6443` |
+| `spec.port` | `string` | yes | `` | `` | TCP port number to check. | `6443` |
 | `spec.timeout` | `string` | no | `` | `` | Maximum total duration to wait before failing the step. | `5m` |
 
 ### Notes
 
 - `Wait` bridges convergence gaps between steps. It should not replace the configuration action itself.
 - Keep waits specific so failures identify exactly which dependency did not become ready within the timeout.
-- Use `initialDelay` when a service emits a transient non-active state immediately after being started.
 
 ## `WaitForMissingTCPPort`
 
@@ -238,18 +234,16 @@ spec:
 
 | Key | Type | Required | Default | Enum | Description | Example |
 |---|---|---:|---|---|---|---|
-| `spec.address` | `string` | no | `` | `` | Host or IP address for TCP port checks. Defaults to `127.0.0.1` when omitted. | `127.0.0.1` |
-| `spec.initialDelay` | `string` | no | `` | `` | Duration to wait before the first poll attempt. Useful when a service needs a moment before it becomes checkable. | `1s` |
-| `spec.interval` | `string` | no | `` | `` | Duration between poll attempts. Accepts Go duration strings. | `2s` |
+| `spec.address` | `string` | no | `` | `` | Host or IP address for TCP port checks. | `127.0.0.1` |
+| `spec.initialDelay` | `string` | no | `` | `` | Duration to wait before the first poll attempt. | `1s` |
+| `spec.interval` | `string` | no | `` | `` | Duration between poll attempts. | `2s` |
 | `spec.pollInterval` | `string` | no | `` | `` | Deprecated alias for `interval`. Use `interval` instead. | `2s` |
-| `spec.port` | `string` | yes | `` | `` | TCP port number to check. Required for `WaitForTCPPort` and `WaitForMissingTCPPort`. | `6443` |
+| `spec.port` | `string` | yes | `` | `` | TCP port number to check. | `6443` |
 | `spec.timeout` | `string` | no | `` | `` | Maximum total duration to wait before failing the step. | `5m` |
 
 ### Notes
 
-- `Wait` bridges convergence gaps between steps. It should not replace the configuration action itself.
-- Keep waits specific so failures identify exactly which dependency did not become ready within the timeout.
-- Use `initialDelay` when a service emits a transient non-active state immediately after being started.
+- Use this when a process must fully stop before a later step continues.
 
 ## Related
 

--- a/internal/schemadoc/metadata.go
+++ b/internal/schemadoc/metadata.go
@@ -5,6 +5,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/Airgap-Castaways/deck/internal/stepspec"
 	"github.com/Airgap-Castaways/deck/internal/workflowcontract"
 )
 
@@ -489,6 +490,9 @@ var toolMetadata = map[string]ToolMetadata{
 
 func ToolMetaForDefinition(def workflowcontract.StepDefinition) ToolMetadata {
 	kind := def.Kind
+	if meta, ok := stepspec.LookupToolDoc(kind); ok {
+		return toolMetaFromStepspec(kind, def, meta)
+	}
 	meta, ok := toolMetadata[kind]
 	if !ok {
 		meta, ok = toolMetadata[def.FamilyTitle]
@@ -508,6 +512,26 @@ func ToolMetaForDefinition(def workflowcontract.StepDefinition) ToolMetadata {
 	delete(merged, "spec.action")
 	meta.FieldDocs = merged
 	return meta
+}
+
+func toolMetaFromStepspec(kind string, def workflowcontract.StepDefinition, meta stepspec.ToolDocMetadata) ToolMetadata {
+	tool := ToolMetadata{
+		Kind:      kind,
+		Category:  def.Category,
+		Summary:   def.Summary,
+		WhenToUse: def.WhenToUse,
+		Example:   strings.TrimSpace(meta.Example),
+		Notes:     append([]string(nil), meta.Notes...),
+		FieldDocs: make(map[string]FieldDoc, len(commonFieldDocs)+len(meta.FieldDocs)),
+	}
+	maps.Copy(tool.FieldDocs, commonFieldDocs)
+	for path, field := range meta.FieldDocs {
+		tool.FieldDocs[path] = FieldDoc{Description: field.Description, Example: field.Example}
+	}
+	if tool.Example != "" {
+		tool.Example += "\n"
+	}
+	return tool
 }
 
 func normalizedToolExample(kind string, def workflowcontract.StepDefinition, meta ToolMetadata) string {

--- a/internal/schemadoc/render_test.go
+++ b/internal/schemadoc/render_test.go
@@ -84,6 +84,65 @@ func TestRenderToolPageIncludesSchemaDerivedBranchRuleSummary(t *testing.T) {
 	}
 }
 
+func TestRenderToolPageAvoidsGenericPlaceholderExamplesForRestoredFamilies(t *testing.T) {
+	for _, family := range []string{"file", "package", "wait", "image"} {
+		rendered := string(RenderToolPage(testFamilyPageInput(t, family)))
+		for _, bad := range []string{"| `example` |", "| `{...}` |", "| `[{...}]` |"} {
+			if strings.Contains(rendered, bad) {
+				t.Fatalf("family %s still contains placeholder %s:\n%s", family, bad, rendered)
+			}
+		}
+	}
+}
+
+func TestRenderToolPageUsesKindScopedNotesForImageAndPackageFamilies(t *testing.T) {
+	imagePage := string(RenderToolPage(testFamilyPageInput(t, "image")))
+	loadSection := sectionForKind(imagePage, "LoadImage")
+	if strings.Contains(loadSection, "spec.auth") || strings.Contains(loadSection, "outputDir") {
+		t.Fatalf("expected LoadImage notes to exclude DownloadImage-only guidance:\n%s", loadSection)
+	}
+	packagePage := string(RenderToolPage(testFamilyPageInput(t, "package")))
+	installSection := sectionForKind(packagePage, "InstallPackage")
+	if strings.Contains(installSection, "outputDir") || strings.Contains(installSection, "Container-backed `DownloadPackage`") {
+		t.Fatalf("expected InstallPackage notes to exclude DownloadPackage-only guidance:\n%s", installSection)
+	}
+}
+
+func TestGeneratedToolDocsDoNotContainGenericPlaceholders(t *testing.T) {
+	for _, family := range []string{"file", "wait", "package", "image"} {
+		rendered := string(RenderToolPage(testFamilyPageInput(t, family)))
+		for _, bad := range []string{"`example`", "`{...}`", "`[{...}]`"} {
+			if strings.Contains(rendered, bad) {
+				t.Fatalf("family %s still contains generic placeholder %s:\n%s", family, bad, rendered)
+			}
+		}
+	}
+}
+
+func TestWaitForCommandUsesConcreteExample(t *testing.T) {
+	rendered := string(RenderToolPage(testFamilyPageInput(t, "wait")))
+	section := sectionForKind(rendered, "WaitForCommand")
+	if !strings.Contains(section, "command: [test, -f, /etc/kubernetes/admin.conf]") {
+		t.Fatalf("expected WaitForCommand concrete example:\n%s", section)
+	}
+	if strings.Contains(section, "apiVersion: deck/v1alpha1") || strings.Contains(section, "example-waitforcommand") {
+		t.Fatalf("expected WaitForCommand to avoid generic fallback example:\n%s", section)
+	}
+}
+
+func sectionForKind(page string, kind string) string {
+	marker := "## `" + kind + "`"
+	idx := strings.Index(page, marker)
+	if idx == -1 {
+		return ""
+	}
+	rest := page[idx:]
+	if next := strings.Index(rest[len(marker):], "\n## `"); next >= 0 {
+		return rest[:len(marker)+next]
+	}
+	return rest
+}
+
 func testFamilyPageInput(t *testing.T, family string) PageInput {
 	t.Helper()
 	defs := workflowcontract.StepDefinitions()

--- a/internal/stepspec/docmeta.go
+++ b/internal/stepspec/docmeta.go
@@ -1,0 +1,47 @@
+package stepspec
+
+import "sync"
+
+type FieldDoc struct {
+	Description string
+	Example     string
+}
+
+type ToolDocMetadata struct {
+	Example   string
+	FieldDocs map[string]FieldDoc
+	Notes     []string
+}
+
+var (
+	toolDocMu   sync.RWMutex
+	toolDocMeta = map[string]ToolDocMetadata{}
+)
+
+func registerToolDoc(kind string, meta ToolDocMetadata) struct{} {
+	toolDocMu.Lock()
+	defer toolDocMu.Unlock()
+	toolDocMeta[kind] = cloneToolDocMetadata(meta)
+	return struct{}{}
+}
+
+func LookupToolDoc(kind string) (ToolDocMetadata, bool) {
+	toolDocMu.RLock()
+	meta, ok := toolDocMeta[kind]
+	toolDocMu.RUnlock()
+	if !ok {
+		return ToolDocMetadata{}, false
+	}
+	return cloneToolDocMetadata(meta), true
+}
+
+func cloneToolDocMetadata(meta ToolDocMetadata) ToolDocMetadata {
+	cloned := ToolDocMetadata{Example: meta.Example, Notes: append([]string(nil), meta.Notes...)}
+	if meta.FieldDocs != nil {
+		cloned.FieldDocs = make(map[string]FieldDoc, len(meta.FieldDocs))
+		for key, value := range meta.FieldDocs {
+			cloned.FieldDocs[key] = value
+		}
+	}
+	return cloned
+}

--- a/internal/stepspec/file_docs.go
+++ b/internal/stepspec/file_docs.go
@@ -1,0 +1,172 @@
+package stepspec
+
+var (
+	commonFileFieldDocs = map[string]FieldDoc{
+		"spec.path":                 {Description: "Destination path on the node.", Example: "/etc/containerd/config.toml"},
+		"spec.mode":                 {Description: "File permissions in octal notation applied after the step completes.", Example: "0644"},
+		"spec.source":               {Description: "Structured source descriptor for copy or extraction operations.", Example: "{path:/etc/kubernetes/admin.conf}"},
+		"spec.source.url":           {Description: "URL to fetch the file from during prepare.", Example: "https://mirror.example.com/runc"},
+		"spec.source.path":          {Description: "Local filesystem path to use as the source.", Example: "/opt/cache/runc"},
+		"spec.source.sha256":        {Description: "Expected SHA-256 checksum for the fetched file.", Example: "abc123..."},
+		"spec.source.bundle":        {Description: "Reference to a file already stored in the prepared bundle.", Example: "{root:files,path:bin/linux/amd64/runc}"},
+		"spec.source.bundle.root":   {Description: "Bundle root category to read from.", Example: "files"},
+		"spec.source.bundle.path":   {Description: "Relative path within the selected bundle root.", Example: "bin/linux/amd64/runc"},
+		"spec.fetch":                {Description: "Optional download transport settings used when the source may need to be fetched.", Example: "{offlineOnly:true}"},
+		"spec.fetch.offlineOnly":    {Description: "Restrict fetches to offline-safe sources only.", Example: "true"},
+		"spec.fetch.sources":        {Description: "Ordered list of fetch source candidates tried for the transfer.", Example: "[{type:url,url:https://mirror.example.com/runc}]"},
+		"spec.fetch.sources[].type": {Description: "Source selector type for a fetch candidate.", Example: "url"},
+		"spec.fetch.sources[].path": {Description: "Local path source used when `type` is `path`.", Example: "/opt/cache/runc"},
+		"spec.fetch.sources[].url":  {Description: "Remote URL source used when `type` is `url`.", Example: "https://mirror.example.com/runc"},
+	}
+
+	downloadFileFieldDocs = mergeFieldDocs(commonFileFieldDocs, map[string]FieldDoc{
+		"spec.items":                      {Description: "Optional list form for batching multiple download items in one step.", Example: "[{source:{url:https://mirror.example.com/runc},outputPath:files/bin/runc,mode:0755}]"},
+		"spec.source":                     {Description: "Structured source descriptor for the download.", Example: "{url:https://mirror.example.com/runc,sha256:abc123...}"},
+		"spec.outputPath":                 {Description: "Bundle-relative output path for the downloaded artifact.", Example: "files/bin/runc"},
+		"spec.timeout":                    {Description: "Optional per-transfer timeout for the download.", Example: "30s"},
+		"spec.items[].source":             {Description: "Source descriptor for this item.", Example: "{url:https://mirror.example.com/runc}"},
+		"spec.items[].source.url":         {Description: "URL to fetch for this item.", Example: "https://mirror.example.com/runc"},
+		"spec.items[].source.path":        {Description: "Local path source for this item.", Example: "/opt/cache/runc"},
+		"spec.items[].source.sha256":      {Description: "Expected SHA-256 checksum for this item.", Example: "abc123..."},
+		"spec.items[].source.bundle":      {Description: "Bundle reference source for this item.", Example: "{root:files,path:bin/linux/amd64/runc}"},
+		"spec.items[].source.bundle.root": {Description: "Bundle root category for this item.", Example: "files"},
+		"spec.items[].source.bundle.path": {Description: "Relative path within the selected bundle root for this item.", Example: "bin/linux/amd64/runc"},
+		"spec.items[].fetch":              {Description: "Optional transport policy for this item.", Example: "{offlineOnly:true}"},
+		"spec.items[].fetch.offlineOnly":  {Description: "Restrict this item to offline-safe sources only.", Example: "true"},
+		"spec.items[].fetch.sources":      {Description: "Ordered list of source candidates for this item.", Example: "[{type:url,url:https://mirror.example.com/runc}]"},
+		"spec.items[].outputPath":         {Description: "Bundle-relative output path for this item.", Example: "files/bin/runc"},
+		"spec.items[].mode":               {Description: "File permissions applied after this item is written.", Example: "0755"},
+	})
+
+	_ = registerToolDoc("DownloadFile", ToolDocMetadata{
+		Example:   "kind: DownloadFile\nspec:\n  source:\n    url: https://mirror.example.com/runc\n    sha256: abc123...\n  outputPath: files/bin/runc\n  mode: \"0755\"\n",
+		FieldDocs: downloadFileFieldDocs,
+		Notes: []string{
+			"`DownloadFile` writes into prepared bundle storage through `outputPath` rather than a node path.",
+			"Omit `outputPath` unless later steps need a stable custom prepared location.",
+			"Use `template` instead of `content` only for `WriteFile`; `DownloadFile` always uses explicit sources.",
+		},
+	})
+
+	_ = registerToolDoc("WriteFile", ToolDocMetadata{
+		Example: "kind: WriteFile\nspec:\n  path: /etc/containerd/config.toml\n  template: |\n    [plugins.\"io.containerd.grpc.v1.cri\".containerd.runtimes.runc.options]\n      SystemdCgroup = {{ .vars.systemdCgroup }}\n  mode: \"0644\"\n",
+		FieldDocs: map[string]FieldDoc{
+			"spec.path":     {Description: "Destination path on the node.", Example: "/etc/containerd/config.toml"},
+			"spec.content":  {Description: "Inline file content written verbatim to `path`.", Example: "[offline-base]\nbaseurl=http://repo.local"},
+			"spec.template": {Description: "Inline multi-line content rendered with current vars before writing.", Example: "[Service]\nEnvironment=ROLE={{ .vars.role }}"},
+			"spec.mode":     {Description: "File permissions in octal notation applied after the write completes.", Example: "0644"},
+		},
+		Notes: []string{"Use `template` instead of `content` when the body needs variable interpolation."},
+	})
+
+	_ = registerToolDoc("CopyFile", ToolDocMetadata{
+		Example: "kind: CopyFile\nspec:\n  source:\n    path: /etc/kubernetes/admin.conf\n  path: /home/vagrant/.kube/config\n  mode: \"0644\"\n",
+		FieldDocs: map[string]FieldDoc{
+			"spec.source":               commonFileFieldDocs["spec.source"],
+			"spec.source.url":           commonFileFieldDocs["spec.source.url"],
+			"spec.source.path":          commonFileFieldDocs["spec.source.path"],
+			"spec.source.sha256":        commonFileFieldDocs["spec.source.sha256"],
+			"spec.source.bundle":        commonFileFieldDocs["spec.source.bundle"],
+			"spec.source.bundle.root":   commonFileFieldDocs["spec.source.bundle.root"],
+			"spec.source.bundle.path":   commonFileFieldDocs["spec.source.bundle.path"],
+			"spec.fetch":                commonFileFieldDocs["spec.fetch"],
+			"spec.fetch.offlineOnly":    commonFileFieldDocs["spec.fetch.offlineOnly"],
+			"spec.fetch.sources":        commonFileFieldDocs["spec.fetch.sources"],
+			"spec.fetch.sources[].type": commonFileFieldDocs["spec.fetch.sources[].type"],
+			"spec.fetch.sources[].path": commonFileFieldDocs["spec.fetch.sources[].path"],
+			"spec.fetch.sources[].url":  commonFileFieldDocs["spec.fetch.sources[].url"],
+			"spec.path":                 {Description: "Destination path on the node.", Example: "/home/vagrant/.kube/config"},
+			"spec.mode":                 {Description: "File permissions in octal notation applied after the copy completes.", Example: "0644"},
+		},
+		Notes: []string{"Use `source.path` for simple local paths and `source.bundle` or `source.url` when the source is structured or external."},
+	})
+
+	_ = registerToolDoc("EditFile", ToolDocMetadata{
+		Example: "kind: EditFile\nspec:\n  path: /etc/containerd/config.toml\n  edits:\n    - match: SystemdCgroup = false\n      replaceWith: SystemdCgroup = true\n",
+		FieldDocs: map[string]FieldDoc{
+			"spec.path":                {Description: "File path to edit in place.", Example: "/etc/containerd/config.toml"},
+			"spec.backup":              {Description: "Create a `.bak` copy of the original file before overwriting it.", Example: "true"},
+			"spec.edits":               {Description: "Ordered list of match/replace rules applied sequentially to the file.", Example: "[{match:SystemdCgroup = false,replaceWith:SystemdCgroup = true}]"},
+			"spec.edits[].match":       {Description: "Literal string or pattern to search for in the file.", Example: "SystemdCgroup = false"},
+			"spec.edits[].replaceWith": {Description: "Replacement string applied where `match` is found.", Example: "SystemdCgroup = true"},
+			"spec.edits[].op":          {Description: "Edit operation type. Defaults to `replace`.", Example: "replace"},
+			"spec.mode":                {Description: "File permissions in octal notation applied after the edit completes.", Example: "0644"},
+		},
+		Notes: []string{"Use `EditTOML`, `EditYAML`, or `EditJSON` when structured edits are available and less brittle."},
+	})
+
+	_ = registerToolDoc("EditTOML", ToolDocMetadata{
+		Example: "kind: EditTOML\nspec:\n  path: /etc/containerd/config.toml\n  edits:\n    - op: set\n      rawPath: plugins.\"io.containerd.grpc.v1.cri\".registry.config_path\n      value: /etc/containerd/certs.d\n",
+		FieldDocs: map[string]FieldDoc{
+			"spec.path":            {Description: "TOML file path to edit in place.", Example: "/etc/containerd/config.toml"},
+			"spec.createIfMissing": {Description: "Create a new empty TOML document when the file does not exist.", Example: "true"},
+			"spec.edits":           {Description: "Ordered list of structured edits applied sequentially to the TOML document.", Example: "[{op:set,rawPath:plugins.\"io.containerd.grpc.v1.cri\".registry.config_path,value:/etc/containerd/certs.d}]"},
+			"spec.edits[].op":      {Description: "Structured edit operation.", Example: "set"},
+			"spec.edits[].rawPath": {Description: "Quoted-segment TOML path.", Example: "plugins.\"io.containerd.grpc.v1.cri\".registry.config_path"},
+			"spec.edits[].value":   {Description: "Typed edit value.", Example: "/etc/containerd/certs.d"},
+			"spec.mode":            {Description: "Optional file permissions to apply after the edit completes.", Example: "0644"},
+		},
+		Notes: []string{"Use this for generic TOML editing when a domain-specific step is unnecessary."},
+	})
+
+	_ = registerToolDoc("EditYAML", ToolDocMetadata{
+		Example: "kind: EditYAML\nspec:\n  path: /etc/kubernetes/kubeadm-config.yaml\n  edits:\n    - op: set\n      rawPath: ClusterConfiguration.imageRepository\n      value: registry.local/k8s\n",
+		FieldDocs: map[string]FieldDoc{
+			"spec.path":            {Description: "YAML file path to edit in place.", Example: "/etc/kubernetes/kubeadm-config.yaml"},
+			"spec.createIfMissing": {Description: "Create a new empty YAML document when the file does not exist.", Example: "true"},
+			"spec.edits":           {Description: "Ordered list of structured edits applied sequentially to the YAML document.", Example: "[{op:set,rawPath:spec.template.spec.containers.0.image,value:registry.local/app:v1}]"},
+			"spec.edits[].op":      {Description: "Structured edit operation.", Example: "set"},
+			"spec.edits[].rawPath": {Description: "Dot-path with optional quoted key segments and numeric array indexes.", Example: "spec.template.spec.containers.0.image"},
+			"spec.edits[].value":   {Description: "Typed edit value.", Example: "registry.local/k8s"},
+			"spec.mode":            {Description: "Optional file permissions to apply after the edit completes.", Example: "0644"},
+		},
+		Notes: []string{"Comment placement, anchors, aliases, merge keys, and style preservation are not guaranteed."},
+	})
+
+	_ = registerToolDoc("EditJSON", ToolDocMetadata{
+		Example: "kind: EditJSON\nspec:\n  path: /etc/cni/net.d/10-custom.conflist\n  edits:\n    - op: set\n      rawPath: plugins.0.type\n      value: bridge\n",
+		FieldDocs: map[string]FieldDoc{
+			"spec.path":            {Description: "JSON file path to edit in place.", Example: "/etc/cni/net.d/10-custom.conflist"},
+			"spec.createIfMissing": {Description: "Create a new empty JSON object when the file does not exist.", Example: "true"},
+			"spec.edits":           {Description: "Ordered list of structured edits applied sequentially to the JSON document.", Example: "[{op:set,rawPath:plugins.0.type,value:bridge}]"},
+			"spec.edits[].op":      {Description: "Structured edit operation.", Example: "set"},
+			"spec.edits[].rawPath": {Description: "Dot-path with optional quoted key segments and numeric array indexes.", Example: "plugins.0.type"},
+			"spec.edits[].value":   {Description: "Typed edit value.", Example: "bridge"},
+			"spec.mode":            {Description: "Optional file permissions to apply after the edit completes.", Example: "0644"},
+		},
+	})
+
+	_ = registerToolDoc("ExtractArchive", ToolDocMetadata{
+		Example: "kind: ExtractArchive\nspec:\n  source:\n    path: /tmp/cni-plugins.tgz\n  path: /opt/cni/bin\n  include: [bridge, loopback]\n",
+		FieldDocs: map[string]FieldDoc{
+			"spec.source":               commonFileFieldDocs["spec.source"],
+			"spec.source.url":           commonFileFieldDocs["spec.source.url"],
+			"spec.source.path":          commonFileFieldDocs["spec.source.path"],
+			"spec.source.sha256":        commonFileFieldDocs["spec.source.sha256"],
+			"spec.source.bundle":        commonFileFieldDocs["spec.source.bundle"],
+			"spec.source.bundle.root":   commonFileFieldDocs["spec.source.bundle.root"],
+			"spec.source.bundle.path":   commonFileFieldDocs["spec.source.bundle.path"],
+			"spec.fetch":                commonFileFieldDocs["spec.fetch"],
+			"spec.fetch.offlineOnly":    commonFileFieldDocs["spec.fetch.offlineOnly"],
+			"spec.fetch.sources":        commonFileFieldDocs["spec.fetch.sources"],
+			"spec.fetch.sources[].type": commonFileFieldDocs["spec.fetch.sources[].type"],
+			"spec.fetch.sources[].path": commonFileFieldDocs["spec.fetch.sources[].path"],
+			"spec.fetch.sources[].url":  commonFileFieldDocs["spec.fetch.sources[].url"],
+			"spec.path":                 {Description: "Destination directory on the node.", Example: "/opt/cni/bin"},
+			"spec.include":              {Description: "Optional archive members to extract. Extract all members when omitted.", Example: "[bridge,loopback]"},
+			"spec.mode":                 {Description: "File permissions applied to extracted files when supported.", Example: "0755"},
+		},
+		Notes: []string{"Extract all archive members when `include` is omitted."},
+	})
+)
+
+func mergeFieldDocs(base map[string]FieldDoc, extra map[string]FieldDoc) map[string]FieldDoc {
+	out := make(map[string]FieldDoc, len(base)+len(extra))
+	for k, v := range base {
+		out[k] = v
+	}
+	for k, v := range extra {
+		out[k] = v
+	}
+	return out
+}

--- a/internal/stepspec/image_docs.go
+++ b/internal/stepspec/image_docs.go
@@ -1,0 +1,41 @@
+package stepspec
+
+var (
+	_ = registerToolDoc("DownloadImage", ToolDocMetadata{
+		Example: "kind: DownloadImage\nspec:\n  images:\n    - registry.k8s.io/kube-apiserver:v1.30.1\n    - registry.example.com/platform/pause:3.9\n  auth:\n    - registry: registry.example.com\n      basic:\n        username: \"{{ .vars.registryUser }}\"\n        password: \"{{ .vars.registryPassword }}\"\n",
+		FieldDocs: map[string]FieldDoc{
+			"spec.images":                {Description: "Fully qualified image references to download.", Example: "[registry.k8s.io/pause:3.9]"},
+			"spec.auth":                  {Description: "Optional registry authentication entries used during download.", Example: "[{registry:registry.example.com,basic:{username:robot,password:${REGISTRY_PASSWORD}}}]"},
+			"spec.auth[].registry":       {Description: "Registry host matched against each image reference.", Example: "registry.example.com"},
+			"spec.auth[].basic":          {Description: "Explicit basic-auth credentials used when downloading from the matched registry.", Example: "{username:robot,password:${REGISTRY_PASSWORD}}"},
+			"spec.auth[].basic.username": {Description: "Registry username used for basic authentication.", Example: "robot"},
+			"spec.auth[].basic.password": {Description: "Registry password or access token paired with `basic.username`.", Example: "${REGISTRY_PASSWORD}"},
+			"spec.outputDir":             {Description: "Optional bundle-relative directory where per-image tar archives are written.", Example: "images/control-plane"},
+			"spec.backend":               {Description: "Backend-specific download settings. Applies to `DownloadImage` only.", Example: "{engine:go-containerregistry}"},
+			"spec.backend.engine":        {Description: "Image download engine.", Example: "go-containerregistry"},
+		},
+		Notes: []string{
+			"Use `DownloadImage` during prepare to collect required images for offline use.",
+			"Omit `outputDir` unless you need a custom bundle subdirectory; deck writes to `images/` by default.",
+			"`spec.auth` is optional and only applies to `DownloadImage`.",
+		},
+	})
+	_ = registerToolDoc("LoadImage", ToolDocMetadata{
+		Example: "kind: LoadImage\nspec:\n  sourceDir: images/control-plane\n  runtime: ctr\n  images:\n    - registry.k8s.io/kube-apiserver:v1.30.1\n",
+		FieldDocs: map[string]FieldDoc{
+			"spec.command":   {Description: "Optional runtime command override. This command may include `{archive}` placeholders that deck substitutes per image archive.", Example: "[ctr,-n,k8s.io,images,import,{archive}]"},
+			"spec.images":    {Description: "Fully qualified image references to load.", Example: "[registry.k8s.io/pause:3.9]"},
+			"spec.runtime":   {Description: "Runtime loader used by `LoadImage`.", Example: "ctr"},
+			"spec.sourceDir": {Description: "Directory containing prepared image archives to load into the runtime.", Example: "images/control-plane"},
+		},
+		Notes: []string{"Use `LoadImage` during apply when archives must be imported into the runtime."},
+	})
+	_ = registerToolDoc("VerifyImage", ToolDocMetadata{
+		Example: "kind: VerifyImage\nspec:\n  command: [ctr, -n, k8s.io, images, list, -q]\n  images:\n    - registry.k8s.io/kube-apiserver:v1.30.1\n",
+		FieldDocs: map[string]FieldDoc{
+			"spec.command": {Description: "Optional image-listing command override.", Example: "[ctr,-n,k8s.io,images,list,-q]"},
+			"spec.images":  {Description: "Fully qualified image references that must already exist on the node.", Example: "[registry.k8s.io/pause:3.9]"},
+		},
+		Notes: []string{"Use `VerifyImage` when the runtime should already contain the required images and only verification is needed."},
+	})
+)

--- a/internal/stepspec/package_docs.go
+++ b/internal/stepspec/package_docs.go
@@ -1,0 +1,89 @@
+package stepspec
+
+var (
+	commonRepositoryFieldDocs = map[string]FieldDoc{
+		"spec.format":                   {Description: "Repository file format to write.", Example: "deb"},
+		"spec.path":                     {Description: "Explicit output path for the generated repository file.", Example: "/etc/apt/sources.list.d/offline.list"},
+		"spec.mode":                     {Description: "File permissions applied to the generated repository file in octal notation.", Example: "0644"},
+		"spec.replaceExisting":          {Description: "Replace an existing repository file at the target path before writing the new definition.", Example: "true"},
+		"spec.disableExisting":          {Description: "Disable all existing repository definitions before writing the new one.", Example: "true"},
+		"spec.backupPaths":              {Description: "Paths to back up before modifying.", Example: "[/etc/apt/sources.list]"},
+		"spec.cleanupPaths":             {Description: "Paths to remove before writing the new repository definition.", Example: "[/etc/apt/sources.list.d/ubuntu.list]"},
+		"spec.repositories":             {Description: "Repository entries to write.", Example: "[{baseurl:http://repo.local/debian,trusted:true}]"},
+		"spec.repositories[].id":        {Description: "RPM repository ID.", Example: "offline-kubernetes"},
+		"spec.repositories[].name":      {Description: "Human-readable repository name.", Example: "Offline Kubernetes"},
+		"spec.repositories[].baseurl":   {Description: "Base URL for the repository.", Example: "http://repo.local/debian"},
+		"spec.repositories[].enabled":   {Description: "Explicit enabled state for the repository entry.", Example: "true"},
+		"spec.repositories[].gpgcheck":  {Description: "Explicit gpgcheck state for RPM repositories.", Example: "true"},
+		"spec.repositories[].gpgkey":    {Description: "URL or path to the repository GPG key.", Example: "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-offline"},
+		"spec.repositories[].trusted":   {Description: "Mark a deb repository as trusted.", Example: "true"},
+		"spec.repositories[].suite":     {Description: "Deb repository suite.", Example: "stable"},
+		"spec.repositories[].component": {Description: "Deb repository component.", Example: "main"},
+		"spec.repositories[].type":      {Description: "Deb repository type.", Example: "deb"},
+		"spec.repositories[].extra":     {Description: "Additional rpm-style repository key-value pairs.", Example: "{priority:10,module_hotfixes:true}"},
+	}
+
+	_ = registerToolDoc("ConfigureRepository", ToolDocMetadata{
+		Example:   "kind: ConfigureRepository\nspec:\n  format: deb\n  path: /etc/apt/sources.list.d/offline.list\n  repositories:\n    - baseurl: http://repo.local/debian\n      trusted: true\n",
+		FieldDocs: commonRepositoryFieldDocs,
+		Notes: []string{
+			"`ConfigureRepository` only writes repository definition files.",
+			"Use `RefreshRepository` when the package manager needs an explicit metadata refresh.",
+		},
+	})
+
+	_ = registerToolDoc("RefreshRepository", ToolDocMetadata{
+		Example: "kind: RefreshRepository\nspec:\n  manager: apt\n  clean: true\n  update: true\n  restrictToRepos:\n    - /etc/apt/sources.list.d/offline.list\n",
+		FieldDocs: map[string]FieldDoc{
+			"spec.manager":         {Description: "Package manager to use for repository metadata refresh.", Example: "apt"},
+			"spec.clean":           {Description: "Run a cache clean before updating metadata.", Example: "true"},
+			"spec.update":          {Description: "Fetch fresh package metadata from the configured repositories.", Example: "true"},
+			"spec.restrictToRepos": {Description: "Limit the metadata update to these repository selectors.", Example: "[/etc/apt/sources.list.d/offline.list]"},
+			"spec.excludeRepos":    {Description: "Repository selectors to skip during metadata update.", Example: "[updates]"},
+			"spec.timeout":         {Description: "Maximum total duration for refresh operations.", Example: "5m"},
+		},
+		Notes: []string{"Use `RefreshRepository` after writing repo definitions and before package installs that depend on fresh metadata."},
+	})
+
+	_ = registerToolDoc("DownloadPackage", ToolDocMetadata{
+		Example: "kind: DownloadPackage\nspec:\n  packages: [podman]\n  distro:\n    family: rhel\n    release: rocky9\n  repo:\n    type: rpm\n    modules:\n      - name: container-tools\n        stream: \"4.0\"\n  backend:\n    mode: container\n    runtime: docker\n    image: rockylinux:9\n",
+		FieldDocs: map[string]FieldDoc{
+			"spec.packages":              {Description: "Package names to download.", Example: "[kubelet,kubeadm,kubectl]"},
+			"spec.distro":                {Description: "Target distribution hint used to select resolver behavior.", Example: "{family:rhel,release:rocky9}"},
+			"spec.distro.family":         {Description: "Distribution family used to resolve package tooling.", Example: "rhel"},
+			"spec.distro.release":        {Description: "Distribution release used for resolver and repo layout selection.", Example: "rocky9"},
+			"spec.repo":                  {Description: "Repository settings applied before download.", Example: "{type:rpm,modules:[{name:container-tools,stream:4.0}]}"},
+			"spec.repo.type":             {Description: "Repository output type for download repo mode.", Example: "rpm"},
+			"spec.repo.generate":         {Description: "Generate repository metadata after collecting packages.", Example: "true"},
+			"spec.repo.pkgsDir":          {Description: "Subdirectory under the generated repo root where packages are written.", Example: "pkgs"},
+			"spec.repo.modules":          {Description: "RPM module streams to enable before resolving downloads.", Example: "[{name:container-tools,stream:4.0}]"},
+			"spec.repo.modules[].name":   {Description: "RPM module name to enable.", Example: "container-tools"},
+			"spec.repo.modules[].stream": {Description: "Module stream version paired with the module name.", Example: "4.0"},
+			"spec.backend":               {Description: "Container-based download backend configuration.", Example: "{mode:container,runtime:docker,image:rockylinux:9}"},
+			"spec.backend.mode":          {Description: "Download backend mode.", Example: "container"},
+			"spec.backend.runtime":       {Description: "Preferred container runtime for the download helper container.", Example: "docker"},
+			"spec.backend.image":         {Description: "Container image used for package resolution in download mode.", Example: "rockylinux:9"},
+			"spec.outputDir":             {Description: "Optional bundle-relative output directory for downloaded package artifacts.", Example: "packages/kubernetes"},
+			"spec.timeout":               {Description: "Maximum total duration for package download operations.", Example: "30m"},
+		},
+		Notes: []string{
+			"Use `DownloadPackage` during prepare to stage offline package-manager content.",
+			"Omit `outputDir` unless you need a custom package location.",
+			"Container-backed `DownloadPackage` exports completed artifacts into a host-owned cache and does not bind-mount package-manager cache directories.",
+		},
+	})
+
+	_ = registerToolDoc("InstallPackage", ToolDocMetadata{
+		Example: "kind: InstallPackage\nspec:\n  packages: [kubelet, kubeadm, kubectl]\n  source:\n    type: local-repo\n    path: /opt/deck/repos/kubernetes\n",
+		FieldDocs: map[string]FieldDoc{
+			"spec.packages":        {Description: "Package names to install.", Example: "[kubelet,kubeadm,kubectl]"},
+			"spec.source":          {Description: "Local repository source used for the installation.", Example: "{type:local-repo,path:/opt/deck/repos/kubernetes}"},
+			"spec.source.type":     {Description: "Source type. Currently `local-repo` is the only supported value.", Example: "local-repo"},
+			"spec.source.path":     {Description: "Filesystem path to the pre-prepared local package repository.", Example: "/opt/deck/repos/kubernetes"},
+			"spec.restrictToRepos": {Description: "Limit package manager visibility to these repository selectors.", Example: "[offline-kubernetes]"},
+			"spec.excludeRepos":    {Description: "Repository selectors to exclude from package resolution.", Example: "[updates]"},
+			"spec.timeout":         {Description: "Maximum total duration for package installation.", Example: "20m"},
+		},
+		Notes: []string{"Use `InstallPackage` during apply to install packages from configured local or mirrored repositories."},
+	})
+)

--- a/internal/stepspec/wait_docs.go
+++ b/internal/stepspec/wait_docs.go
@@ -1,0 +1,26 @@
+package stepspec
+
+var waitFieldDocs = map[string]FieldDoc{
+	"spec.name":         {Description: "Service name to check.", Example: "containerd"},
+	"spec.command":      {Description: "Command vector to run on each poll attempt. The step succeeds when the command exits 0.", Example: "[test,-f,/etc/kubernetes/admin.conf]"},
+	"spec.path":         {Description: "Filesystem path to check.", Example: "/etc/kubernetes/admin.conf"},
+	"spec.paths":        {Description: "List of paths that must all be absent before the step succeeds.", Example: "[/etc/kubernetes/manifests/a.yaml,/etc/kubernetes/manifests/b.yaml]"},
+	"spec.glob":         {Description: "Glob pattern that must resolve to zero matches before the step succeeds.", Example: "/etc/kubernetes/manifests/*.yaml"},
+	"spec.type":         {Description: "Filesystem entry type restriction for path checks.", Example: "file"},
+	"spec.nonEmpty":     {Description: "Require the matched file to have non-zero size.", Example: "true"},
+	"spec.port":         {Description: "TCP port number to check.", Example: "6443"},
+	"spec.address":      {Description: "Host or IP address for TCP port checks.", Example: "127.0.0.1"},
+	"spec.interval":     {Description: "Duration between poll attempts.", Example: "2s"},
+	"spec.initialDelay": {Description: "Duration to wait before the first poll attempt.", Example: "1s"},
+	"spec.timeout":      {Description: "Maximum total duration to wait before failing the step.", Example: "5m"},
+	"spec.pollInterval": {Description: "Deprecated alias for `interval`. Use `interval` instead.", Example: "2s"},
+}
+
+var (
+	_ = registerToolDoc("WaitForService", ToolDocMetadata{Example: "kind: WaitForService\nspec:\n  name: containerd\n  interval: 2s\n  timeout: 2m\n", FieldDocs: waitFieldDocs, Notes: []string{"`Wait` bridges convergence gaps between steps. It should not replace the configuration action itself.", "Keep waits specific so failures identify exactly which dependency did not become ready within the timeout.", "Use `initialDelay` when a service emits a transient non-active state immediately after being started."}})
+	_ = registerToolDoc("WaitForCommand", ToolDocMetadata{Example: "kind: WaitForCommand\nspec:\n  command: [test, -f, /etc/kubernetes/admin.conf]\n  interval: 2s\n  timeout: 2m\n", FieldDocs: waitFieldDocs, Notes: []string{"`Wait` bridges convergence gaps between steps. It should not replace the configuration action itself.", "Keep waits specific so failures identify exactly which dependency did not become ready within the timeout.", "Use `initialDelay` when a service emits a transient non-active state immediately after being started."}})
+	_ = registerToolDoc("WaitForFile", ToolDocMetadata{Example: "kind: WaitForFile\nspec:\n  path: /etc/kubernetes/admin.conf\n  type: file\n  nonEmpty: true\n  interval: 2s\n  timeout: 5m\n", FieldDocs: waitFieldDocs, Notes: []string{"`Wait` bridges convergence gaps between steps. It should not replace the configuration action itself.", "Keep waits specific so failures identify exactly which dependency did not become ready within the timeout.", "Use `nonEmpty` when waiting on a file that is written progressively."}})
+	_ = registerToolDoc("WaitForMissingFile", ToolDocMetadata{Example: "kind: WaitForMissingFile\nspec:\n  path: /var/lib/etcd/member\n  interval: 2s\n  timeout: 2m\n", FieldDocs: waitFieldDocs, Notes: []string{"Use `paths` or `glob` when multiple files must disappear before the step can succeed."}})
+	_ = registerToolDoc("WaitForTCPPort", ToolDocMetadata{Example: "kind: WaitForTCPPort\nspec:\n  port: \"6443\"\n  interval: 2s\n  timeout: 5m\n", FieldDocs: waitFieldDocs, Notes: []string{"`Wait` bridges convergence gaps between steps. It should not replace the configuration action itself.", "Keep waits specific so failures identify exactly which dependency did not become ready within the timeout."}})
+	_ = registerToolDoc("WaitForMissingTCPPort", ToolDocMetadata{Example: "kind: WaitForMissingTCPPort\nspec:\n  port: \"10250\"\n  interval: 2s\n  timeout: 2m\n", FieldDocs: waitFieldDocs, Notes: []string{"Use this when a process must fully stop before a later step continues."}})
+)


### PR DESCRIPTION
## Summary
- restore schema doc examples and nested field metadata for file, wait, package, and image tool families using code-adjacent stepspec metadata
- teach schemadoc generation to prefer stepspec-provided examples, field docs, and notes before generic fallbacks
- add regression coverage to prevent placeholder examples and family-note leakage in generated schema docs

## Verification
- go test ./internal/schemadoc ./cmd/schema-gen
- make generate
- make test
- make lint