### PR TITLE
feat: surface server URL and access logs

### DIFF
--- a/cmd/deck/cmd_serve.go
+++ b/cmd/deck/cmd_serve.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net"
 	"net/http"
 	"os"
 	"os/signal"
@@ -59,7 +60,7 @@ func executeServe(ctx context.Context, root string, addr string, auditMaxSizeMB 
 		}
 	}
 
-	h, err := server.NewHandler(resolvedRoot, server.HandlerOptions{AuditMaxSizeMB: auditMaxSizeMB, AuditMaxFiles: auditMaxFiles})
+	h, err := server.NewHandler(resolvedRoot, server.HandlerOptions{AuditMaxSizeMB: auditMaxSizeMB, AuditMaxFiles: auditMaxFiles, AccessLog: os.Stdout})
 	if err != nil {
 		return fmt.Errorf("init server handler: %w", err)
 	}
@@ -81,14 +82,12 @@ func executeServe(ctx context.Context, root string, addr string, auditMaxSizeMB 
 		}
 		errCh <- httpServer.ListenAndServe()
 	}()
-	if certPath != "" {
-		if err := stdoutPrintf("server start: listening on https://%s (root=%s)\n", resolvedAddr, resolvedRoot); err != nil {
-			return err
-		}
-	} else {
-		if err := stdoutPrintf("server start: listening on http://%s (root=%s)\n", resolvedAddr, resolvedRoot); err != nil {
-			return err
-		}
+	serverURL := displayServerURL(resolvedAddr, certPath != "")
+	if err := stdoutPrintf("server start: listening on %s (bind=%s root=%s)\n", serverURL, resolvedAddr, resolvedRoot); err != nil {
+		return err
+	}
+	if err := stdoutPrintf("open: %s/\n", strings.TrimRight(serverURL, "/")); err != nil {
+		return err
 	}
 	select {
 	case <-ctx.Done():
@@ -108,6 +107,38 @@ func executeServe(ctx context.Context, root string, addr string, auditMaxSizeMB 
 		}
 		return nil
 	}
+}
+
+func displayServerURL(addr string, tlsEnabled bool) string {
+	scheme := "http"
+	if tlsEnabled {
+		scheme = "https"
+	}
+	host, port := splitServerAddr(addr)
+	if host == "" || host == "0.0.0.0" || host == "::" || host == "[::]" {
+		host = "localhost"
+	}
+	if strings.Contains(host, ":") && !strings.HasPrefix(host, "[") {
+		host = "[" + host + "]"
+	}
+	if port == "" {
+		return fmt.Sprintf("%s://%s", scheme, host)
+	}
+	return fmt.Sprintf("%s://%s:%s", scheme, host, port)
+}
+
+func splitServerAddr(addr string) (string, string) {
+	trimmed := strings.TrimSpace(addr)
+	if trimmed == "" {
+		return "localhost", ""
+	}
+	if strings.HasPrefix(trimmed, ":") {
+		return "localhost", strings.TrimPrefix(trimmed, ":")
+	}
+	if host, port, err := net.SplitHostPort(trimmed); err == nil {
+		return host, port
+	}
+	return trimmed, ""
 }
 
 type healthReport struct {

--- a/cmd/deck/server_misc_cli_test.go
+++ b/cmd/deck/server_misc_cli_test.go
@@ -424,6 +424,28 @@ func TestRunServerAuditRotationFlagValidation(t *testing.T) {
 	}
 }
 
