### PR TITLE
Log apply and prepare step progress in real time

### DIFF
--- a/cmd/deck/apply_cli_test.go
+++ b/cmd/deck/apply_cli_test.go
@@ -497,10 +497,32 @@ func TestApplyVerboseDiagnostics(t *testing.T) {
 	if res.stdout != "apply: ok\n" {
 		t.Fatalf("unexpected stdout: %q", res.stdout)
 	}
-	for _, want := range []string{"deck: apply workflow=", "deck: apply runlog=", "deck: apply step=verbose-step kind=Command phase=install status=started attempt=1", "deck: apply step=verbose-step kind=Command phase=install status=succeeded attempt=1"} {
+	for _, want := range []string{"deck: apply workflow=", "deck: apply runlog=", "deck: apply step=verbose-step kind=Command phase=install status=started attempt=1", "deck: apply step=verbose-step kind=Command phase=install status=succeeded attempt=1 duration="} {
 		if !strings.Contains(res.stderr, want) {
 			t.Fatalf("expected %q in stderr, got %q", want, res.stderr)
 		}
+	}
+}
+
+func TestApplyDefaultProgressLogs(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	wfPath := filepath.Join(t.TempDir(), "apply-default-progress.yaml")
+	writeWorkflowYAML(t, wfPath, "version: v1alpha1\nphases:\n  - name: install\n    steps:\n      - id: progress-step\n        kind: Command\n        spec:\n          command: [\"true\"]\n")
+	bundle := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(bundle, "workflows"), 0o755); err != nil {
+		t.Fatalf("mkdir bundle workflows: %v", err)
+	}
+	createValidBundleManifest(t, bundle)
+
+	res := execute([]string{"apply", "--workflow", wfPath, bundle})
+	if res.err != nil {
+		t.Fatalf("expected success, got %v", res.err)
+	}
+	if !strings.Contains(res.stderr, "deck: apply step=progress-step kind=Command phase=install status=started attempt=1") {
+		t.Fatalf("expected started progress log, got %q", res.stderr)
+	}
+	if !strings.Contains(res.stderr, "deck: apply step=progress-step kind=Command phase=install status=succeeded attempt=1 duration=") {
+		t.Fatalf("expected completion progress log with duration, got %q", res.stderr)
 	}
 }
 

--- a/cmd/deck/cmd_apply_events.go
+++ b/cmd/deck/cmd_apply_events.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"context"
-	"fmt"
 	"strings"
 
 	"github.com/Airgap-Castaways/deck/internal/applycli"
@@ -11,31 +10,8 @@ import (
 )
 
 func verboseApplyStepSink() install.StepEventSink {
-	if cliVerbosity < 1 {
-		return nil
-	}
 	return func(event install.StepEvent) {
-		status := strings.TrimSpace(event.Status)
-		level := 1
-		if status == "started" {
-			level = 2
-		}
-		parts := []string{
-			fmt.Sprintf("deck: apply step=%s", strings.TrimSpace(event.StepID)),
-			fmt.Sprintf("kind=%s", strings.TrimSpace(event.Kind)),
-			fmt.Sprintf("phase=%s", displayValueOrDash(event.Phase)),
-			fmt.Sprintf("status=%s", displayValueOrDash(status)),
-		}
-		if event.Attempt > 0 {
-			parts = append(parts, fmt.Sprintf("attempt=%d", event.Attempt))
-		}
-		if strings.TrimSpace(event.Reason) != "" {
-			parts = append(parts, fmt.Sprintf("reason=%s", strings.TrimSpace(event.Reason)))
-		}
-		if strings.TrimSpace(event.Error) != "" {
-			parts = append(parts, fmt.Sprintf("error=%s", strings.TrimSpace(event.Error)))
-		}
-		_ = verbosef(level, "%s\n", strings.Join(parts, " "))
+		_ = stderrPrintf("%s\n", formatStepProgressLine("apply", event.StepID, event.Kind, event.Phase, strings.TrimSpace(event.Status), event.Attempt, event.Reason, event.Error, event.StartedAt, event.EndedAt))
 	}
 }
 

--- a/cmd/deck/cmd_prepare.go
+++ b/cmd/deck/cmd_prepare.go
@@ -96,5 +96,6 @@ func runPrepareWithOptions(cmd *cobra.Command, opts prepareOptions) error {
 		VarOverrides: varsAsAnyMap(opts.varOverrides),
 		Stdout:       stdoutWriter(),
 		Diagnosticf:  verbosef,
+		EventSink:    verbosePrepareStepSink(),
 	})
 }

