### PR TITLE
fix: relax hosted nightly e2e timeouts

### DIFF
--- a/.github/e2e/hosted/fixtures/smoke/workflows/scenarios/apply.yaml
+++ b/.github/e2e/hosted/fixtures/smoke/workflows/scenarios/apply.yaml
@@ -5,21 +5,21 @@ phases:
       - id: refresh-apt-cache
         when: vars.installPackages == "true" && vars.packageManager == "apt"
         kind: RefreshRepository
-        timeout: 2m
+        timeout: 5m
         spec:
           manager: apt
           update: true
       - id: refresh-dnf-cache
         when: vars.installPackages == "true" && vars.packageManager == "dnf"
         kind: RefreshRepository
-        timeout: 2m
+        timeout: 5m
         spec:
           manager: dnf
           update: true
       - id: install-jq
         when: vars.installPackages == "true"
         kind: InstallPackage
-        timeout: 5m
+        timeout: 10m
         spec:
           packages: [jq]
       - id: ensure-hosted-output-dir

--- a/.github/workflows/hosted-e2e-nightly.yml
+++ b/.github/workflows/hosted-e2e-nightly.yml
@@ -18,7 +18,7 @@ concurrency:
 jobs:
   hosted-e2e:
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
## Summary
- increase the hosted nightly job timeout from 20 to 30 minutes so slow package mirror responses do not fail the whole run early
- raise hosted smoke workflow package refresh timeouts from 2 to 5 minutes for both apt and dnf paths
- extend the hosted package install timeout from 5 to 10 minutes to better tolerate slow nightly package operations