### PR TITLE
fix: cover doc parity compatibility cleanup

### DIFF
--- a/cmd/deck/cache_compat_test.go
+++ b/cmd/deck/cache_compat_test.go
@@ -1,0 +1,75 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/Airgap-Castaways/deck/internal/userdirs"
+)
+
+func TestResolveLegacyDeckCacheRoot(t *testing.T) {
+	t.Run("found", func(t *testing.T) {
+		home := t.TempDir()
+		t.Setenv("HOME", home)
+
+		legacyRoot, err := userdirs.LegacyCacheRoot()
+		if err != nil {
+			t.Fatalf("LegacyCacheRoot failed: %v", err)
+		}
+		if err := os.MkdirAll(legacyRoot, 0o755); err != nil {
+			t.Fatalf("mkdir legacy cache root: %v", err)
+		}
+
+		resolved, found, err := resolveLegacyDeckCacheRoot()
+		if err != nil {
+			t.Fatalf("resolveLegacyDeckCacheRoot failed: %v", err)
+		}
+		if !found {
+			t.Fatal("expected legacy cache root to be found")
+		}
+		if resolved != legacyRoot {
+			t.Fatalf("unexpected legacy cache root: got %q want %q", resolved, legacyRoot)
+		}
+	})
+
+	t.Run("missing", func(t *testing.T) {
+		home := t.TempDir()
+		t.Setenv("HOME", home)
+
+		resolved, found, err := resolveLegacyDeckCacheRoot()
+		if err != nil {
+			t.Fatalf("resolveLegacyDeckCacheRoot failed: %v", err)
+		}
+		if found {
+			t.Fatal("expected missing legacy cache root")
+		}
+		if resolved != "" {
+			t.Fatalf("expected empty legacy cache root, got %q", resolved)
+		}
+	})
+
+	t.Run("stat error", func(t *testing.T) {
+		homeParent := t.TempDir()
+		homeFile := filepath.Join(homeParent, "home-file")
+		if err := os.WriteFile(homeFile, []byte("x"), 0o644); err != nil {
+			t.Fatalf("write fake home file: %v", err)
+		}
+		t.Setenv("HOME", homeFile)
+
+		resolved, found, err := resolveLegacyDeckCacheRoot()
+		if err == nil {
+			t.Fatal("expected stat error")
+		}
+		if found {
+			t.Fatal("did not expect found on stat error")
+		}
+		if resolved != "" {
+			t.Fatalf("expected empty legacy cache root on error, got %q", resolved)
+		}
+		if !strings.Contains(err.Error(), "stat legacy cache root") {
+			t.Fatalf("expected stat error context, got %v", err)
+		}
+	})
+}

--- a/cmd/deck/docs_parity_test.go
+++ b/cmd/deck/docs_parity_test.go
@@ -1,0 +1,65 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestUserFacingCommandFlowDocsDoNotMentionDoctor(t *testing.T) {
+	for _, rel := range []string{
+		"README.md",
+		"docs/reference/cli.md",
+		"docs/guides/quick-start.md",
+		"test/vagrant/README.md",
+	} {
+		rel := rel
+		t.Run(rel, func(t *testing.T) {
+			content := readRepoDoc(t, rel)
+			if strings.Contains(strings.ToLower(content), "doctor") {
+				t.Fatalf("%s must not mention removed doctor command", rel)
+			}
+		})
+	}
+}
+
+func TestQuickStartDocsIncludeCurrentLifecycleCommands(t *testing.T) {
+	for _, rel := range []string{"README.md", "docs/guides/quick-start.md"} {
+		rel := rel
+		t.Run(rel, func(t *testing.T) {
+			content := readRepoDoc(t, rel)
+			for _, want := range []string{"deck init", "deck lint", "deck prepare", "deck bundle build", "deck apply"} {
+				if !strings.Contains(content, want) {
+					t.Fatalf("%s must include %q", rel, want)
+				}
+			}
+		})
+	}
+}
+
+func TestLegacyCompatibilityDocsListCurrentCompatTests(t *testing.T) {
+	content := readRepoDoc(t, "docs/contributing/legacy-compatibility.md")
+	for _, rel := range []string{
+		"cmd/deck/source_defaults_compat_test.go",
+		"cmd/deck/cache_compat_test.go",
+		"internal/install/state_compat_test.go",
+		"internal/prepare/cache_compat_test.go",
+	} {
+		if _, err := os.Stat(filepath.Join("..", "..", filepath.FromSlash(rel))); err != nil {
+			t.Fatalf("expected compatibility test file %s: %v", rel, err)
+		}
+		if !strings.Contains(content, rel) {
+			t.Fatalf("legacy compatibility docs must list %s", rel)
+		}
+	}
+}
+
+func readRepoDoc(t *testing.T, rel string) string {
+	t.Helper()
+	raw, err := os.ReadFile(filepath.Join("..", "..", filepath.FromSlash(rel)))
+	if err != nil {
+		t.Fatalf("read %s: %v", rel, err)
+	}
+	return string(raw)
+}

