### PR TITLE
refactor: consolidate ask metadata under askcontext

### DIFF
--- a/cmd/deck/cobra_ask_ai.go
+++ b/cmd/deck/cobra_ask_ai.go
@@ -8,8 +8,8 @@ import (
 
 	mcpaugment "github.com/Airgap-Castaways/deck/internal/askaugment/mcp"
 	"github.com/Airgap-Castaways/deck/internal/askcli"
-	"github.com/Airgap-Castaways/deck/internal/askcommandspec"
 	"github.com/Airgap-Castaways/deck/internal/askconfig"
+	"github.com/Airgap-Castaways/deck/internal/askcontext"
 	"github.com/Airgap-Castaways/deck/internal/askprovider"
 	openaiprovider "github.com/Airgap-Castaways/deck/internal/askprovider/openai"
 	"github.com/Airgap-Castaways/deck/internal/workspacepaths"
@@ -31,7 +31,7 @@ func newAskCommand() *cobra.Command {
 	var provider string
 	var model string
 	var endpoint string
-	spec := askcommandspec.Current()
+	spec := askcontext.CurrentCommandSpec()
 
 	cmd := &cobra.Command{
 		Use:   spec.Root.Use,
@@ -98,7 +98,7 @@ func newAskPlanCommand() *cobra.Command {
 	var provider string
 	var model string
 	var endpoint string
-	spec := askcommandspec.Current()
+	spec := askcontext.CurrentCommandSpec()
 	cmd := &cobra.Command{
 		Use:   spec.Plan.Use,
 		Short: spec.Plan.Short,
@@ -139,8 +139,8 @@ func newAskPlanCommand() *cobra.Command {
 
 func newAskConfigCommand() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   askcommandspec.Current().Config.Use,
-		Short: askcommandspec.Current().Config.Short,
+		Use:   askcontext.CurrentCommandSpec().Config.Use,
+		Short: askcontext.CurrentCommandSpec().Config.Short,
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			return cmd.Help()

--- a/docs/core-concepts/architecture.md
+++ b/docs/core-concepts/architecture.md
@@ -223,6 +223,8 @@ For authoring routes, the intended shape is route classification first, clarify 
 
 The important architectural boundary is that ask may project canonical facts for prompting and assembly, but it should not own a second copy of step validity, field enums, or workspace path rules.
 
+At the code level, `internal/askcontext` is the main home for those canonical ask facts: command metadata, prompt/source-of-truth bundles, and schema-derived authoring context live there, while orchestration stays in `internal/askcli`. That split keeps the metadata surface easier to discover without changing ask behavior.
+
 ## Site-local helper model
 
 When a site needs a shared local source inside the air gap, `deck server` can expose prepared bundle content and audit what it serves. That helper remains secondary to the core local execution path.

--- a/internal/askcli/generation.go
+++ b/internal/askcli/generation.go
@@ -5,11 +5,11 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/Airgap-Castaways/deck/internal/askcontext"
 	"github.com/Airgap-Castaways/deck/internal/askcontract"
 	"github.com/Airgap-Castaways/deck/internal/askdiagnostic"
 	"github.com/Airgap-Castaways/deck/internal/askintent"
 	"github.com/Airgap-Castaways/deck/internal/askir"
-	"github.com/Airgap-Castaways/deck/internal/askknowledge"
 	"github.com/Airgap-Castaways/deck/internal/askprovider"
 	"github.com/Airgap-Castaways/deck/internal/askrepair"
 	"github.com/Airgap-Castaways/deck/internal/askretrieve"
@@ -23,7 +23,7 @@ func generateWithValidation(ctx context.Context, client askprovider.Client, req 
 	var lastJudge askcontract.JudgeResponse
 	var lastFiles []askcontract.GeneratedFile
 	taintedFiles := map[string]bool{}
-	bundle := askknowledge.Current()
+	bundle := askcontext.CurrentBundle()
 	for attempt := 1; attempt <= attempts; attempt++ {
 		currentPrompt := req.Prompt
 		currentSystemPrompt := req.SystemPrompt

--- a/internal/askcli/plan.go
+++ b/internal/askcli/plan.go
@@ -13,7 +13,6 @@ import (
 	"github.com/Airgap-Castaways/deck/internal/askcontext"
 	"github.com/Airgap-Castaways/deck/internal/askcontract"
 	"github.com/Airgap-Castaways/deck/internal/askintent"
-	"github.com/Airgap-Castaways/deck/internal/askknowledge"
 	"github.com/Airgap-Castaways/deck/internal/askpolicy"
 	"github.com/Airgap-Castaways/deck/internal/askprovider"
 	"github.com/Airgap-Castaways/deck/internal/askretrieve"
@@ -60,7 +59,7 @@ func explicitClusterTopology(prompt string) bool {
 
 func planSystemPrompt(decision askintent.Decision, retrieval askretrieve.RetrievalResult, prompt string, workspace askretrieve.WorkspaceSummary) string {
 	requirements := askpolicy.BuildRequirementsForPrompt(prompt, retrieval, workspace, decision.Route)
-	bundle := askknowledge.Current()
+	bundle := askcontext.CurrentBundle()
 	b := &strings.Builder{}
 	b.WriteString("You are deck ask planner. Return strict JSON only.\n")
 	b.WriteString("JSON shape: {\"version\":number,\"request\":string,\"intent\":string,\"complexity\":string,\"authoringBrief\":{\"routeIntent\":string,\"targetScope\":string,\"targetPaths\":[],\"anchorPaths\":[],\"allowedCompanionPaths\":[],\"disallowedExpansionPaths\":[],\"modeIntent\":string,\"connectivity\":string,\"completenessTarget\":string,\"topology\":string,\"nodeCount\":number,\"platformFamily\":string,\"requiredCapabilities\":[]},\"authoringProgram\":{\"platform\":{\"family\":string,\"release\":string,\"repoType\":string,\"backendImage\":string},\"artifacts\":{\"packages\":[],\"images\":[],\"packageOutputDir\":string,\"imageOutputDir\":string},\"cluster\":{\"joinFile\":string,\"podCIDR\":string,\"kubernetesVersion\":string,\"criSocket\":string,\"roleSelector\":string,\"controlPlaneCount\":number,\"workerCount\":number},\"verification\":{\"expectedNodeCount\":number,\"expectedReadyCount\":number,\"expectedControlPlaneReady\":number,\"finalVerificationRole\":string,\"interval\":string,\"timeout\":string}},\"executionModel\":{\"artifactContracts\":[{\"kind\":string,\"producerPath\":string,\"consumerPath\":string,\"description\":string}],\"sharedStateContracts\":[{\"name\":string,\"producerPath\":string,\"consumerPaths\":[],\"availabilityModel\":string,\"description\":string}],\"roleExecution\":{\"roleSelector\":string,\"controlPlaneFlow\":string,\"workerFlow\":string,\"perNodeInvocation\":boolean},\"verification\":{\"bootstrapPhase\":string,\"finalPhase\":string,\"expectedNodeCount\":number,\"expectedControlPlaneReady\":number},\"applyAssumptions\":[]},\"offlineAssumption\":string,\"needsPrepare\":boolean,\"artifactKinds\":[],\"varsRecommendation\":[],\"componentRecommendation\":[],\"blockers\":[],\"targetOutcome\":string,\"assumptions\":[],\"openQuestions\":[],\"clarifications\":[{\"id\":string,\"question\":string,\"kind\":string,\"reason\":string,\"decision\":string,\"options\":[],\"recommendedDefault\":string,\"answer\":string,\"blocksGeneration\":boolean,\"affects\":[]}],\"entryScenario\":string,\"files\":[{\"path\":string,\"kind\":string,\"action\":string,\"purpose\":string}],\"validationChecklist\":[]}.\n")

--- a/internal/askcli/prompts_generation.go
+++ b/internal/askcli/prompts_generation.go
@@ -10,7 +10,6 @@ import (
 	"github.com/Airgap-Castaways/deck/internal/askdraft"
 	"github.com/Airgap-Castaways/deck/internal/askintent"
 	"github.com/Airgap-Castaways/deck/internal/askir"
-	"github.com/Airgap-Castaways/deck/internal/askknowledge"
 	"github.com/Airgap-Castaways/deck/internal/askpolicy"
 	"github.com/Airgap-Castaways/deck/internal/askrefine"
 	"github.com/Airgap-Castaways/deck/internal/askretrieve"
@@ -60,7 +59,7 @@ func classifierUserPrompt(prompt string, reviewFlag bool, workspace askretrieve.
 }
 
 func generationSystemPrompt(route askintent.Route, target askintent.Target, requestText string, retrieval askretrieve.RetrievalResult, requirements askpolicy.ScenarioRequirements, plan askcontract.PlanResponse, brief askcontract.AuthoringBrief, executionModel askcontract.ExecutionModel, scaffold askscaffold.Scaffold) string {
-	bundle := askknowledge.Current()
+	bundle := askcontext.CurrentBundle()
 	b := &strings.Builder{}
 	b.WriteString("You are deck ask, a workflow authoring assistant.\n")
 	b.WriteString("Route: ")

--- a/internal/askcli/service.go
+++ b/internal/askcli/service.go
@@ -10,10 +10,10 @@ import (
 
 	mcpaugment "github.com/Airgap-Castaways/deck/internal/askaugment/mcp"
 	"github.com/Airgap-Castaways/deck/internal/askconfig"
+	"github.com/Airgap-Castaways/deck/internal/askcontext"
 	"github.com/Airgap-Castaways/deck/internal/askcontract"
 	"github.com/Airgap-Castaways/deck/internal/askhooks"
 	"github.com/Airgap-Castaways/deck/internal/askintent"
-	"github.com/Airgap-Castaways/deck/internal/askknowledge"
 	"github.com/Airgap-Castaways/deck/internal/askpolicy"
 	"github.com/Airgap-Castaways/deck/internal/askprovider"
 	"github.com/Airgap-Castaways/deck/internal/askretrieve"
@@ -182,7 +182,7 @@ func Execute(ctx context.Context, opts Options, client askprovider.Client) error
 	retrieval := askretrieve.Retrieve(decision.Route, requestText, decision.Target, workspace, state, externalChunks)
 	requirements := askpolicy.BuildScenarioRequirements(requestText, retrieval, workspace, decision)
 	authoringBrief := askpolicy.BriefFromRequirements(requirements, decision)
-	bundle := askknowledge.Current()
+	bundle := askcontext.CurrentBundle()
 	result := runResult{
 		Route:         decision.Route,
 		Target:        decision.Target,

--- a/internal/askcli/service_test.go
+++ b/internal/askcli/service_test.go
@@ -17,7 +17,6 @@ import (
 	"github.com/Airgap-Castaways/deck/internal/askdiagnostic"
 	"github.com/Airgap-Castaways/deck/internal/askintent"
 	"github.com/Airgap-Castaways/deck/internal/askir"
-	"github.com/Airgap-Castaways/deck/internal/askknowledge"
 	"github.com/Airgap-Castaways/deck/internal/askpolicy"
 	"github.com/Airgap-Castaways/deck/internal/askprovider"
 	"github.com/Airgap-Castaways/deck/internal/askretrieve"
@@ -1040,7 +1039,7 @@ func TestAskLoggerDebugAndTrace(t *testing.T) {
 
 func TestGenerationSystemPromptIncludesAskContextBlocks(t *testing.T) {
 	req := askpolicy.ScenarioRequirements{Connectivity: "offline", RequiredFiles: []string{"workflows/scenarios/apply.yaml"}}
-	scaffold := askscaffold.Build(req, askretrieve.WorkspaceSummary{}, askintent.Decision{Route: askintent.RouteDraft}, askcontract.PlanResponse{}, askknowledge.Current())
+	scaffold := askscaffold.Build(req, askretrieve.WorkspaceSummary{}, askintent.Decision{Route: askintent.RouteDraft}, askcontract.PlanResponse{}, askcontext.CurrentBundle())
 	retrieval := askretrieve.RetrievalResult{Chunks: []askretrieve.Chunk{{ID: "facts-1", Source: "local-facts", Label: "source-of-truth-stepmeta", Topic: "local-facts:stepmeta", Content: "Local facts:\n- path: internal/stepmeta/registry.go", Score: 91}, {ID: "example-1", Source: "example", Label: "test/workflows/scenarios/kubeadm.yaml", Content: "Reference example:\n- path: test/workflows/scenarios/kubeadm.yaml\nversion: v1alpha1\nsteps:\n  - id: init\n    kind: InitKubeadm\n", Score: 90}, {ID: "workspace-apply", Source: "workspace", Label: "workflows/scenarios/apply.yaml", Content: "version: v1alpha1\nsteps:\n  - id: join\n    kind: JoinKubeadm\n", Score: 80}, {ID: "mcp-1", Source: "mcp", Label: "web-search:kubernetes.io", Topic: "mcp:web-search:kubernetes.io", Content: "Typed MCP evidence JSON:\n{}", Score: 75, Evidence: &askretrieve.EvidenceSummary{Title: "Installing kubeadm", Domain: "kubernetes.io", DomainCategory: "official-docs", Freshness: "external-docs", Official: true, TrustLevel: "high"}}, {ID: "typed-steps-draft", Source: "askcontext", Topic: askcontext.TopicTypedSteps, Label: "typed-steps", Content: "typed guidance", Score: 70}}}
 	prompt := generationSystemPrompt(askintent.RouteDraft, askintent.Target{Kind: "workspace"}, "create an air-gapped 3-node kubeadm workflow", retrieval, req, askcontract.PlanResponse{}, askcontract.AuthoringBrief{ModeIntent: "prepare+apply", Connectivity: "offline", CompletenessTarget: "starter", Topology: "multi-node", RequiredCapabilities: []string{"kubeadm-join", "cluster-verification"}}, askcontract.ExecutionModel{ArtifactContracts: []askcontract.ArtifactContract{{Kind: "package", ProducerPath: "workflows/prepare.yaml", ConsumerPath: "workflows/scenarios/apply.yaml", Description: "offline package flow"}}, SharedStateContracts: []askcontract.SharedStateContract{{Name: "join-file", ProducerPath: "/tmp/deck/join.txt", ConsumerPaths: []string{"/tmp/deck/join.txt"}, AvailabilityModel: "published-for-worker-consumption"}}, RoleExecution: askcontract.RoleExecutionModel{RoleSelector: "vars.role", ControlPlaneFlow: "bootstrap", WorkerFlow: "join", PerNodeInvocation: true}, Verification: askcontract.VerificationStrategy{FinalVerificationRole: "control-plane", ExpectedNodeCount: 3, ExpectedControlPlaneReady: 1}, ApplyAssumptions: []string{"apply consumes local artifacts"}}, scaffold)
 	for _, want := range []string{"Workflow source-of-truth:", "Authoring policy from deck metadata:", "Validated scaffold:", "Return structured workflow documents, not final YAML text.", "JSON shape: {\"summary\":string,\"review\":[]string,\"selection\":", "Evidence boundaries:", "Local facts are authoritative for deck workflow validity", "External evidence is only for upstream product behavior", "Do not let external docs override local deck workflow truth", "external source: Installing kubeadm [domain=kubernetes.io, category=official-docs, freshness=external-docs, official=true, trust=high]"} {
@@ -1107,7 +1106,7 @@ func TestGenerationRetrievalPromptBlockSeparatesLocalFactsAndExternalEvidence(t 
 
 func TestGenerationSystemPromptUsesStructuredDocumentResponseShape(t *testing.T) {
 	req := askpolicy.ScenarioRequirements{Connectivity: "unspecified", RequiredFiles: []string{"workflows/prepare.yaml"}, NeedsPrepare: true}
-	scaffold := askscaffold.Build(req, askretrieve.WorkspaceSummary{}, askintent.Decision{Route: askintent.RouteDraft, Target: askintent.Target{Kind: "scenario", Path: "workflows/prepare.yaml"}}, askcontract.PlanResponse{}, askknowledge.Current())
+	scaffold := askscaffold.Build(req, askretrieve.WorkspaceSummary{}, askintent.Decision{Route: askintent.RouteDraft, Target: askintent.Target{Kind: "scenario", Path: "workflows/prepare.yaml"}}, askcontract.PlanResponse{}, askcontext.CurrentBundle())
 	prompt := generationSystemPrompt(askintent.RouteDraft, askintent.Target{Kind: "scenario", Path: "workflows/prepare.yaml"}, "create a prepare workflow using DownloadFile and default output location", askretrieve.RetrievalResult{}, req, askcontract.PlanResponse{}, askcontract.AuthoringBrief{ModeIntent: "prepare-only", CompletenessTarget: "complete"}, askcontract.ExecutionModel{}, scaffold)
 	for _, want := range []string{"JSON shape: {\"summary\":string,\"review\":[]string,\"selection\":", "Return structured workflow documents, not final YAML text.", "Keep document structure schema-focused:"} {
 		if !strings.Contains(prompt, want) {
@@ -1118,7 +1117,7 @@ func TestGenerationSystemPromptUsesStructuredDocumentResponseShape(t *testing.T)
 
 func TestGenerationSystemPromptOmitsTypedStepCandidateBlocks(t *testing.T) {
 	req := askpolicy.ScenarioRequirements{Connectivity: "offline", RequiredFiles: []string{"workflows/scenarios/apply.yaml"}}
-	scaffold := askscaffold.Build(req, askretrieve.WorkspaceSummary{}, askintent.Decision{Route: askintent.RouteDraft}, askcontract.PlanResponse{}, askknowledge.Current())
+	scaffold := askscaffold.Build(req, askretrieve.WorkspaceSummary{}, askintent.Decision{Route: askintent.RouteDraft}, askcontract.PlanResponse{}, askcontext.CurrentBundle())
 	prompt := generationSystemPrompt(askintent.RouteDraft, askintent.Target{Kind: "workspace"}, "create an air-gapped rhel9 single-node kubeadm workflow", askretrieve.RetrievalResult{}, req, askcontract.PlanResponse{}, askcontract.AuthoringBrief{ModeIntent: "apply-only", Connectivity: "offline", CompletenessTarget: "starter", Topology: "single-node", RequiredCapabilities: []string{"kubeadm-bootstrap", "cluster-verification"}}, askcontract.ExecutionModel{}, scaffold)
 	for _, avoid := range []string{"Candidate typed steps you may choose from:", "These are hints, not required selections."} {
 		if strings.Contains(prompt, avoid) {
@@ -1134,7 +1133,7 @@ func TestGenerationSystemPromptOmitsTypedStepCandidateBlocks(t *testing.T) {
 
 func TestGenerationSystemPromptCarriesWorkflowStepIDUniquenessRule(t *testing.T) {
 	req := askpolicy.ScenarioRequirements{Connectivity: "offline", RequiredFiles: []string{"workflows/prepare.yaml", "workflows/scenarios/apply.yaml"}, NeedsPrepare: true}
-	scaffold := askscaffold.Build(req, askretrieve.WorkspaceSummary{}, askintent.Decision{Route: askintent.RouteDraft}, askcontract.PlanResponse{}, askknowledge.Current())
+	scaffold := askscaffold.Build(req, askretrieve.WorkspaceSummary{}, askintent.Decision{Route: askintent.RouteDraft}, askcontract.PlanResponse{}, askcontext.CurrentBundle())
 	prompt := generationSystemPrompt(askintent.RouteDraft, askintent.Target{Kind: "workspace"}, "create a 3-node workflow", askretrieve.RetrievalResult{}, req, askcontract.PlanResponse{}, askcontract.AuthoringBrief{ModeIntent: "prepare+apply", CompletenessTarget: "complete"}, askcontract.ExecutionModel{}, scaffold)
 	for _, want := range []string{"Every step id must be unique across top-level steps and steps nested under phases.", "Rename duplicate step ids with role- or phase-specific prefixes instead of reusing the same id."} {
 		if !strings.Contains(prompt, want) {
@@ -1145,7 +1144,7 @@ func TestGenerationSystemPromptCarriesWorkflowStepIDUniquenessRule(t *testing.T)
 
 func TestGenerationSystemPromptPrefersInlineFirstForComplexWorkspaceDrafts(t *testing.T) {
 	req := askpolicy.ScenarioRequirements{Connectivity: "offline", RequiredFiles: []string{"workflows/prepare.yaml", "workflows/scenarios/apply.yaml"}, NeedsPrepare: true}
-	scaffold := askscaffold.Build(req, askretrieve.WorkspaceSummary{}, askintent.Decision{Route: askintent.RouteDraft}, askcontract.PlanResponse{}, askknowledge.Current())
+	scaffold := askscaffold.Build(req, askretrieve.WorkspaceSummary{}, askintent.Decision{Route: askintent.RouteDraft}, askcontract.PlanResponse{}, askcontext.CurrentBundle())
 	prompt := generationSystemPrompt(askintent.RouteDraft, askintent.Target{Kind: "workspace"}, "create an air-gapped 3-node kubeadm workflow", askretrieve.RetrievalResult{}, req, askcontract.PlanResponse{}, askcontract.AuthoringBrief{ModeIntent: "prepare+apply", Connectivity: "offline", CompletenessTarget: "complete", Topology: "multi-node"}, askcontract.ExecutionModel{}, scaffold)
 	for _, want := range []string{"prefer a first schema-valid inline result", "extract `workflows/components/` only when reuse is explicit"} {
 		if !strings.Contains(prompt, want) {
@@ -1156,7 +1155,7 @@ func TestGenerationSystemPromptPrefersInlineFirstForComplexWorkspaceDrafts(t *te
 
 func TestGenerationSystemPromptPrefersSelectionForDrafts(t *testing.T) {
 	req := askpolicy.ScenarioRequirements{Connectivity: "offline", RequiredFiles: []string{"workflows/scenarios/apply.yaml"}}
-	scaffold := askscaffold.Build(req, askretrieve.WorkspaceSummary{}, askintent.Decision{Route: askintent.RouteDraft}, askcontract.PlanResponse{}, askknowledge.Current())
+	scaffold := askscaffold.Build(req, askretrieve.WorkspaceSummary{}, askintent.Decision{Route: askintent.RouteDraft}, askcontract.PlanResponse{}, askcontext.CurrentBundle())
 	prompt := generationSystemPrompt(askintent.RouteDraft, askintent.Target{Kind: "workspace"}, "create a simple apply workflow", askretrieve.RetrievalResult{}, req, askcontract.PlanResponse{}, askcontract.AuthoringBrief{ModeIntent: "apply-only", CompletenessTarget: "starter"}, askcontract.ExecutionModel{}, scaffold)
 	for _, want := range []string{"selection.targets[].builders", "Do not author arbitrary typed step specs on the primary draft path", "selection.targets"} {
 		if !strings.Contains(prompt, want) {
@@ -1168,7 +1167,7 @@ func TestGenerationSystemPromptPrefersSelectionForDrafts(t *testing.T) {
 func TestGenerationSystemPromptUsesRefineDocumentActions(t *testing.T) {
 	req := askpolicy.ScenarioRequirements{Connectivity: "offline", AcceptanceLevel: "refine", RequiredFiles: []string{"workflows/scenarios/apply.yaml"}}
 	workspace := askretrieve.WorkspaceSummary{HasWorkflowTree: true, Files: []askretrieve.WorkspaceFile{{Path: "workflows/scenarios/apply.yaml", Content: "version: v1alpha1\nsteps:\n  - id: run\n    kind: Command\n    spec:\n      command: [true]\n"}}}
-	scaffold := askscaffold.Build(req, workspace, askintent.Decision{Route: askintent.RouteRefine}, askcontract.PlanResponse{}, askknowledge.Current())
+	scaffold := askscaffold.Build(req, workspace, askintent.Decision{Route: askintent.RouteRefine}, askcontract.PlanResponse{}, askcontext.CurrentBundle())
 	plan := askcontract.PlanResponse{AuthoringBrief: askcontract.AuthoringBrief{TargetPaths: []string{"workflows/scenarios/apply.yaml"}, TargetScope: "scenario"}}
 	systemPrompt := generationSystemPrompt(askintent.RouteRefine, askintent.Target{Kind: "workspace"}, "refine the apply workflow to add a timeout", askretrieve.RetrievalResult{}, req, plan, askcontract.AuthoringBrief{ModeIntent: "apply-only", CompletenessTarget: "refine", TargetPaths: []string{"workflows/scenarios/apply.yaml"}, TargetScope: "scenario"}, askcontract.ExecutionModel{}, scaffold)
 	userPrompt := generationUserPrompt(workspace, askstate.Context{}, "refine the apply workflow to add a timeout", "", askintent.RouteRefine, plan)
@@ -1191,7 +1190,7 @@ func TestGenerationSystemPromptAddsVarsTransformHintsForRefine(t *testing.T) {
 		VarsRecommendation: []string{"Use workflows/vars.yaml for repeated values."},
 		AuthoringBrief:     askcontract.AuthoringBrief{TargetScope: "workspace", TargetPaths: []string{"workflows/scenarios/control-plane-bootstrap.yaml", "workflows/vars.yaml"}, ModeIntent: "apply-only", CompletenessTarget: "refine"},
 	}
-	scaffold := askscaffold.Build(req, workspace, askintent.Decision{Route: askintent.RouteRefine}, plan, askknowledge.Current())
+	scaffold := askscaffold.Build(req, workspace, askintent.Decision{Route: askintent.RouteRefine}, plan, askcontext.CurrentBundle())
 	prompt := generationSystemPrompt(askintent.RouteRefine, askintent.Target{Kind: "scenario", Path: "workflows/scenarios/control-plane-bootstrap.yaml"}, "refactor workflows/scenarios/control-plane-bootstrap.yaml to use workflows/vars.yaml for repeated values", askretrieve.RetrievalResult{}, req, plan, plan.AuthoringBrief, askcontract.ExecutionModel{}, scaffold)
 	for _, want := range []string{"Refine transform contract:", "Approved target paths: workflows/scenarios/control-plane-bootstrap.yaml, workflows/vars.yaml", "update the scenario file and vars file together as one transform", "For `extract-var`, put the variable key in `varName`.", "Only extract values into workflows/vars.yaml when they are explicitly recommended or genuinely repeated.", "vars advisory:"} {
 		if !strings.Contains(prompt, want) {
@@ -1333,7 +1332,7 @@ func TestGenerationSystemPromptAddsComponentTransformHintsForRefine(t *testing.T
 	req := askpolicy.ScenarioRequirements{AcceptanceLevel: "refine", RequiredFiles: []string{"workflows/scenarios/control-plane-bootstrap.yaml", "workflows/components/bootstrap.yaml"}}
 	workspace := askretrieve.WorkspaceSummary{HasWorkflowTree: true}
 	plan := askcontract.PlanResponse{ComponentRecommendation: []string{"Consider workflows/components/ for reusable repeated logic across phases or scenarios."}, AuthoringBrief: askcontract.AuthoringBrief{TargetScope: "workspace", TargetPaths: []string{"workflows/scenarios/control-plane-bootstrap.yaml", "workflows/components/bootstrap.yaml"}, ModeIntent: "apply-only", CompletenessTarget: "refine"}}
-	scaffold := askscaffold.Build(req, workspace, askintent.Decision{Route: askintent.RouteRefine}, plan, askknowledge.Current())
+	scaffold := askscaffold.Build(req, workspace, askintent.Decision{Route: askintent.RouteRefine}, plan, askcontext.CurrentBundle())
 	prompt := generationSystemPrompt(askintent.RouteRefine, askintent.Target{Kind: "scenario", Path: "workflows/scenarios/control-plane-bootstrap.yaml"}, "extract reusable bootstrap logic into workflows/components/", askretrieve.RetrievalResult{}, req, plan, plan.AuthoringBrief, askcontract.ExecutionModel{}, scaffold)
 	for _, want := range []string{"extract-component", "component advisory:", "moving inline phase steps into workflows/components/ while preserving the scenario phase layout"} {
 		if !strings.Contains(prompt, want) {
@@ -1380,7 +1379,7 @@ func TestPromptAndDocsShareSchemaRuleSummaryForDownloadFile(t *testing.T) {
 	page := testSchemaDocGroupPageInput(t, "artifact-staging")
 	rendered := string(schemadoc.RenderGroupPage(page))
 	req := askpolicy.ScenarioRequirements{Connectivity: "unspecified", RequiredFiles: []string{"workflows/prepare.yaml"}, NeedsPrepare: true}
-	scaffold := askscaffold.Build(req, askretrieve.WorkspaceSummary{}, askintent.Decision{Route: askintent.RouteDraft, Target: askintent.Target{Kind: "scenario", Path: "workflows/prepare.yaml"}}, askcontract.PlanResponse{}, askknowledge.Current())
+	scaffold := askscaffold.Build(req, askretrieve.WorkspaceSummary{}, askintent.Decision{Route: askintent.RouteDraft, Target: askintent.Target{Kind: "scenario", Path: "workflows/prepare.yaml"}}, askcontract.PlanResponse{}, askcontext.CurrentBundle())
 	prompt := generationSystemPrompt(askintent.RouteDraft, askintent.Target{Kind: "scenario", Path: "workflows/prepare.yaml"}, "create a prepare workflow using DownloadFile", askretrieve.RetrievalResult{}, req, askcontract.PlanResponse{}, askcontract.AuthoringBrief{ModeIntent: "prepare-only", CompletenessTarget: "complete"}, askcontract.ExecutionModel{}, scaffold)
 	rule := "At least one of `spec.source` or `spec.items` must be set."
 	if !strings.Contains(rendered, rule) {

--- a/internal/askcontext/bundle.go
+++ b/internal/askcontext/bundle.go
@@ -1,4 +1,4 @@
-package askknowledge
+package askcontext
 
 import (
 	"fmt"
@@ -7,8 +7,6 @@ import (
 	"sync"
 
 	"github.com/Airgap-Castaways/deck/internal/askcatalog"
-	"github.com/Airgap-Castaways/deck/internal/askcontext"
-	"github.com/Airgap-Castaways/deck/internal/stepmeta"
 )
 
 type Bundle struct {
@@ -76,9 +74,9 @@ type StepKnowledge struct {
 	AllowedRoles             []string
 	Outputs                  []string
 	Example                  string
-	KeyFields                []askcontext.StepFieldContext
+	KeyFields                []StepFieldContext
 	SchemaRuleSummaries      []string
-	ConstrainedLiteralFields []askcontext.ConstrainedFieldHint
+	ConstrainedLiteralFields []ConstrainedFieldHint
 }
 
 type ConstraintKnowledge struct {
@@ -94,7 +92,7 @@ var (
 	bundleData Bundle
 )
 
-func Current() Bundle {
+func CurrentBundle() Bundle {
 	bundleOnce.Do(func() {
 		bundleData = buildBundle()
 	})
@@ -157,7 +155,7 @@ func buildBundle() Bundle {
 			Outputs:                  append([]string(nil), step.Outputs...),
 			KeyFields:                stepFieldContexts(step),
 			SchemaRuleSummaries:      append([]string(nil), step.RuleSummaries...),
-			ConstrainedLiteralFields: constrainedFieldHints(step.ConstrainedLiteralFields),
+			ConstrainedLiteralFields: constrainedLiteralFields(step.ConstrainedLiteralFields),
 		})
 		for _, field := range step.ConstrainedLiteralFields {
 			bundle.Constraints = append(bundle.Constraints, ConstraintKnowledge{
@@ -177,38 +175,6 @@ func buildBundle() Bundle {
 		return bundle.Constraints[i].StepKind < bundle.Constraints[j].StepKind
 	})
 	return bundle
-}
-
-func stepFieldContexts(step askcatalog.Step) []askcontext.StepFieldContext {
-	keys := append([]string(nil), step.KeyFields...)
-	if len(keys) == 0 {
-		for path, field := range step.Fields {
-			if field.Requirement == "required" {
-				keys = append(keys, path)
-			}
-		}
-		sort.Strings(keys)
-		if len(keys) > 5 {
-			keys = keys[:5]
-		}
-	}
-	out := make([]askcontext.StepFieldContext, 0, len(keys))
-	for _, key := range keys {
-		field, ok := step.Fields[key]
-		if !ok {
-			continue
-		}
-		out = append(out, askcontext.StepFieldContext{Path: key, Description: field.Description, Example: field.Example, Requirement: string(field.Requirement)})
-	}
-	return out
-}
-
-func constrainedFieldHints(items []stepmeta.ConstrainedLiteralField) []askcontext.ConstrainedFieldHint {
-	out := make([]askcontext.ConstrainedFieldHint, 0, len(items))
-	for _, item := range items {
-		out = append(out, askcontext.ConstrainedFieldHint{Path: item.Path, AllowedValues: append([]string(nil), item.AllowedValues...), Guidance: item.Guidance})
-	}
-	return out
 }
 
 func (b Bundle) WorkflowPromptBlock() string {

--- a/internal/askcontext/bundle_test.go
+++ b/internal/askcontext/bundle_test.go
@@ -1,12 +1,12 @@
-package askknowledge
+package askcontext
 
 import (
 	"strings"
 	"testing"
 )
 
-func TestCurrentIncludesComponentAndConstraintKnowledge(t *testing.T) {
-	bundle := Current()
+func TestCurrentBundleIncludesComponentAndConstraintKnowledge(t *testing.T) {
+	bundle := CurrentBundle()
 	if bundle.Components.FragmentExample == "" || !strings.Contains(bundle.Components.FragmentRule, "fragment") {
 		t.Fatalf("expected component fragment guidance, got %#v", bundle.Components)
 	}

--- a/internal/askcontext/cli.go
+++ b/internal/askcontext/cli.go
@@ -1,7 +1,5 @@
 package askcontext
 
-import "github.com/Airgap-Castaways/deck/internal/askcommandspec"
-
 type AskCommandMetadata struct {
 	Short  string
 	Plan   AskPlanCommandMetadata
@@ -20,7 +18,7 @@ type AskConfigCommandMetadata struct {
 }
 
 func AskCommandMeta() AskCommandMetadata {
-	spec := askcommandspec.Current()
+	spec := CurrentCommandSpec()
 	planFlags := make([]CLIFlag, 0, len(spec.Plan.Flags))
 	for _, flag := range spec.Plan.Flags {
 		planFlags = append(planFlags, CLIFlag{Name: flag.Name, Description: flag.Description})

--- a/internal/askcontext/cli_test.go
+++ b/internal/askcontext/cli_test.go
@@ -2,13 +2,11 @@ package askcontext
 
 import (
 	"testing"
-
-	"github.com/Airgap-Castaways/deck/internal/askcommandspec"
 )
 
 func TestAskCommandMetaMatchesSharedSpec(t *testing.T) {
 	meta := AskCommandMeta()
-	spec := askcommandspec.Current()
+	spec := CurrentCommandSpec()
 	if meta.Short != spec.Root.Short {
 		t.Fatalf("root short mismatch: %q != %q", meta.Short, spec.Root.Short)
 	}

--- a/internal/askcontext/command_spec.go
+++ b/internal/askcontext/command_spec.go
@@ -1,29 +1,24 @@
-package askcommandspec
+package askcontext
 
-type Flag struct {
-	Name        string
-	Description string
-}
-
-type Command struct {
+type CLICommandSpec struct {
 	Use   string
 	Short string
 	Long  string
-	Flags []Flag
+	Flags []CLIFlag
 }
 
-type Spec struct {
-	Root   Command
-	Plan   Command
-	Config Command
+type AskCommandSpec struct {
+	Root   CLICommandSpec
+	Plan   CLICommandSpec
+	Config CLICommandSpec
 }
 
-func Current() Spec {
-	return Spec{
-		Root: Command{
+func CurrentCommandSpec() AskCommandSpec {
+	return AskCommandSpec{
+		Root: CLICommandSpec{
 			Use:   "ask [request]",
 			Short: "(Experimental) AI helper for drafting and reviewing workflows",
-			Flags: []Flag{
+			Flags: []CLIFlag{
 				{Name: "--create", Description: "Treat the request as new workflow authoring."},
 				{Name: "--edit", Description: "Treat the request as workflow refinement."},
 				{Name: "--review", Description: "Review the current workspace without writing files."},
@@ -32,16 +27,19 @@ func Current() Spec {
 				{Name: "--plan-dir", Description: "Directory for ask plan artifacts."},
 			},
 		},
-		Plan: Command{
+		Plan: CLICommandSpec{
 			Use:   "plan [request]",
 			Short: "Generate an ask plan artifact without writing workflow files",
 			Long:  "Generate a reusable planning artifact under .deck/plan without writing workflow files. This mode is intended for draft/refine style authoring requests.",
-			Flags: []Flag{
+			Flags: []CLIFlag{
 				{Name: "--from", Description: "Load additional request details from a text or markdown file."},
 				{Name: "--plan-name", Description: "Optional plan artifact name."},
 				{Name: "--plan-dir", Description: "Directory for ask plan artifacts."},
 			},
 		},
-		Config: Command{Use: "config", Short: "Manage global ask config defaults and API credentials"},
+		Config: CLICommandSpec{
+			Use:   "config",
+			Short: "Manage global ask config defaults and API credentials",
+		},
 	}
 }

--- a/internal/askdiagnostic/diagnostic.go
+++ b/internal/askdiagnostic/diagnostic.go
@@ -7,8 +7,8 @@ import (
 	"strings"
 
 	"github.com/Airgap-Castaways/deck/internal/askcatalog"
+	"github.com/Airgap-Castaways/deck/internal/askcontext"
 	"github.com/Airgap-Castaways/deck/internal/askcontract"
-	"github.com/Airgap-Castaways/deck/internal/askknowledge"
 	"github.com/Airgap-Castaways/deck/internal/askpolicy"
 	"github.com/Airgap-Castaways/deck/internal/validate"
 	"github.com/Airgap-Castaways/deck/internal/workflowissues"
@@ -32,7 +32,7 @@ type Diagnostic struct {
 	SuggestedFix string   `json:"suggestedFix,omitempty"`
 }
 
-func FromValidationError(err error, message string, bundle askknowledge.Bundle) []Diagnostic {
+func FromValidationError(err error, message string, bundle askcontext.Bundle) []Diagnostic {
 	var validationErr *validate.ValidationError
 	if errors.As(err, &validationErr) {
 		structured := FromValidationIssues(validationErr.ValidationIssues())
@@ -317,16 +317,16 @@ func extractMissingPlannedFile(message string) (string, bool) {
 	return path, true
 }
 
-func findStep(bundle askknowledge.Bundle, kind string) (askknowledge.StepKnowledge, bool) {
+func findStep(bundle askcontext.Bundle, kind string) (askcontext.StepKnowledge, bool) {
 	for _, step := range bundle.Steps {
 		if step.Kind == strings.TrimSpace(kind) {
 			return step, true
 		}
 	}
-	return askknowledge.StepKnowledge{}, false
+	return askcontext.StepKnowledge{}, false
 }
 
-func renderKeyFieldList(step askknowledge.StepKnowledge) string {
+func renderKeyFieldList(step askcontext.StepKnowledge) string {
 	paths := make([]string, 0, len(step.KeyFields))
 	for _, field := range step.KeyFields {
 		if strings.TrimSpace(field.Path) != "" {
@@ -345,7 +345,7 @@ func renderKeyFieldList(step askknowledge.StepKnowledge) string {
 	return strings.Join(paths, ", ")
 }
 
-func renderRuleSummaryList(step askknowledge.StepKnowledge) string {
+func renderRuleSummaryList(step askcontext.StepKnowledge) string {
 	rules := make([]string, 0, len(step.SchemaRuleSummaries))
 	for _, rule := range step.SchemaRuleSummaries {
 		rule = strings.TrimSpace(rule)

--- a/internal/askdiagnostic/diagnostic_test.go
+++ b/internal/askdiagnostic/diagnostic_test.go
@@ -4,13 +4,13 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/Airgap-Castaways/deck/internal/askknowledge"
+	"github.com/Airgap-Castaways/deck/internal/askcontext"
 	"github.com/Airgap-Castaways/deck/internal/validate"
 	"github.com/Airgap-Castaways/deck/internal/workflowissues"
 )
 
 func TestFromValidationErrorDetectsComponentFragmentShape(t *testing.T) {
-	diags := FromValidationError(nil, "workflows/components/bootstrap.yaml: additional property version is not allowed", askknowledge.Current())
+	diags := FromValidationError(nil, "workflows/components/bootstrap.yaml: additional property version is not allowed", askcontext.CurrentBundle())
 	joined := JSON(diags)
 	if !strings.Contains(joined, "component_fragment_shape") {
 		t.Fatalf("expected component fragment diagnostic, got %s", joined)
@@ -27,7 +27,7 @@ func TestRepairPromptBlockIncludesStructuredJSON(t *testing.T) {
 }
 
 func TestFromValidationErrorSuggestsKnownStepFields(t *testing.T) {
-	diags := FromValidationError(nil, "E_SCHEMA_INVALID: step install-packages (InstallPackage): spec: Additional property sourceDir is not allowed", askknowledge.Current())
+	diags := FromValidationError(nil, "E_SCHEMA_INVALID: step install-packages (InstallPackage): spec: Additional property sourceDir is not allowed", askcontext.CurrentBundle())
 	joined := JSON(diags)
 	for _, want := range []string{"unknown_step_field", "spec.source", "InstallPackage"} {
 		if !strings.Contains(joined, want) {
@@ -37,7 +37,7 @@ func TestFromValidationErrorSuggestsKnownStepFields(t *testing.T) {
 }
 
 func TestFromValidationErrorSuggestsRequiredInitKubeadmField(t *testing.T) {
-	diags := FromValidationError(nil, "E_SCHEMA_INVALID: step init-cluster (InitKubeadm): spec: outputJoinFile is required", askknowledge.Current())
+	diags := FromValidationError(nil, "E_SCHEMA_INVALID: step init-cluster (InitKubeadm): spec: outputJoinFile is required", askcontext.CurrentBundle())
 	joined := JSON(diags)
 	for _, want := range []string{"missing_step_field", "spec.outputJoinFile", "InitKubeadm"} {
 		if !strings.Contains(joined, want) {
@@ -47,7 +47,7 @@ func TestFromValidationErrorSuggestsRequiredInitKubeadmField(t *testing.T) {
 }
 
 func TestFromValidationErrorSuggestsUniqueDuplicateStepIDs(t *testing.T) {
-	diags := FromValidationError(nil, "workflows/scenarios/apply.yaml: E_DUPLICATE_STEP_ID: preflight-host", askknowledge.Current())
+	diags := FromValidationError(nil, "workflows/scenarios/apply.yaml: E_DUPLICATE_STEP_ID: preflight-host", askcontext.CurrentBundle())
 	joined := JSON(diags)
 	for _, want := range []string{string(workflowissues.CodeDuplicateStepID), "Every step id must be unique across top-level steps and steps nested under phases.", "control-plane-preflight-host", "workflows/scenarios/apply.yaml"} {
 		if !strings.Contains(joined, want) {
@@ -58,7 +58,7 @@ func TestFromValidationErrorSuggestsUniqueDuplicateStepIDs(t *testing.T) {
 
 func TestFromValidationErrorPrefersStructuredIssues(t *testing.T) {
 	err := validationErrorWithIssues()
-	diags := FromValidationError(err, err.Error(), askknowledge.Current())
+	diags := FromValidationError(err, err.Error(), askcontext.CurrentBundle())
 	joined := JSON(diags)
 	for _, want := range []string{"missing_step_field", "spec.backend.image", "DownloadPackage", "package.download.schema.json"} {
 		if !strings.Contains(joined, want) {
@@ -68,7 +68,7 @@ func TestFromValidationErrorPrefersStructuredIssues(t *testing.T) {
 }
 
 func TestFromValidationErrorSuggestsSupportedDraftBuilders(t *testing.T) {
-	diags := FromValidationError(nil, `unsupported draft builder "prepare.check-host" for workflows/prepare.yaml`, askknowledge.Current())
+	diags := FromValidationError(nil, `unsupported draft builder "prepare.check-host" for workflows/prepare.yaml`, askcontext.CurrentBundle())
 	joined := JSON(diags)
 	for _, want := range []string{"unsupported_draft_builder", "prepare.download-package", "prepare.download-image", "workflows/prepare.yaml"} {
 		if !strings.Contains(joined, want) {

--- a/internal/askretrieve/retrieve.go
+++ b/internal/askretrieve/retrieve.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/Airgap-Castaways/deck/internal/askcontext"
 	"github.com/Airgap-Castaways/deck/internal/askintent"
-	"github.com/Airgap-Castaways/deck/internal/askknowledge"
 	"github.com/Airgap-Castaways/deck/internal/askstate"
 	"github.com/Airgap-Castaways/deck/internal/workspacepaths"
 )
@@ -185,7 +184,7 @@ func appendFactGroup(groups []factGroup, items ...factGroup) []factGroup {
 }
 
 func informationalFactChunks(route askintent.Route, prompt string) []Chunk {
-	bundle := askknowledge.Current()
+	bundle := askcontext.CurrentBundle()
 	switch route {
 	case askintent.RouteQuestion:
 		return []Chunk{{ID: "workflow-meta", Source: "askcontext", Label: "workflow-summary", Topic: askcontext.TopicWorkflowInvariants, Content: bundle.WorkflowPromptBlock(), Score: 50}}

--- a/internal/askscaffold/scaffold.go
+++ b/internal/askscaffold/scaffold.go
@@ -6,9 +6,9 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/Airgap-Castaways/deck/internal/askcontext"
 	"github.com/Airgap-Castaways/deck/internal/askcontract"
 	"github.com/Airgap-Castaways/deck/internal/askintent"
-	"github.com/Airgap-Castaways/deck/internal/askknowledge"
 	"github.com/Airgap-Castaways/deck/internal/askpattern"
 	"github.com/Airgap-Castaways/deck/internal/askpolicy"
 	"github.com/Airgap-Castaways/deck/internal/askretrieve"
@@ -39,7 +39,7 @@ type File struct {
 	SourceHint string
 }
 
-func Build(req askpolicy.ScenarioRequirements, workspace askretrieve.WorkspaceSummary, decision askintent.Decision, plan askcontract.PlanResponse, bundle askknowledge.Bundle) Scaffold {
+func Build(req askpolicy.ScenarioRequirements, workspace askretrieve.WorkspaceSummary, decision askintent.Decision, plan askcontract.PlanResponse, bundle askcontext.Bundle) Scaffold {
 	family := selectFamily(req, workspace, decision, plan)
 	scaffold := Scaffold{Family: family}
 	switch family {
@@ -82,7 +82,7 @@ func selectFamily(req askpolicy.ScenarioRequirements, workspace askretrieve.Work
 	return FamilyApplyOnly
 }
 
-func applyOnlyScaffold(req askpolicy.ScenarioRequirements, bundle askknowledge.Bundle) Scaffold {
+func applyOnlyScaffold(req askpolicy.ScenarioRequirements, bundle askcontext.Bundle) Scaffold {
 	files := []File{{
 		Path:     bundle.Topology.CanonicalApply,
 		Purpose:  "Primary apply entrypoint",
@@ -103,7 +103,7 @@ func applyOnlyScaffold(req askpolicy.ScenarioRequirements, bundle askknowledge.B
 	}
 }
 
-func offlineBundleScaffold(req askpolicy.ScenarioRequirements, bundle askknowledge.Bundle) Scaffold {
+func offlineBundleScaffold(req askpolicy.ScenarioRequirements, bundle askcontext.Bundle) Scaffold {
 	files := []File{
 		{Path: bundle.Topology.CanonicalPrepare, Purpose: "Prepare offline artifacts before apply", Locked: true, Template: "version: v1alpha1\nphases:\n  - name: collect\n    steps:\n      - id: TODO_PREPARE_STEP_ID\n        kind: TODO_PREPARE_TYPED_KIND\n        spec: {}\n"},
 		{Path: bundle.Topology.CanonicalApply, Purpose: "Consume prepared artifacts on the node", Locked: true, Template: "version: v1alpha1\nphases:\n  - name: apply\n    steps:\n      - id: install-packages\n        kind: InstallPackage\n        spec:\n          packages: []\n          source:\n            type: local-repo\n            path: TODO_LOCAL_REPO_PATH\n      - id: load-images\n        kind: LoadImage\n        spec:\n          sourceDir: TODO_LOCAL_IMAGE_DIR\n          runtime: ctr\n          images: []\n"},
@@ -128,7 +128,7 @@ func offlineBundleScaffold(req askpolicy.ScenarioRequirements, bundle askknowled
 	}
 }
 
-func kubeadmScaffold(req askpolicy.ScenarioRequirements, bundle askknowledge.Bundle) Scaffold {
+func kubeadmScaffold(req askpolicy.ScenarioRequirements, bundle askcontext.Bundle) Scaffold {
 	s := offlineBundleScaffold(req, bundle)
 	s.Family = FamilyBootstrap
 	s.Summary = "Cluster bootstrap starter scaffold with offline preparation and apply verification."
@@ -144,7 +144,7 @@ func kubeadmScaffold(req askpolicy.ScenarioRequirements, bundle askknowledge.Bun
 	return s
 }
 
-func kubeadmMultiNodeScaffold(req askpolicy.ScenarioRequirements, plan askcontract.PlanResponse, bundle askknowledge.Bundle) Scaffold {
+func kubeadmMultiNodeScaffold(req askpolicy.ScenarioRequirements, plan askcontract.PlanResponse, bundle askcontext.Bundle) Scaffold {
 	s := offlineBundleScaffold(req, bundle)
 	s.Family = FamilyRoleAware
 	s.Summary = "Role-aware prepare/apply scaffold with explicit bootstrap, join, and verification phases."

--- a/internal/askscaffold/scaffold_test.go
+++ b/internal/askscaffold/scaffold_test.go
@@ -4,9 +4,9 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/Airgap-Castaways/deck/internal/askcontext"
 	"github.com/Airgap-Castaways/deck/internal/askcontract"
 	"github.com/Airgap-Castaways/deck/internal/askintent"
-	"github.com/Airgap-Castaways/deck/internal/askknowledge"
 	"github.com/Airgap-Castaways/deck/internal/askpolicy"
 	"github.com/Airgap-Castaways/deck/internal/askretrieve"
 )
@@ -17,7 +17,7 @@ func TestBuildSelectsBootstrapScaffold(t *testing.T) {
 		askretrieve.WorkspaceSummary{},
 		askintent.Decision{Route: askintent.RouteDraft},
 		askcontract.PlanResponse{Request: "create kubeadm workflow"},
-		askknowledge.Current(),
+		askcontext.CurrentBundle(),
 	)
 	if scaffold.Family != FamilyBootstrap {
 		t.Fatalf("expected kubeadm scaffold, got %#v", scaffold)
@@ -33,7 +33,7 @@ func TestBuildSelectsRefineScaffoldForRefineRoute(t *testing.T) {
 		askretrieve.WorkspaceSummary{Files: []askretrieve.WorkspaceFile{{Path: "workflows/scenarios/apply.yaml", Content: "version: v1alpha1\nsteps: []\n"}}},
 		askintent.Decision{Route: askintent.RouteRefine},
 		askcontract.PlanResponse{Files: []askcontract.PlanFile{{Path: "workflows/scenarios/apply.yaml", Action: "update", Purpose: "entry"}}},
-		askknowledge.Current(),
+		askcontext.CurrentBundle(),
 	)
 	if scaffold.Family != FamilyRefine {
 		t.Fatalf("expected refine scaffold, got %#v", scaffold)
@@ -49,7 +49,7 @@ func TestBuildSelectsRoleAwareScaffold(t *testing.T) {
 		askretrieve.WorkspaceSummary{},
 		askintent.Decision{Route: askintent.RouteDraft},
 		askcontract.PlanResponse{Request: "create 3-node kubeadm workflow", AuthoringBrief: askcontract.AuthoringBrief{Topology: "multi-node", NodeCount: 3}},
-		askknowledge.Current(),
+		askcontext.CurrentBundle(),
 	)
 	if scaffold.Family != FamilyRoleAware {
 		t.Fatalf("expected multi-node kubeadm scaffold, got %#v", scaffold)


### PR DESCRIPTION
## Summary
- move the ask command spec and prompt/source-of-truth bundle ownership into `internal/askcontext` so canonical ask metadata lives in one obvious package
- update ask CLI, retrieval, diagnostic, and scaffold callers to consume `askcontext.CurrentCommandSpec()` and `askcontext.CurrentBundle()` without changing ask behavior
- document the new ask metadata ownership boundary in the architecture guide

## Testing
- go test ./internal/askcontext ./internal/askcli ./internal/askretrieve ./internal/askdiagnostic ./internal/askscaffold ./cmd/deck
- make test
- make lint

Closes #125