### PR TITLE
fix: publish DownloadFile via temp file

### DIFF
--- a/internal/prepare/download_file.go
+++ b/internal/prepare/download_file.go
@@ -168,12 +168,6 @@ func runDownloadFileItem(ctx context.Context, bundleRoot string, decoded prepare
 		}
 	}
 
-	if expectedSHA != "" {
-		if err := verifyFileSHA256(tempPath, expectedSHA); err != nil {
-			return "", err
-		}
-	}
-
 	var targetMode os.FileMode = filemode.ArtifactFileMode
 	if modeRaw := strings.TrimSpace(decoded.Mode); modeRaw != "" {
 		modeVal, err := strconv.ParseUint(modeRaw, 8, 32)
@@ -182,11 +176,16 @@ func runDownloadFileItem(ctx context.Context, bundleRoot string, decoded prepare
 		}
 		targetMode = os.FileMode(modeVal)
 	}
-	if err := os.Chmod(tempPath, targetMode); err != nil {
+	if err := f.Chmod(targetMode); err != nil {
 		return "", fmt.Errorf("apply mode: %w", err)
 	}
 	if err := f.Close(); err != nil {
 		return "", fmt.Errorf("close output file: %w", err)
+	}
+	if expectedSHA != "" {
+		if err := verifyFileSHA256(tempPath, expectedSHA); err != nil {
+			return "", err
+		}
 	}
 	if err := os.Rename(tempPath, target); err != nil {
 		return "", fmt.Errorf("publish output file: %w", err)

--- a/internal/prepare/runner_test.go
+++ b/internal/prepare/runner_test.go
@@ -813,7 +813,7 @@ func TestRun_DownloadFileReusesURLOnlyArtifact(t *testing.T) {
 		requests++
 		n := requests
 		mu.Unlock()
-		_, _ = w.Write([]byte(fmt.Sprintf("payload-%d", n)))
+		_, _ = fmt.Fprintf(w, "payload-%d", n)
 	}))
 	defer server.Close()
 
@@ -865,7 +865,7 @@ func TestRun_DownloadFileForceRedownloadBypassesURLReuse(t *testing.T) {
 		requests++
 		n := requests
 		mu.Unlock()
-		_, _ = w.Write([]byte(fmt.Sprintf("payload-%d", n)))
+		_, _ = fmt.Fprintf(w, "payload-%d", n)
 	}))
 	defer server.Close()
 


### PR DESCRIPTION
## Summary
- publish DownloadFile artifacts via same-directory temp files and atomic rename
- keep URL-only reuse behavior while protecting existing artifacts from failed redownloads
- add regression coverage for reuse, forced redownload, and failed redownload cleanup

## Testing
- go test ./internal/prepare -run 'TestRun_(DownloadFileReusesURLOnlyArtifact|DownloadFileForceRedownloadBypassesURLReuse|DownloadFileFailedRedownloadKeepsExistingArtifact|FileOfflinePolicyBlocksDirectURL)'

## Follow-up
- Related: #95
