### PR TITLE
docs: remove redundant brew tap command from README

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -56,7 +56,6 @@ deck apply
 
 ```bash
 # Homebrew tap
-brew tap Airgap-Castaways/tap
 brew install Airgap-Castaways/tap/deck
 ```
 

--- a/README.md
+++ b/README.md
@@ -57,7 +57,6 @@ Release downloads are published on the GitHub Releases page. Homebrew installs a
 
 ```bash
 # Homebrew tap
-brew tap Airgap-Castaways/tap
 brew install Airgap-Castaways/tap/deck
 ```
 


### PR DESCRIPTION
Removed unnecessary 'brew tap' commands as 'brew install' handles it automatically.