### PR TITLE
docs: expand guide links and server examples

### DIFF
--- a/docs/guides/offline-kubernetes.md
+++ b/docs/guides/offline-kubernetes.md
@@ -32,7 +32,7 @@ Use steps and phases to show what the procedure is doing. Typical boundaries in 
 - kubeadm bootstrap or join
 - verification
 
-Prefer typed steps where possible. `Command` is available for the edges that are not modeled yet.
+Prefer typed steps where possible. `Command` is available for the edges that are not modeled yet. For shared step fields such as `when`, `parallelGroup`, `register`, `metadata`, `retry`, and `timeout`, use the [Step Envelope Contract](../reference/workflow-model.md#step-envelope-contract).
 
 Useful group entrypoints for Kubernetes workflows:
 

--- a/docs/guides/quick-start.md
+++ b/docs/guides/quick-start.md
@@ -30,7 +30,7 @@ This creates a starter layout with two entry workflows and a prepared output tre
 
 Prefer typed steps. They make the procedure easier to read and lint as it grows.
 
-When choosing a step, start with [Typed Steps](../reference/typed-steps.md). For shared step fields such as `when`, `parallelGroup`, `register`, and `metadata`, use the [Step Envelope Contract](../reference/workflow-model.md#step-envelope-contract).
+When choosing a step, start with [Typed Steps](../reference/typed-steps.md). For shared step fields such as `when`, `parallelGroup`, `register`, `metadata`, `retry`, and `timeout`, use the [Step Envelope Contract](../reference/workflow-model.md#step-envelope-contract).
 
 ```yaml
 version: v1alpha1


### PR DESCRIPTION
## Summary
- add stronger guide cross-links into the updated typed-step and workflow reference structure
- document practical `server up` usage patterns and local `--var` testing examples in the quick-start and offline Kubernetes guides

## Verification
- git diff --check