--- a/cmd/deck/cmd_prepare_events.go
+++ b/cmd/deck/cmd_prepare_events.go
@@ -1,0 +1,13 @@
+package main
+
+import (
+	"strings"
+
+	"github.com/Airgap-Castaways/deck/internal/prepare"
+)
+
+func verbosePrepareStepSink() prepare.StepEventSink {
+	return func(event prepare.StepEvent) {
+		_ = stderrPrintf("%s\n", formatStepProgressLine("prepare", event.StepID, event.Kind, event.Phase, strings.TrimSpace(event.Status), event.Attempt, event.Reason, event.Error, event.StartedAt, event.EndedAt))
+	}
+}

--- a/cmd/deck/main.go
+++ b/cmd/deck/main.go
@@ -8,14 +8,23 @@ import (
 )
 
 func main() {
-	res := execute(os.Args[1:])
-	if err := writeResult(res); err != nil {
-		fmt.Fprintf(os.Stderr, "deck: %v\n", err)
-		os.Exit(1)
+	if err := runMain(os.Args[1:]); err != nil {
+		if _, writeErr := fmt.Fprintf(os.Stderr, "Error: %v\n", err); writeErr != nil {
+			fmt.Fprintf(os.Stderr, "deck: %v\n", writeErr)
+		}
+		os.Exit(resolveExitCode(err))
 	}
-	if res.err != nil {
-		os.Exit(res.exitCode)
-	}
+}
+
+func runMain(args []string) error {
+	root := newRootCommand()
+	setCLIWriters(os.Stdout, os.Stderr)
+	defer setCLIWriters(os.Stdout, os.Stderr)
+	root.SetOut(os.Stdout)
+	root.SetErr(os.Stderr)
+	root.SetArgs(args)
+	_, err := root.ExecuteC()
+	return err
 }
 
 func run(args []string) error {

--- a/cmd/deck/prepare_cli_test.go
+++ b/cmd/deck/prepare_cli_test.go
@@ -153,6 +153,75 @@ func TestRunPrepareVerboseDiagnostics(t *testing.T) {
 	}
 }
 
+func TestRunPrepareVerboseStepDiagnostics(t *testing.T) {
+	root := t.TempDir()
+	workflowsDir := filepath.Join(root, "workflows")
+	if err := os.MkdirAll(filepath.Join(workflowsDir, "scenarios"), 0o755); err != nil {
+		t.Fatalf("mkdir workflows: %v", err)
+	}
+	writePrepareDownloadWorkflowFixture(t, root, "files/seed.bin")
+	if err := os.WriteFile(filepath.Join(workflowsDir, "scenarios", "apply.yaml"), []byte("version: v1alpha1\nsteps: []\n"), 0o644); err != nil {
+		t.Fatalf("write apply workflow: %v", err)
+	}
+
+	originalCWD, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	if err := os.Chdir(root); err != nil {
+		t.Fatalf("chdir root: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(originalCWD) })
+
+	res := execute([]string{"prepare", "--root", filepath.Join(root, "outputs"), "--v=1"})
+	if res.err != nil {
+		t.Fatalf("expected success, got %v", res.err)
+	}
+	if !strings.Contains(res.stdout, "prepare: ok") {
+		t.Fatalf("unexpected stdout: %q", res.stdout)
+	}
+	for _, want := range []string{
+		"deck: prepare step=seed kind=DownloadFile phase=prepare status=started attempt=1",
+		"deck: prepare step=seed kind=DownloadFile phase=prepare status=succeeded attempt=1 duration=",
+	} {
+		if !strings.Contains(res.stderr, want) {
+			t.Fatalf("expected %q in stderr, got %q", want, res.stderr)
+		}
+	}
+}
+
+func TestRunPrepareEmitsDefaultProgressLog(t *testing.T) {
+	root := t.TempDir()
+	workflowsDir := filepath.Join(root, "workflows")
+	if err := os.MkdirAll(filepath.Join(workflowsDir, "scenarios"), 0o755); err != nil {
+		t.Fatalf("mkdir workflows: %v", err)
+	}
+	writePrepareDownloadWorkflowFixture(t, root, "files/seed.bin")
+	if err := os.WriteFile(filepath.Join(workflowsDir, "scenarios", "apply.yaml"), []byte("version: v1alpha1\nsteps: []\n"), 0o644); err != nil {
+		t.Fatalf("write apply workflow: %v", err)
+	}
+
+	originalCWD, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	if err := os.Chdir(root); err != nil {
+		t.Fatalf("chdir root: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(originalCWD) })
+
+	res := execute([]string{"prepare", "--root", filepath.Join(root, "outputs")})
+	if res.err != nil {
+		t.Fatalf("expected success, got %v", res.err)
+	}
+	if !strings.Contains(res.stderr, "deck: prepare step=seed kind=DownloadFile phase=prepare status=started attempt=1") {
+		t.Fatalf("expected default step progress on stderr, got %q", res.stderr)
+	}
+	if !strings.Contains(res.stderr, "deck: prepare step=seed kind=DownloadFile phase=prepare status=succeeded attempt=1 duration=") {
+		t.Fatalf("expected completion progress with duration, got %q", res.stderr)
+	}
+}
+
 func TestRunPrepareSucceedsWithoutApplyWorkflow(t *testing.T) {
 	root := t.TempDir()
 	workflowsDir := filepath.Join(root, "workflows")

--- a/cmd/deck/step_progress.go
+++ b/cmd/deck/step_progress.go
@@ -1,0 +1,46 @@
+package main
+
+import (
+	"fmt"
+	"strings"
+	"time"
+)
+
+func formatStepProgressLine(command, stepID, kind, phase, status string, attempt int, reason, errText, startedAt, endedAt string) string {
+	parts := []string{
+		fmt.Sprintf("deck: %s step=%s", strings.TrimSpace(command), strings.TrimSpace(stepID)),
+		fmt.Sprintf("kind=%s", strings.TrimSpace(kind)),
+		fmt.Sprintf("phase=%s", displayValueOrDash(phase)),
+		fmt.Sprintf("status=%s", displayValueOrDash(status)),
+	}
+	if attempt > 0 {
+		parts = append(parts, fmt.Sprintf("attempt=%d", attempt))
+	}
+	if duration := formatEventDuration(startedAt, endedAt); duration != "" {
+		parts = append(parts, fmt.Sprintf("duration=%s", duration))
+	}
+	if strings.TrimSpace(reason) != "" {
+		parts = append(parts, fmt.Sprintf("reason=%s", strings.TrimSpace(reason)))
+	}
+	if strings.TrimSpace(errText) != "" {
+		parts = append(parts, fmt.Sprintf("error=%s", strings.TrimSpace(errText)))
+	}
+	return strings.Join(parts, " ")
+}
+
+func formatEventDuration(startedAt, endedAt string) string {
+	started := strings.TrimSpace(startedAt)
+	ended := strings.TrimSpace(endedAt)
+	if started == "" || ended == "" {
+		return ""
+	}
+	start, err := time.Parse(time.RFC3339Nano, started)
+	if err != nil {
+		return ""
+	}
+	end, err := time.Parse(time.RFC3339Nano, ended)
+	if err != nil || end.Before(start) {
+		return ""
+	}
+	return end.Sub(start).String()
+}

--- a/internal/prepare/events.go
+++ b/internal/prepare/events.go
@@ -1,0 +1,14 @@
+package prepare
+
+import "github.com/Airgap-Castaways/deck/internal/install"
+
+type StepEvent = install.StepEvent
+
+type StepEventSink = install.StepEventSink
+
+func emitStepEvent(sink StepEventSink, event StepEvent) {
+	if sink == nil {
+		return
+	}
+	sink(event)
+}

--- a/internal/prepare/runner.go
+++ b/internal/prepare/runner.go
@@ -11,6 +11,7 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
+	"time"
 
 	"golang.org/x/sync/errgroup"
 
@@ -26,6 +27,7 @@ type RunOptions struct {
 	BundleRoot       string
 	CommandRunner    CommandRunner
 	ForceRedownload  bool
+	EventSink        StepEventSink
 	imageDownloadOps imageDownloadOps
 	checksRuntime    checksRuntime
 }
@@ -184,7 +186,7 @@ func executePrepareBatch(ctx context.Context, runner CommandRunner, bundleRoot s
 	snapshot := cloneRuntimeVars(runtimeVars)
 	results := make([]prepareBatchResult, len(batch.Steps))
 	if !batch.Parallel() {
-		result, err := executePrepareStep(ctx, runner, bundleRoot, wf, snapshot, ctxData, batch.Steps[0], opts)
+		result, err := executePrepareStep(ctx, runner, bundleRoot, wf, snapshot, ctxData, batch.PhaseName, batch.Steps[0], opts)
 		if err != nil {
 			return nil, err
 		}
@@ -200,7 +202,7 @@ func executePrepareBatch(ctx context.Context, runner CommandRunner, bundleRoot s
 			i := i
 			step := step
 			group.Go(func() error {
-				result, err := executePrepareStep(groupCtx, runner, bundleRoot, wf, snapshot, ctxData, step, opts)
+				result, err := executePrepareStep(groupCtx, runner, bundleRoot, wf, snapshot, ctxData, batch.PhaseName, step, opts)
 				if err != nil {
 					return err
 				}
@@ -223,12 +225,13 @@ func executePrepareBatch(ctx context.Context, runner CommandRunner, bundleRoot s
 	return files, nil
 }
 
-func executePrepareStep(ctx context.Context, runner CommandRunner, bundleRoot string, wf *config.Workflow, runtimeSnapshot map[string]any, ctxData map[string]any, step config.Step, opts RunOptions) (prepareBatchResult, error) {
+func executePrepareStep(ctx context.Context, runner CommandRunner, bundleRoot string, wf *config.Workflow, runtimeSnapshot map[string]any, ctxData map[string]any, phaseName string, step config.Step, opts RunOptions) (prepareBatchResult, error) {
 	ok, err := evaluateWhen(step.When, wf.Vars, runtimeSnapshot)
 	if err != nil {
 		return prepareBatchResult{}, fmt.Errorf("step %s (%s): %w", step.ID, step.Kind, err)
 	}
 	if !ok {
+		emitStepEvent(opts.EventSink, StepEvent{StepID: step.ID, Kind: step.Kind, Phase: phaseName, Status: "skipped", Reason: "when"})
 		return prepareBatchResult{outputs: map[string]any{}}, nil
 	}
 	attempts := step.Retry + 1
@@ -237,22 +240,34 @@ func executePrepareStep(ctx context.Context, runner CommandRunner, bundleRoot st
 	}
 	var execErr error
 	for i := 0; i < attempts; i++ {
+		if err := ctx.Err(); err != nil {
+			execErr = err
+			break
+		}
+		startedAt := time.Now().UTC().Format(time.RFC3339Nano)
+		emitStepEvent(opts.EventSink, StepEvent{StepID: step.ID, Kind: step.Kind, Phase: phaseName, Status: "started", Attempt: i + 1, StartedAt: startedAt})
 		rendered, renderErr := renderSpecWithContext(step.Spec, wf, runtimeSnapshot, ctxData)
 		if renderErr != nil {
 			execErr = fmt.Errorf("render spec template: %w", renderErr)
+			emitStepEvent(opts.EventSink, StepEvent{StepID: step.ID, Kind: step.Kind, Phase: phaseName, Status: "failed", Attempt: i + 1, StartedAt: startedAt, EndedAt: time.Now().UTC().Format(time.RFC3339Nano), Error: execErr.Error()})
 			break
 		}
 		inputVars := collectStepInputVarValues(step.Spec, wf.Vars)
 		key, keyErr := workflowexec.ResolveStepTypeKey(wf.Version, step.APIVersion, step.Kind)
 		if keyErr != nil {
 			execErr = keyErr
-			continue
+		} else {
+			stepFiles, outputs, stepErr := runPrepareRenderedStepWithKey(ctx, runner, bundleRoot, step, rendered, key, inputVars, opts)
+			if stepErr == nil {
+				emitStepEvent(opts.EventSink, StepEvent{StepID: step.ID, Kind: step.Kind, Phase: phaseName, Status: "succeeded", Attempt: i + 1, StartedAt: startedAt, EndedAt: time.Now().UTC().Format(time.RFC3339Nano)})
+				return prepareBatchResult{files: stepFiles, outputs: outputs}, nil
+			}
+			execErr = stepErr
 		}
-		stepFiles, outputs, stepErr := runPrepareRenderedStepWithKey(ctx, runner, bundleRoot, step, rendered, key, inputVars, opts)
-		if stepErr == nil {
-			return prepareBatchResult{files: stepFiles, outputs: outputs}, nil
+		emitStepEvent(opts.EventSink, StepEvent{StepID: step.ID, Kind: step.Kind, Phase: phaseName, Status: "failed", Attempt: i + 1, StartedAt: startedAt, EndedAt: time.Now().UTC().Format(time.RFC3339Nano), Error: execErr.Error()})
+		if ctx.Err() != nil {
+			break
 		}
-		execErr = stepErr
 	}
 	return prepareBatchResult{}, fmt.Errorf("step %s (%s): %w", step.ID, step.Kind, execErr)
 }

--- a/internal/prepare/runner_test.go
+++ b/internal/prepare/runner_test.go
@@ -871,6 +871,72 @@ func TestRun_WhenAndRegisterSemantics(t *testing.T) {
 	}
 }
 
+func TestRun_EmitsStepEvents(t *testing.T) {
+	bundle := t.TempDir()
+	localCache := t.TempDir()
+
+	sourceRel := filepath.ToSlash(filepath.Join("files", "a.bin"))
+	sourceAbs := filepath.Join(localCache, filepath.FromSlash(sourceRel))
+	if err := os.MkdirAll(filepath.Dir(sourceAbs), 0o755); err != nil {
+		t.Fatalf("mkdir source dir: %v", err)
+	}
+	if err := os.WriteFile(sourceAbs, []byte("hello"), 0o644); err != nil {
+		t.Fatalf("write source: %v", err)
+	}
+
+	wf := &config.Workflow{
+		Version: "v1",
+		Vars:    map[string]any{"role": "control-plane"},
+		Phases: []config.Phase{{
+			Name: "prepare",
+			Steps: []config.Step{
+				{
+					ID:   "download-a",
+					Kind: "DownloadFile",
+					Spec: map[string]any{
+						"source":     map[string]any{"path": sourceRel},
+						"fetch":      map[string]any{"sources": []any{map[string]any{"type": "local", "path": localCache}}},
+						"outputPath": "files/a-out.bin",
+					},
+				},
+				{
+					ID:   "skip-worker-only",
+					Kind: "DownloadFile",
+					When: "vars.role == \"worker\"",
+					Spec: map[string]any{
+						"source":     map[string]any{"path": sourceRel},
+						"fetch":      map[string]any{"sources": []any{map[string]any{"type": "local", "path": localCache}}},
+						"outputPath": "files/skip.bin",
+					},
+				},
+			},
+		}},
+	}
+
+	var events []StepEvent
+	if err := Run(context.Background(), wf, RunOptions{
+		BundleRoot: bundle,
+		EventSink: func(event StepEvent) {
+			events = append(events, event)
+		},
+	}); err != nil {
+		t.Fatalf("Run failed: %v", err)
+	}
+
+	if len(events) != 3 {
+		t.Fatalf("expected 3 events, got %#v", events)
+	}
+	if events[0].StepID != "download-a" || events[0].Status != "started" || events[0].Phase != "prepare" || events[0].Attempt != 1 {
+		t.Fatalf("unexpected first event: %+v", events[0])
+	}
+	if events[1].StepID != "download-a" || events[1].Status != "succeeded" || events[1].Phase != "prepare" || events[1].Attempt != 1 {
+		t.Fatalf("unexpected second event: %+v", events[1])
+	}
+	if events[2].StepID != "skip-worker-only" || events[2].Status != "skipped" || events[2].Reason != "when" || events[2].Phase != "prepare" {
+		t.Fatalf("unexpected third event: %+v", events[2])
+	}
+}
+
 func TestRunPrepareStep_DownloadFileItems(t *testing.T) {
 	bundle := t.TempDir()
 	localCache := t.TempDir()

--- a/internal/preparecli/service.go
+++ b/internal/preparecli/service.go
@@ -28,6 +28,7 @@ type Options struct {
 	VarOverrides      map[string]any
 	Stdout            io.Writer
 	Diagnosticf       func(level int, format string, args ...any) error
+	EventSink         prepare.StepEventSink
 	runtimeBinaryDeps runtimeBinaryDeps
 }
 
@@ -175,7 +176,7 @@ func Run(ctx context.Context, opts Options) error {
 		return fmt.Errorf("create prepared root: %w", err)
 	}
 
-	if err := prepare.Run(ctx, prepareWorkflow, prepare.RunOptions{BundleRoot: preparedRoot.Abs(), ForceRedownload: opts.Refresh}); err != nil {
+	if err := prepare.Run(ctx, prepareWorkflow, prepare.RunOptions{BundleRoot: preparedRoot.Abs(), ForceRedownload: opts.Refresh, EventSink: opts.EventSink}); err != nil {
 		return err
 	}
 	if err := emitDiagnostic(opts, 2, "deck: prepare bundleRoot=%s\n", filepath.ToSlash(preparedRoot.Abs())); err != nil {


### PR DESCRIPTION
## Summary
- emit prepare step events so prepare can report per-step progress
- print apply and prepare step progress to stderr by default with elapsed duration
- run the real CLI entrypoint without buffering stdout/stderr so logs appear in real time

## Testing
- Not run in this environment due sandbox restrictions around network/module download and local listener access
