### PR TITLE
fix: preserve hosted E2E Docker env expansion

### DIFF
--- a/.github/e2e/hosted/fixtures/smoke/workflows/prepare.yaml
+++ b/.github/e2e/hosted/fixtures/smoke/workflows/prepare.yaml
@@ -10,5 +10,5 @@ phases:
           fetch:
             sources:
               - type: local
-                path: __FIXTURE_ROOT__/seed
+                path: seed
           outputPath: files/hosted-e2e/input.txt

--- a/.github/e2e/hosted/fixtures/smoke/workflows/prepare.yaml
+++ b/.github/e2e/hosted/fixtures/smoke/workflows/prepare.yaml
@@ -2,13 +2,21 @@ version: v1alpha1
 phases:
   - name: prepare
     steps:
-      - id: stage-hosted-input
+      - id: stage-hosted-assets
         kind: DownloadFile
         spec:
-          source:
-            path: files/input.txt
-          fetch:
-            sources:
-              - type: local
-                path: seed
-          outputPath: files/hosted-e2e/input.txt
+          items:
+            - source:
+                path: files/input.txt
+              fetch:
+                sources:
+                  - type: local
+                    path: seed
+              outputPath: files/hosted-e2e/input.txt
+            - source:
+                path: files/archive.tgz
+              fetch:
+                sources:
+                  - type: local
+                    path: seed
+              outputPath: files/hosted-e2e/archive.tgz

--- a/.github/e2e/hosted/fixtures/smoke/workflows/scenarios/apply.yaml
+++ b/.github/e2e/hosted/fixtures/smoke/workflows/scenarios/apply.yaml
@@ -3,11 +3,18 @@ phases:
   - name: install
     steps:
       - id: refresh-apt-cache
-        when: vars.installPackages == "true"
+        when: vars.installPackages == "true" && vars.packageManager == "apt"
         kind: RefreshRepository
         timeout: 2m
         spec:
           manager: apt
+          update: true
+      - id: refresh-dnf-cache
+        when: vars.installPackages == "true" && vars.packageManager == "dnf"
+        kind: RefreshRepository
+        timeout: 2m
+        spec:
+          manager: dnf
           update: true
       - id: install-jq
         when: vars.installPackages == "true"
@@ -20,6 +27,11 @@ phases:
         spec:
           path: .deck-hosted-e2e
           mode: "0755"
+      - id: ensure-extract-dir
+        kind: EnsureDirectory
+        spec:
+          path: .deck-hosted-e2e/extracted
+          mode: "0755"
       - id: copy-bundled-input
         kind: CopyFile
         spec:
@@ -27,12 +39,19 @@ phases:
             path: outputs/files/hosted-e2e/input.txt
           path: .deck-hosted-e2e/input.txt
           mode: "0644"
+      - id: extract-bundled-archive
+        kind: ExtractArchive
+        spec:
+          source:
+            path: outputs/files/hosted-e2e/archive.tgz
+          path: .deck-hosted-e2e/extracted
       - id: write-hosted-config
         kind: WriteFile
         spec:
           path: .deck-hosted-e2e/config.env
           template: |
-            PACKAGE=jq
+            PACKAGE={{ .vars.packageName }}
+            PACKAGE_MANAGER={{ .vars.packageManager }}
             OS={{ .runtime.host.os }}
             ARCH={{ .runtime.host.arch }}
             MESSAGE=hosted-e2e
@@ -54,6 +73,13 @@ phases:
         kind: WaitForFile
         spec:
           path: .deck-hosted-e2e/config.env
+          type: file
+          nonEmpty: true
+          timeout: 30s
+      - id: wait-for-extracted-message
+        kind: WaitForFile
+        spec:
+          path: .deck-hosted-e2e/extracted/message.txt
           type: file
           nonEmpty: true
           timeout: 30s

--- a/.github/e2e/hosted/fixtures/smoke/workflows/vars.yaml
+++ b/.github/e2e/hosted/fixtures/smoke/workflows/vars.yaml
@@ -1,1 +1,3 @@
 installPackages: "true"
+packageManager: apt
+packageName: jq

--- a/.github/scripts/run-hosted-e2e.sh
+++ b/.github/scripts/run-hosted-e2e.sh
@@ -8,6 +8,8 @@ WORKDIR="${DECK_HOSTED_E2E_WORKDIR:-$(mktemp -d "${TMPDIR:-/tmp}/deck-hosted-e2e
 KEEP_WORKDIR="${DECK_HOSTED_E2E_KEEP_WORKDIR:-}"
 RUNTIME="${DECK_HOSTED_E2E_RUNTIME:-docker}"
 INSTALL_PACKAGES="${DECK_HOSTED_E2E_INSTALL_PACKAGES:-true}"