--- a/cmd/deck/docs_parity_test.go
+++ b/cmd/deck/docs_parity_test.go
@@ -17,7 +17,7 @@ func TestUserFacingCommandFlowDocsDoNotMentionDoctor(t *testing.T) {
 		rel := rel
 		t.Run(rel, func(t *testing.T) {
 			content := readRepoDoc(t, rel)
-			if strings.Contains(strings.ToLower(content), "doctor") {
+			if containsRemovedDoctorCommandReference(content) {
 				t.Fatalf("%s must not mention removed doctor command", rel)
 			}
 		})
@@ -62,4 +62,22 @@ func readRepoDoc(t *testing.T, rel string) string {
 		t.Fatalf("read %s: %v", rel, err)
 	}
 	return string(raw)
+}
+
+func containsRemovedDoctorCommandReference(content string) bool {
+	lower := strings.ToLower(content)
+	for _, pattern := range []string{
+		"deck doctor",
+		"-> doctor",
+		"doctor ->",
+		"- `doctor`",
+		"* `doctor`",
+		"## doctor",
+		"### doctor",
+	} {
+		if strings.Contains(lower, pattern) {
+			return true
+		}
+	}
+	return false
 }

--- a/docs/contributing/legacy-compatibility.md
+++ b/docs/contributing/legacy-compatibility.md
@@ -25,6 +25,7 @@ This document describes the few pre-`v1.0.0` compatibility exceptions that are s
 ## Test Coverage
 
 - `cmd/deck/source_defaults_compat_test.go`
+- `cmd/deck/cache_compat_test.go`
 - `internal/install/state_compat_test.go`
 - `internal/prepare/cache_compat_test.go`
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -9,10 +9,12 @@ It supports a simple operator flow: author the workflow, lint it, prepare bundle
 - `init`: create starter workflow files under `workflows/`
 - `lint`: validate a workflow file or workspace against the workflow and step schemas (`-o text|json`)
 - `prepare`: gather artifacts into `outputs/`, write a local `deck` launcher, and write `.deck/manifest.json`
-- `plan`: inspect which apply steps would run or skip before execution (`-o text|json`)
+- `bundle build`: package the current workspace into a transportable archive
 - `apply`: execute the `apply` workflow locally
 
 ## Additional helpers
+
+- `plan`: inspect which apply steps would run or skip before execution (`-o text|json`)
 
 - `list`: list available scenarios from the local workspace or the saved remote server
 - `cache list`: inspect cached artifact entries

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -13,9 +13,7 @@ It supports a simple operator flow: author the workflow, lint it, prepare bundle
 - `apply`: execute the `apply` workflow locally
 
 ## Additional helpers
-
 - `plan`: inspect which apply steps would run or skip before execution (`-o text|json`)
-
 - `list`: list available scenarios from the local workspace or the saved remote server
 - `cache list`: inspect cached artifact entries
 - `cache clean`: delete cached entries, optionally by age or as a dry run

--- a/test/vagrant/README.md
+++ b/test/vagrant/README.md
@@ -69,7 +69,7 @@ Important outputs:
 
 ## Execution Model
 
-This document is for maintaining the Vagrant regression environment. The product-facing local workflow remains the documented `plan -> doctor -> apply` path.
+This document is for maintaining the Vagrant regression environment. The product-facing local workflow remains the documented `init -> lint -> prepare -> bundle build -> apply` path.
 
 - The internal regression flow is: host preparation, VM startup, scenario execution, verification collection, and optional cleanup
 - Scenario entrypoint workflows live under `test/workflows/scenarios/*.yaml`


### PR DESCRIPTION
## Summary
- remove stale `doctor` workflow wording from Vagrant maintenance docs and align the CLI reference flow with the current quick start lifecycle
- add focused coverage for legacy CLI cache root discovery
- add doc parity checks for command-flow docs and legacy compatibility test coverage

## Verification
- `go test ./cmd/deck`
- `go test ./internal/validate`
- `make test`
- `make lint`

Closes #169