### PR TITLE
fix: centralize remaining workspace path rules

### DIFF
--- a/cmd/deck/scenario_cli.go
+++ b/cmd/deck/scenario_cli.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/Airgap-Castaways/deck/internal/httpfetch"
 	ctrllogs "github.com/Airgap-Castaways/deck/internal/logs"
+	"github.com/Airgap-Castaways/deck/internal/workspacepaths"
 )
 
 const (
@@ -276,7 +277,7 @@ func resolveLocalScenarioPath(root, scenario string) (string, error) {
 }
 
 func buildServerScenarioWorkflowURL(serverURL, scenario string) string {
-	return strings.TrimRight(strings.TrimSpace(serverURL), "/") + "/workflows/scenarios/" + strings.TrimLeft(scenario, "/") + ".yaml"
+	return strings.TrimRight(strings.TrimSpace(serverURL), "/") + "/" + workspacepaths.CanonicalScenariosPrefix + strings.TrimLeft(scenario, "/") + ".yaml"
 }
 
 func fetchScenarioIndexFromServer(ctx context.Context, server string) ([]string, error) {
@@ -284,7 +285,7 @@ func fetchScenarioIndexFromServer(ctx context.Context, server string) ([]string,
 		return nil, fmt.Errorf("context is nil")
 	}
 	trimmed := strings.TrimRight(server, "/")
-	indexURL := trimmed + "/workflows/index.json"
+	indexURL := trimmed + "/" + workspacepaths.WorkflowIndexPathRel
 	resp, err := httpfetch.Do(ctx, scenarioHTTPClient, http.MethodGet, indexURL, nil, "scenario list request")
 	if err != nil {
 		return nil, err

--- a/internal/askrepair/repair.go
+++ b/internal/askrepair/repair.go
@@ -16,6 +16,7 @@ import (
 	"github.com/Airgap-Castaways/deck/internal/stepspec"
 	"github.com/Airgap-Castaways/deck/internal/structurededit"
 	"github.com/Airgap-Castaways/deck/internal/validate"
+	"github.com/Airgap-Castaways/deck/internal/workspacepaths"
 )
 
 func TryAutoRepair(root string, files []askcontract.GeneratedFile, diags []askdiagnostic.Diagnostic, repairPaths []string) ([]askcontract.GeneratedFile, []string, bool, error) {
@@ -161,7 +162,7 @@ func repairPathAllowed(path string, repairPaths []string) bool {
 func diagnosticFile(diag askdiagnostic.Diagnostic) string {
 	for _, value := range []string{diag.File, diag.Path} {
 		clean := filepath.ToSlash(strings.TrimSpace(value))
-		if strings.HasPrefix(clean, "workflows/") {
+		if workspacepaths.IsWorkflowAuthoringPath(clean) {
 			if idx := strings.Index(clean, ":"); idx > 0 {
 				clean = strings.TrimSpace(clean[:idx])
 			}

--- a/internal/askrepair/repair.go
+++ b/internal/askrepair/repair.go
@@ -163,13 +163,23 @@ func diagnosticFile(diag askdiagnostic.Diagnostic) string {
 	for _, value := range []string{diag.File, diag.Path} {
 		clean := filepath.ToSlash(strings.TrimSpace(value))
 		if workspacepaths.IsWorkflowAuthoringPath(clean) {
-			if idx := strings.Index(clean, ":"); idx > 0 {
-				clean = strings.TrimSpace(clean[:idx])
-			}
-			return clean
+			return trimLineSuffix(clean)
 		}
 	}
 	return ""
+}
+
+func trimLineSuffix(path string) string {
+	idx := strings.LastIndex(path, ":")
+	if idx <= 0 || idx == len(path)-1 {
+		return path
+	}
+	for _, ch := range path[idx+1:] {
+		if ch < '0' || ch > '9' {
+			return path
+		}
+	}
+	return strings.TrimSpace(path[:idx])
 }
 
 func repairRawPath(diag askdiagnostic.Diagnostic) string {

--- a/internal/askrepair/repair_test.go
+++ b/internal/askrepair/repair_test.go
@@ -120,6 +120,28 @@ func TestTryAutoRepairRestoresTypedLiteralsFromProgramDefaults(t *testing.T) {
 	}
 }
 
+func TestDiagnosticFileTrimsOnlyNumericLineSuffix(t *testing.T) {
+	tests := []struct {
+		name string
+		file string
+		want string
+	}{
+		{name: "relative line", file: "workflows/scenarios/apply.yaml:10", want: "workflows/scenarios/apply.yaml"},
+		{name: "absolute line", file: "/tmp/demo/workflows/scenarios/apply.yaml:10", want: "/tmp/demo/workflows/scenarios/apply.yaml"},
+		{name: "windows absolute line", file: "C:/demo/workflows/scenarios/apply.yaml:10", want: "C:/demo/workflows/scenarios/apply.yaml"},
+		{name: "windows absolute no line", file: "C:/demo/workflows/scenarios/apply.yaml", want: "C:/demo/workflows/scenarios/apply.yaml"},
+		{name: "nonnumeric suffix", file: "workflows/scenarios/apply.yaml:note", want: "workflows/scenarios/apply.yaml:note"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := diagnosticFile(askdiagnostic.Diagnostic{File: tt.file})
+			if got != tt.want {
+				t.Fatalf("unexpected diagnostic file: got %q want %q", got, tt.want)
+			}
+		})
+	}
+}
+
 func currentRepairClusterCheckKind() string {
 	for _, step := range askcatalog.Current().StepKinds() {
 		if strings.Contains(step.Kind, "Check") && strings.Contains(step.Kind, "Cluster") {

--- a/internal/bundlecli/service.go
+++ b/internal/bundlecli/service.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/Airgap-Castaways/deck/internal/bundle"
 	"github.com/Airgap-Castaways/deck/internal/logs"
+	"github.com/Airgap-Castaways/deck/internal/workspacepaths"
 )
 
 type VerifyOptions struct {
@@ -131,11 +132,11 @@ func summarizeBundleManifest(entries []bundle.ManifestEntry) manifestSummary {
 	for _, entry := range entries {
 		path := strings.TrimSpace(entry.Path)
 		switch {
-		case strings.HasPrefix(path, "outputs/files/") || strings.HasPrefix(path, "files/"):
+		case workspacepaths.IsPreparedFilePath(path):
 			summary.Files++
-		case strings.HasPrefix(path, "outputs/images/") || strings.HasPrefix(path, "images/"):
+		case workspacepaths.IsPreparedImagePath(path):
 			summary.Images++
-		case strings.HasPrefix(path, "outputs/packages/") || strings.HasPrefix(path, "packages/"):
+		case workspacepaths.IsPreparedPackagePath(path):
 			summary.Packages++
 		default:
 			summary.Other++

--- a/internal/workspacepaths/paths.go
+++ b/internal/workspacepaths/paths.go
@@ -10,6 +10,8 @@ const (
 	WorkflowRootDir             = "workflows"
 	WorkflowScenariosDir        = "scenarios"
 	WorkflowComponentsDir       = "components"
+	WorkflowIndexRel            = "index.json"
+	WorkflowIndexPathRel        = WorkflowRootDir + "/" + WorkflowIndexRel
 	CanonicalScenariosDir       = WorkflowRootDir + "/" + WorkflowScenariosDir
 	CanonicalComponentsDir      = WorkflowRootDir + "/" + WorkflowComponentsDir
 	CanonicalScenariosPrefix    = CanonicalScenariosDir + "/"
@@ -127,6 +129,14 @@ func IsScenarioAuthoringPath(path string) bool {
 	return strings.HasPrefix(clean, CanonicalScenariosPrefix) || strings.Contains(clean, "/"+CanonicalScenariosPrefix)
 }
 
+func IsWorkflowAuthoringPath(path string) bool {
+	clean := filepath.ToSlash(strings.TrimSpace(path))
+	if clean == "" {
+		return false
+	}
+	return strings.HasPrefix(clean, WorkflowRootDir+"/") || strings.Contains(clean, "/"+WorkflowRootDir+"/")
+}
+
 func IsComponentAuthoringPath(path string) bool {
 	clean := filepath.ToSlash(strings.TrimSpace(path))
 	if clean == "" {
@@ -166,6 +176,30 @@ func IsPreparedPathUnderRoot(rel string, root string) bool {
 		return false
 	}
 	return cleaned == cleanedRoot || strings.HasPrefix(cleaned, cleanedRoot+"/")
+}
+
+func PreparedRootPath(root string) string {
+	return filepath.ToSlash(filepath.Join(PreparedDirRel, strings.TrimSpace(root)))
+}
+
+func IsPreparedFilePath(rel string) bool {
+	return IsPreparedManifestPathUnderRoot(rel, PreparedFilesRoot)
+}
+
+func IsPreparedImagePath(rel string) bool {
+	return IsPreparedManifestPathUnderRoot(rel, PreparedImagesRoot)
+}
+
+func IsPreparedPackagePath(rel string) bool {
+	return IsPreparedManifestPathUnderRoot(rel, PreparedPackagesRoot)
+}
+
+func IsPreparedManifestPathUnderRoot(rel string, root string) bool {
+	trimmed := filepath.ToSlash(strings.TrimSpace(rel))
+	if trimmed == "" {
+		return false
+	}
+	return IsPreparedPathUnderRoot(trimmed, root) || IsPreparedPathUnderRoot(trimmed, PreparedRootPath(root))
 }
 
 func LocateWorkflowTreeRoot(workflowPath string) (string, error) {

--- a/internal/workspacepaths/paths_test.go
+++ b/internal/workspacepaths/paths_test.go
@@ -37,3 +37,41 @@ func TestWorkflowSubdirDetectors(t *testing.T) {
 		t.Fatalf("did not expect unrelated path to be treated as component: %s", otherPath)
 	}
 }
+
+func TestWorkflowAuthoringPathDetector(t *testing.T) {
+	for _, path := range []string{
+		"workflows/prepare.yaml",
+		"workflows/scenarios/apply.yaml",
+		"/tmp/demo/workflows/scenarios/apply.yaml",
+	} {
+		if !IsWorkflowAuthoringPath(path) {
+			t.Fatalf("expected workflow authoring path: %s", path)
+		}
+	}
+	for _, path := range []string{"outputs/files/a.txt", "docs/workflows.md", ""} {
+		if IsWorkflowAuthoringPath(path) {
+			t.Fatalf("did not expect workflow authoring path: %s", path)
+		}
+	}
+}
+
+func TestPreparedManifestPathDetectorsAcceptCanonicalAndBundlePaths(t *testing.T) {
+	for _, path := range []string{"files/a.txt", "outputs/files/a.txt"} {
+		if !IsPreparedFilePath(path) {
+			t.Fatalf("expected prepared file path: %s", path)
+		}
+	}
+	for _, path := range []string{"images/control-plane.tar", "outputs/images/control-plane.tar"} {
+		if !IsPreparedImagePath(path) {
+			t.Fatalf("expected prepared image path: %s", path)
+		}
+	}
+	for _, path := range []string{"packages/p.rpm", "outputs/packages/p.rpm"} {
+		if !IsPreparedPackagePath(path) {
+			t.Fatalf("expected prepared package path: %s", path)
+		}
+	}
+	if IsPreparedFilePath("packages/p.rpm") {
+		t.Fatal("did not expect package path to be classified as file path")
+	}
+}


### PR DESCRIPTION
## Summary
- add workspace path helpers for scenario index URLs, workflow authoring paths, and prepared manifest category detection
- replace remaining scenario URL, bundle manifest summary, and ask repair path literals with `workspacepaths` helpers
- cover the new path helpers with focused tests

## Verification
- `go test ./internal/workspacepaths ./cmd/deck ./internal/bundlecli ./internal/askrepair`
- `go test ./...`
- `bin/golangci-lint run`

Refs #167