### PR TITLE
fix: include 'v' prefix in goreleaser archive naming

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -24,6 +24,7 @@ builds:
 
 archives:
   - id: deck-archive
+    name_template: "{{ .ProjectName }}_{{ .Tag }}_{{ .Os }}_{{ .Arch }}"
     ids:
       - deck
     formats: [tar.gz]


### PR DESCRIPTION
Update .goreleaser.yaml to use {{ .Tag }} in the archive name template to ensure the 'v' prefix is included in the resulting artifacts, matching the expected format.