### PR TITLE
Add GitHub issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,47 @@
+name: Bug Report
+description: Record a defect with reproduction details and a clear done condition.
+title: "bug: "
+labels:
+  - bug
+body:
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      placeholder: deck prepare does not print step progress in real time
+    validations:
+      required: true
+
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      placeholder: |
+        deck version:
+        OS/arch:
+        mode:
+        workflow or scenario:
+    validations:
+      required: false
+
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Reproduction
+      placeholder: |
+        1. Build deck
+        2. Run the command or scenario
+        3. Observe the failure
+    validations:
+      required: true
+
+  - type: textarea
+    id: done
+    attributes:
+      label: Done Criteria
+      placeholder: |
+        - `deck prepare` prints step start and finish lines to stderr
+        - logs include elapsed time
+        - related CLI tests cover the behavior
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: true

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,30 @@
+name: Feature Request
+description: Propose a new capability or product behavior.
+title: "feat: "
+labels:
+  - enhancement
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed Change
+    validations:
+      required: true
+
+  - type: textarea
+    id: done
+    attributes:
+      label: Done Criteria
+      placeholder: |
+        - new flag or workflow behavior is implemented
+        - docs are updated if user-facing
+        - tests cover the expected path
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/maintenance_task.yml
+++ b/.github/ISSUE_TEMPLATE/maintenance_task.yml
@@ -1,0 +1,26 @@
+name: Maintenance Task
+description: Track refactors, test work, docs cleanup, CI work, or other maintenance.
+title: "task: "
+labels:
+  - maintenance
+body:
+  - type: textarea
+    id: objective
+    attributes:
+      label: Objective
+    validations:
+      required: true
+
+  - type: textarea
+    id: scope
+    attributes:
+      label: Scope
+    validations:
+      required: true
+
+  - type: textarea
+    id: done
+    attributes:
+      label: Done Criteria
+    validations:
+      required: true


### PR DESCRIPTION
## Summary
- add a concise bug report template with environment, reproduction, and done criteria
- add a concise feature request template focused on problem, proposal, and done criteria
- add a maintenance task template for refactor, docs, test, and cleanup work
- enable blank issues in issue template config

## Testing
- not run (GitHub issue template files only)