+PACKAGE_MANAGER="${DECK_HOSTED_E2E_PACKAGE_MANAGER:-apt}"
+PACKAGE_NAME="${DECK_HOSTED_E2E_PACKAGE_NAME:-jq}"
 
 resolve_realpath() {
   python3 - <<'PY' "$1"
@@ -34,10 +36,41 @@ extract_bundle() {
   tar -m -xf "${archive_path}" -C "${output_dir}"
 }
 
+prepare_fixture_assets() {
+  local workspace="$1"
+
+  mkdir -p "${workspace}/seed/files/archive-src"
+  cat >"${workspace}/seed/files/archive-src/message.txt" <<'EOF'
+hosted-e2e archive payload
+EOF
+  tar -czf "${workspace}/seed/files/archive.tgz" -C "${workspace}/seed/files/archive-src" .
+}
+
+container_bootstrap() {
+  local image="$1"
+
+  case "${image}" in
+    ubuntu:*|debian:*)
+      apt-get update
+      apt-get install -y --no-install-recommends ca-certificates tar gzip
+      ;;
+    rockylinux:*|quay.io/rockylinux/rockylinux:*)
+      dnf install -y ca-certificates tar gzip
+      update-ca-trust
+      ;;
+    *)
+      printf 'unsupported hosted e2e container image bootstrap: %s\n' "${image}" >&2
+      exit 1
+      ;;
+  esac
+}
+
 run_workspace_flow() {
   local repo_root="$1"
   local workspace="$2"
   local install_packages="$3"
+  local package_manager="$4"
+  local package_name="$5"
   local first_mtime
   local second_mtime
 
@@ -54,21 +87,31 @@ run_workspace_flow() {
   extract_bundle "${workspace}/bundle.tar" "${workspace}/unpacked"
 
   pushd "${workspace}/unpacked/bundle" >/dev/null
-  ./deck apply --var "installPackages=${install_packages}"
+  ./deck apply \
+    --var "installPackages=${install_packages}" \
+    --var "packageManager=${package_manager}" \
+    --var "packageName=${package_name}"
 
   test -f .deck-hosted-e2e/input.txt
   test "$(cat .deck-hosted-e2e/input.txt)" = "hosted-e2e bundle seed"
+  test -f .deck-hosted-e2e/extracted/message.txt
+  test "$(cat .deck-hosted-e2e/extracted/message.txt)" = "hosted-e2e archive payload"
   test -f .deck-hosted-e2e/config.env
+  grep -qxF "PACKAGE=${package_name}" .deck-hosted-e2e/config.env
+  grep -qxF "PACKAGE_MANAGER=${package_manager}" .deck-hosted-e2e/config.env
   grep -qxF "MESSAGE=hosted-e2e-ok" .deck-hosted-e2e/config.env
   test -L .deck-hosted-e2e/latest-input.txt
   test "$(readlink .deck-hosted-e2e/latest-input.txt)" = "input.txt"
   if [[ "${install_packages}" == "true" ]]; then
-    jq --version
+    "${package_name}" --version
   fi
 
   first_mtime="$(mtime_seconds .deck-hosted-e2e/config.env)"
   sleep 1
-  ./deck apply --var "installPackages=${install_packages}"
+  ./deck apply \
+    --var "installPackages=${install_packages}" \
+    --var "packageManager=${package_manager}" \
+    --var "packageName=${package_name}"
   second_mtime="$(mtime_seconds .deck-hosted-e2e/config.env)"
   test "${first_mtime}" = "${second_mtime}"
   popd >/dev/null
@@ -126,6 +169,7 @@ fi
 
 safe_reset_workdir "${WORKDIR}"
 cp -R "${FIXTURE_DIR}/." "${WORKDIR}/"
+prepare_fixture_assets "${WORKDIR}"
 
 mkdir -p "${WORKDIR}/home"
 
@@ -135,18 +179,23 @@ if [[ "${RUNTIME}" == "docker" ]]; then
     --volume "${WORKDIR}:/workspace" \
     --workdir /workspace \
     --env DECK_HOSTED_E2E_INSTALL_PACKAGES="${INSTALL_PACKAGES}" \
+    --env DECK_HOSTED_E2E_PACKAGE_MANAGER="${PACKAGE_MANAGER}" \
+    --env DECK_HOSTED_E2E_PACKAGE_NAME="${PACKAGE_NAME}" \
     "${IMAGE}" \
     bash -lc "$(declare -f mtime_seconds)
 $(declare -f extract_bundle)
+$(declare -f container_bootstrap)
 $(declare -f run_workspace_flow)
 set -euo pipefail
 export DEBIAN_FRONTEND=noninteractive
 
-apt-get update
-apt-get install -y --no-install-recommends ca-certificates tar
+container_bootstrap '${IMAGE}'
 
-run_workspace_flow /repo /workspace \"\${DECK_HOSTED_E2E_INSTALL_PACKAGES}\"
+run_workspace_flow /repo /workspace \
+  \"\${DECK_HOSTED_E2E_INSTALL_PACKAGES}\" \
+  \"\${DECK_HOSTED_E2E_PACKAGE_MANAGER}\" \
+  \"\${DECK_HOSTED_E2E_PACKAGE_NAME}\"
 "
 else
-  run_workspace_flow "${ROOT_DIR}" "${WORKDIR}" "${INSTALL_PACKAGES}"
+  run_workspace_flow "${ROOT_DIR}" "${WORKDIR}" "${INSTALL_PACKAGES}" "${PACKAGE_MANAGER}" "${PACKAGE_NAME}"
 fi

--- a/.github/scripts/run-hosted-e2e.sh
+++ b/.github/scripts/run-hosted-e2e.sh
@@ -127,17 +127,6 @@ fi
 safe_reset_workdir "${WORKDIR}"
 cp -R "${FIXTURE_DIR}/." "${WORKDIR}/"
 
-python3 - <<'PY' "${WORKDIR}/workflows/prepare.yaml" "${WORKDIR}"
-from pathlib import Path
-import sys
-
-prepare_path = Path(sys.argv[1])
-workdir = Path(sys.argv[2]).as_posix()
-content = prepare_path.read_text(encoding="utf-8")
-content = content.replace("__FIXTURE_ROOT__", workdir)
-prepare_path.write_text(content, encoding="utf-8")
-PY
-
 mkdir -p "${WORKDIR}/home"
 
 if [[ "${RUNTIME}" == "docker" ]]; then

--- a/.github/scripts/run-hosted-e2e.sh
+++ b/.github/scripts/run-hosted-e2e.sh
@@ -156,7 +156,7 @@ export DEBIAN_FRONTEND=noninteractive
 apt-get update
 apt-get install -y --no-install-recommends ca-certificates tar
 
-run_workspace_flow /repo /workspace \"${DECK_HOSTED_E2E_INSTALL_PACKAGES}\"
+run_workspace_flow /repo /workspace \"\${DECK_HOSTED_E2E_INSTALL_PACKAGES}\"
 "
 else
   run_workspace_flow "${ROOT_DIR}" "${WORKDIR}" "${INSTALL_PACKAGES}"

--- a/.github/workflows/hosted-e2e-nightly.yml
+++ b/.github/workflows/hosted-e2e-nightly.yml
@@ -19,6 +19,16 @@ jobs:
   hosted-e2e:
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - id: ubuntu24
+            image: ubuntu:24.04
+            package_manager: apt
+          - id: rocky9
+            image: rockylinux:9
+            package_manager: dnf
 
     steps:
       - name: Checkout
@@ -35,14 +45,16 @@ jobs:
       - name: Run GitHub-hosted deck E2E smoke
         env:
           DECK_HOSTED_E2E_KEEP_WORKDIR: "1"
-          DECK_HOSTED_E2E_WORKDIR: ${{ runner.temp }}/deck-hosted-e2e
+          DECK_HOSTED_E2E_WORKDIR: ${{ runner.temp }}/deck-hosted-e2e-${{ matrix.id }}
+          DECK_HOSTED_E2E_IMAGE: ${{ matrix.image }}
+          DECK_HOSTED_E2E_PACKAGE_MANAGER: ${{ matrix.package_manager }}
         run: bash .github/scripts/run-hosted-e2e.sh
 
       - name: Upload hosted E2E workspace
         if: always()
         uses: actions/upload-artifact@v5
         with:
-          name: hosted-e2e-workspace-${{ github.run_id }}-${{ github.run_attempt }}
+          name: hosted-e2e-workspace-${{ matrix.id }}-${{ github.run_id }}-${{ github.run_attempt }}
           if-no-files-found: ignore
           retention-days: 14
-          path: ${{ runner.temp }}/deck-hosted-e2e
+          path: ${{ runner.temp }}/deck-hosted-e2e-${{ matrix.id }}

--- a/.github/workflows/hosted-e2e-nightly.yml
+++ b/.github/workflows/hosted-e2e-nightly.yml
@@ -37,7 +37,7 @@ jobs:
 
       - name: Upload hosted E2E workspace
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: hosted-e2e-workspace-${{ github.run_id }}-${{ github.run_attempt }}
           if-no-files-found: ignore

--- a/.github/workflows/hosted-e2e-nightly.yml
+++ b/.github/workflows/hosted-e2e-nightly.yml
@@ -8,6 +8,9 @@ on:
 permissions:
   contents: read
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 concurrency:
   group: hosted-e2e-nightly-${{ github.ref }}
   cancel-in-progress: false


### PR DESCRIPTION
## Summary
- fix the hosted E2E Docker path so the inner shell reads `DECK_HOSTED_E2E_INSTALL_PACKAGES` from the container environment instead of expanding it in the outer script
- keep the host and Docker execution paths aligned with the same `run_workspace_flow` helper while avoiding the `set -u` failure seen in the nightly workflow

## Verification
- `bash -n .github/scripts/run-hosted-e2e.sh`
- `DECK_HOSTED_E2E_RUNTIME=host DECK_HOSTED_E2E_INSTALL_PACKAGES=false DECK_HOSTED_E2E_KEEP_WORKDIR=1 DECK_HOSTED_E2E_WORKDIR=/tmp/deck-hosted-e2e-local bash .github/scripts/run-hosted-e2e.sh`
- confirmed the script now preserves the literal `\${DECK_HOSTED_E2E_INSTALL_PACKAGES}` reference inside the Docker command string

## Context
This follows up on the failure from the manually triggered Hosted E2E Nightly run on `main`:
- https://github.com/Airgap-Castaways/deck/actions/runs/24124004786/job/70384196713