+func TestDisplayServerURL(t *testing.T) {
+	tests := []struct {
+		name string
+		addr string
+		tls  bool
+		want string
+	}{
+		{name: "default bind", addr: ":8080", want: "http://localhost:8080"},
+		{name: "wildcard host", addr: "0.0.0.0:9090", want: "http://localhost:9090"},
+		{name: "named host", addr: "example.test:9443", tls: true, want: "https://example.test:9443"},
+		{name: "ipv6 wildcard", addr: "[::]:8080", want: "http://localhost:8080"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := displayServerURL(tc.addr, tc.tls); got != tc.want {
+				t.Fatalf("unexpected display url\nwant: %q\ngot : %q", tc.want, got)
+			}
+		})
+	}
+}
+
 func TestRunLegacyTopLevelCommandsAreRemoved(t *testing.T) {
 	for _, cmd := range []string{"run", "resume", "diagnose", "agent", "workflow", "control", "strategy", "ManageService", "serve", "health", "logs"} {
 		t.Run(cmd, func(t *testing.T) {

--- a/internal/server/http.go
+++ b/internal/server/http.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"fmt"
+	"io"
 	"net/http"
 	"path/filepath"
 	"time"
@@ -10,6 +11,7 @@ import (
 type HandlerOptions struct {
 	AuditMaxSizeMB int
 	AuditMaxFiles  int
+	AccessLog      io.Writer
 }
 
 type serverHandler struct {
@@ -39,6 +41,7 @@ func NewHandler(root string, opts HandlerOptions) (http.Handler, error) {
 	}
 	h := &serverHandler{rootAbs: resolvedRoot, logger: logger}
 	h.base = http.HandlerFunc(h.routeRequest)
+	accessLog := opts.AccessLog
 
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		start := time.Now().UTC()
@@ -59,6 +62,7 @@ func NewHandler(root string, opts HandlerOptions) (http.Handler, error) {
 			"duration_ms": time.Since(start).Milliseconds(),
 		})
 		logger.Write(entry)
+		writeAccessLog(accessLog, start, r, rw)
 	}), nil
 }
 
@@ -68,4 +72,22 @@ func (h *serverHandler) handleHealthz(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	w.WriteHeader(http.StatusOK)
+}
+
+func writeAccessLog(w io.Writer, start time.Time, r *http.Request, rw *statusRecorder) {
+	if w == nil {
+		return
+	}
+	_, _ = fmt.Fprintf(
+		w,
+		"%s - [%s] \"%s %s %s\" %d %d %dms\n",
+		r.RemoteAddr,
+		start.UTC().Format(time.RFC3339),
+		r.Method,
+		r.URL.RequestURI(),
+		r.Proto,
+		rw.status,
+		rw.bytes,
+		time.Since(start).Milliseconds(),
+	)
 }

--- a/internal/server/http_audit.go
+++ b/internal/server/http_audit.go
@@ -38,7 +38,9 @@ const (
 
 type statusRecorder struct {
 	http.ResponseWriter
-	status int
+	status      int
+	wroteHeader bool
+	bytes       int64
 }
 
 func newAuditLogger(root string, opts auditLoggerOptions) (*auditLogger, error) {
@@ -139,5 +141,15 @@ func addExtra(entry map[string]any, extra map[string]any) {
 
 func (r *statusRecorder) WriteHeader(code int) {
 	r.status = code
+	r.wroteHeader = true
 	r.ResponseWriter.WriteHeader(code)
+}
+
+func (r *statusRecorder) Write(p []byte) (int, error) {
+	if !r.wroteHeader {
+		r.WriteHeader(http.StatusOK)
+	}
+	n, err := r.ResponseWriter.Write(p)
+	r.bytes += int64(n)
+	return n, err
 }

--- a/internal/server/http_test.go
+++ b/internal/server/http_test.go
@@ -432,6 +432,27 @@ func TestHealth(t *testing.T) {
 	}
 }
 
+func TestAccessLog(t *testing.T) {
+	root := t.TempDir()
+	var accessLog bytes.Buffer
+	h, err := NewHandler(root, HandlerOptions{AccessLog: &accessLog})
+	if err != nil {
+		t.Fatalf("NewHandler: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/healthz", nil)
+	req.RemoteAddr = "127.0.0.1:43210"
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+
+	line := strings.TrimSpace(accessLog.String())
+	for _, want := range []string{"127.0.0.1:43210", `"GET /healthz HTTP/1.1"`, " 200 ", " 0 ", "ms"} {
+		if !strings.Contains(line, want) {
+			t.Fatalf("expected %q in access log, got %q", want, line)
+		}
+	}
+}
+
 func TestHandlerRejectsLegacyPutUploads(t *testing.T) {
 	root := t.TempDir()
 	for _, category := range []string{"files", "packages", "images", "workflows"} {


### PR DESCRIPTION
## Summary
- print a browser-friendly URL when `deck server up` starts, including localhost fallbacks for wildcard bind addresses
- emit nginx-style access logs to stdout for each request while keeping the existing audit log entries
- add tests for the display URL helper and access-log output, and verify with `make test` and `make lint`