### PR TITLE
refactor: inject cli command environment

### DIFF
--- a/cmd/deck/apply_runlog.go
+++ b/cmd/deck/apply_runlog.go
@@ -65,6 +65,7 @@ type applyRunEventRecord struct {
 
 type applyRunLogger struct {
 	mu        sync.Mutex
+	env       *cliEnv
 	dir       string
 	record    applyRunRecord
 	stepOrder []string
@@ -79,7 +80,7 @@ func (l *applyRunLogger) Dir() string {
 	return l.dir
 }
 
-func newApplyRunLogger(workflowPath, workflowSource, scenario, bundleRoot, selectedPhase string) (*applyRunLogger, error) {
+func newApplyRunLogger(env *cliEnv, workflowPath, workflowSource, scenario, bundleRoot, selectedPhase string) (*applyRunLogger, error) {
 	runsRoot, err := userdirs.RunsRoot()
 	if err != nil {
 		return nil, err
@@ -96,6 +97,7 @@ func newApplyRunLogger(workflowPath, workflowSource, scenario, bundleRoot, selec
 	}
 	hostname, _ := os.Hostname()
 	logger := &applyRunLogger{
+		env:    env,
 		dir:    dir,
 		events: eventsFile,
 		steps:  map[string]*applyRunStepRecord{},
@@ -147,7 +149,7 @@ func (l *applyRunLogger) EventSink() install.StepEventSink {
 	}
 	return func(event install.StepEvent) {
 		if err := l.writeEvent(event); err != nil {
-			_ = stderrCLIEvent(ctrllogs.CLIEvent{Level: "error", Component: "apply", Event: "runlog_write_failed", Attrs: map[string]any{"error": err}})
+			_ = l.env.stderrCLIEvent(ctrllogs.CLIEvent{Level: "error", Component: "apply", Event: "runlog_write_failed", Attrs: map[string]any{"error": err}})
 		}
 	}
 }

--- a/cmd/deck/apply_runlog_test.go
+++ b/cmd/deck/apply_runlog_test.go
@@ -13,7 +13,7 @@ import (
 
 func TestApplyRunLoggerHandlesConcurrentEvents(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
-	logger, err := newApplyRunLogger("workflow.yaml", "local", "", "", "")
+	logger, err := newApplyRunLogger(newCLIEnv(nil, nil), "workflow.yaml", "local", "", "", "")
 	if err != nil {
 		t.Fatalf("newApplyRunLogger: %v", err)
 	}

--- a/cmd/deck/ask_ai_test.go
+++ b/cmd/deck/ask_ai_test.go
@@ -217,7 +217,7 @@ func TestAskLoginRejectsNonOpenAIProvider(t *testing.T) {
 }
 
 func TestAskCommandMetadataMatchesAskContext(t *testing.T) {
-	cmd := newAskCommand()
+	cmd := newAskCommand(newCLIEnv(nil, nil))
 	meta := askcontext.AskCommandMeta()
 	if cmd.Short != meta.Short {
 		t.Fatalf("unexpected ask short help: %q", cmd.Short)

--- a/cmd/deck/ask_auth_commands.go
+++ b/cmd/deck/ask_auth_commands.go
@@ -13,7 +13,7 @@ import (
 	"github.com/Airgap-Castaways/deck/internal/askconfig"
 )
 
-func newAskLoginCommand() *cobra.Command {
+func newAskLoginCommand(env *cliEnv) *cobra.Command {
 	var provider string
 	var oauthToken string
 	var refreshToken string
@@ -40,7 +40,7 @@ func newAskLoginCommand() *cobra.Command {
 				return err
 			}
 			if accessToken == "" {
-				session, err := runOpenAILoginFlow(cmd, callbackPort, noBrowser, headless)
+				session, err := runOpenAILoginFlow(env, cmd, callbackPort, noBrowser, headless)
 				if err != nil {
 					return err
 				}
@@ -50,7 +50,7 @@ func newAskLoginCommand() *cobra.Command {
 				if err := askauth.Save(session); err != nil {
 					return err
 				}
-				return printSavedSession(providerName, session)
+				return printSavedSession(env, providerName, session)
 			}
 			session, err := buildImportedSession(providerName, accessToken, refreshToken, accountEmail, expiresAt)
 			if err != nil {
@@ -59,7 +59,7 @@ func newAskLoginCommand() *cobra.Command {
 			if err := askauth.Save(session); err != nil {
 				return err
 			}
-			return printSavedSession(providerName, session)
+			return printSavedSession(env, providerName, session)
 		},
 	}
 	cmd.Flags().StringVar(&provider, "provider", "", "provider to associate with this oauth session")
@@ -74,7 +74,7 @@ func newAskLoginCommand() *cobra.Command {
 	return cmd
 }
 
-func newAskLogoutCommand() *cobra.Command {
+func newAskLogoutCommand(env *cliEnv) *cobra.Command {
 	var provider string
 	cmd := &cobra.Command{
 		Use:   "logout",
@@ -91,14 +91,14 @@ func newAskLogoutCommand() *cobra.Command {
 			if err := askauth.Delete(providerName); err != nil {
 				return err
 			}
-			return stdoutPrintf("ask logout removed provider=%s\n", providerName)
+			return env.stdoutPrintf("ask logout removed provider=%s\n", providerName)
 		},
 	}
 	cmd.Flags().StringVar(&provider, "provider", "", "provider whose saved oauth session should be deleted")
 	return cmd
 }
 
-func newAskStatusCommand() *cobra.Command {
+func newAskStatusCommand(env *cliEnv) *cobra.Command {
 	var provider string
 	cmd := &cobra.Command{
 		Use:   "status",
@@ -126,34 +126,34 @@ func newAskStatusCommand() *cobra.Command {
 				effective.AuthStatus = status
 				effective.AccountID = session.AccountID
 			}
-			if err := stdoutPrintf("provider=%s\n", providerName); err != nil {
+			if err := env.stdoutPrintf("provider=%s\n", providerName); err != nil {
 				return err
 			}
-			if err := stdoutPrintf("authenticated=%t\n", ok); err != nil {
+			if err := env.stdoutPrintf("authenticated=%t\n", ok); err != nil {
 				return err
 			}
-			if err := stdoutPrintf("oauthTokenSource=%s\n", effective.OAuthTokenSource); err != nil {
+			if err := env.stdoutPrintf("oauthTokenSource=%s\n", effective.OAuthTokenSource); err != nil {
 				return err
 			}
 			if !ok {
-				if err := stdoutPrintf("status=missing\n"); err != nil {
+				if err := env.stdoutPrintf("status=missing\n"); err != nil {
 					return err
 				}
-				return stdoutPrintf("accountEmail=\n")
+				return env.stdoutPrintf("accountEmail=\n")
 			}
-			if err := stdoutPrintf("status=%s\n", status); err != nil {
+			if err := env.stdoutPrintf("status=%s\n", status); err != nil {
 				return err
 			}
-			if err := stdoutPrintf("accountEmail=%s\n", session.AccountEmail); err != nil {
+			if err := env.stdoutPrintf("accountEmail=%s\n", session.AccountEmail); err != nil {
 				return err
 			}
-			if err := stdoutPrintf("accountID=%s\n", session.AccountID); err != nil {
+			if err := env.stdoutPrintf("accountID=%s\n", session.AccountID); err != nil {
 				return err
 			}
-			if err := stdoutPrintf("expiresAt=%s\n", formatExpiry(session.ExpiresAt)); err != nil {
+			if err := env.stdoutPrintf("expiresAt=%s\n", formatExpiry(session.ExpiresAt)); err != nil {
 				return err
 			}
-			return stdoutPrintf("hasRefreshToken=%t\n", strings.TrimSpace(session.RefreshToken) != "")
+			return env.stdoutPrintf("hasRefreshToken=%t\n", strings.TrimSpace(session.RefreshToken) != "")
 		},
 	}
 	cmd.Flags().StringVar(&provider, "provider", "", "provider whose oauth session should be inspected")
@@ -172,11 +172,11 @@ func resolveImportedOAuthToken(cmd *cobra.Command, oauthToken string, stdinToken
 	return strings.TrimSpace(string(raw)), nil
 }
 
-func runOpenAILoginFlow(cmd *cobra.Command, callbackPort int, noBrowser bool, headless bool) (askauth.Session, error) {
-	if err := askLoginProgressf("Starting OpenAI Codex login...\n"); err != nil {
+func runOpenAILoginFlow(env *cliEnv, cmd *cobra.Command, callbackPort int, noBrowser bool, headless bool) (askauth.Session, error) {
+	if err := askLoginProgressf(env, "Starting OpenAI Codex login...\n"); err != nil {
 		return askauth.Session{}, err
 	}
-	authOpts := askauth.OpenAICodexOptions{CallbackPort: callbackPort, OpenBrowser: !noBrowser, Writer: os.Stderr}
+	authOpts := askauth.OpenAICodexOptions{CallbackPort: callbackPort, OpenBrowser: !noBrowser, Writer: env.stderr}
 	if headless {
 		return askauth.LoginOpenAICodexDevice(cmd.Context(), authOpts)
 	}
@@ -217,8 +217,8 @@ func overrideSessionMetadata(session *askauth.Session, refreshToken string, acco
 	return nil
 }
 
-func printSavedSession(providerName string, session askauth.Session) error {
-	return stdoutPrintf("ask login saved provider=%s account=%s expiresAt=%s\n", providerName, fallbackValue(session.AccountEmail, "unknown"), formatExpiry(session.ExpiresAt))
+func printSavedSession(env *cliEnv, providerName string, session askauth.Session) error {
+	return env.stdoutPrintf("ask login saved provider=%s account=%s expiresAt=%s\n", providerName, fallbackValue(session.AccountEmail, "unknown"), formatExpiry(session.ExpiresAt))
 }
 
 func formatExpiry(value time.Time) string {
@@ -235,8 +235,8 @@ func fallbackValue(value string, fallback string) string {
 	return strings.TrimSpace(value)
 }
 
-func askLoginProgressf(format string, args ...any) error {
-	_, err := fmt.Fprintf(os.Stderr, format, args...)
+func askLoginProgressf(env *cliEnv, format string, args ...any) error {
+	_, err := fmt.Fprintf(env.stderr, format, args...)
 	return err
 }
 

--- a/cmd/deck/cmd_apply.go
+++ b/cmd/deck/cmd_apply.go
@@ -21,7 +21,7 @@ type diffOptions struct {
 	varOverrides  map[string]string
 }
 
-func newPlanCommand() *cobra.Command {
+func newPlanCommand(env *cliEnv) *cobra.Command {
 	vars := &varFlag{}
 	cmd := &cobra.Command{
 		Use:     "plan",
@@ -52,7 +52,7 @@ func newPlanCommand() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			return runDiffWithOptions(cmd.Context(), diffOptions{
+			return runDiffWithOptions(env, cmd.Context(), diffOptions{
 				workflowPath:  workflowPath,
 				scenario:      scenario,
 				source:        source,
@@ -76,25 +76,25 @@ func newPlanCommand() *cobra.Command {
 	return cmd
 }
 
-func runDiffWithOptions(ctx context.Context, opts diffOptions) error {
+func runDiffWithOptions(env *cliEnv, ctx context.Context, opts diffOptions) error {
 	workflowPath, err := resolvePlanWorkflowPath(ctx, strings.TrimSpace(opts.workflowPath), strings.TrimSpace(opts.scenario), strings.TrimSpace(opts.source))
 	if err != nil {
 		return err
 	}
 	selectedPhase := strings.TrimSpace(opts.selectedPhase)
-	return executeDiff(ctx, workflowPath, selectedPhase, opts.output, opts.fresh, varsAsAnyMap(opts.varOverrides))
+	return executeDiff(env, ctx, workflowPath, selectedPhase, opts.output, opts.fresh, varsAsAnyMap(opts.varOverrides))
 }
 
-func executeDiff(ctx context.Context, workflowPath, selectedPhase, output string, fresh bool, varOverrides map[string]any) error {
+func executeDiff(env *cliEnv, ctx context.Context, workflowPath, selectedPhase, output string, fresh bool, varOverrides map[string]any) error {
 	return applycli.RunPlanCommand(ctx, applycli.PlanCommandOptions{
 		WorkflowPath:    workflowPath,
 		SelectedPhase:   selectedPhase,
 		Output:          output,
 		Fresh:           fresh,
 		VarOverrides:    varOverrides,
-		Verbosef:        verbosef,
-		StdoutPrintf:    stdoutPrintf,
-		JSONEncoderFunc: stdoutJSONEncoder,
+		Verbosef:        env.verbosef,
+		StdoutPrintf:    env.stdoutPrintf,
+		JSONEncoderFunc: env.stdoutJSONEncoder,
 		ResolveOutput:   resolveOutputFormat,
 	})
 }
@@ -110,7 +110,7 @@ type applyOptions struct {
 	positional    []string
 }
 
-func newApplyCommand() *cobra.Command {
+func newApplyCommand(env *cliEnv) *cobra.Command {
 	vars := &varFlag{}
 	cmd := &cobra.Command{
 		Use:   "apply [workflow] [bundle]",
@@ -146,7 +146,7 @@ func newApplyCommand() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			return runApplyWithOptions(cmd.Context(), applyOptions{
+			return runApplyWithOptions(env, cmd.Context(), applyOptions{
 				workflowPath:  workflowPath,
 				scenario:      scenario,
 				source:        source,
@@ -171,7 +171,7 @@ func newApplyCommand() *cobra.Command {
 	return cmd
 }
 
-func runApplyWithOptions(ctx context.Context, opts applyOptions) error {
+func runApplyWithOptions(env *cliEnv, ctx context.Context, opts applyOptions) error {
 	if ctx == nil {
 		return fmt.Errorf("context is nil")
 	}
@@ -196,12 +196,12 @@ func runApplyWithOptions(ctx context.Context, opts applyOptions) error {
 		Fresh:          opts.fresh,
 		DryRun:         opts.dryRun,
 		VarOverrides:   varsAsAnyMap(opts.varOverrides),
-		Verbosef:       verbosef,
-		StdoutPrintf:   stdoutPrintf,
-		StdoutPrintln:  stdoutPrintln,
-		AdditionalSink: verboseApplyStepSink(),
+		Verbosef:       env.verbosef,
+		StdoutPrintf:   env.stdoutPrintf,
+		StdoutPrintln:  env.stdoutPrintln,
+		AdditionalSink: verboseApplyStepSink(env),
 		NewRunLogger: func(workflowPath, workflowSource, scenario, bundleRoot, selectedPhase string) (applycli.RunLogger, error) {
-			return newApplyRunLogger(workflowPath, workflowSource, scenario, bundleRoot, selectedPhase)
+			return newApplyRunLogger(env, workflowPath, workflowSource, scenario, bundleRoot, selectedPhase)
 		},
 	})
 }

--- a/cmd/deck/cmd_apply_events.go
+++ b/cmd/deck/cmd_apply_events.go
@@ -9,9 +9,9 @@ import (
 	"github.com/Airgap-Castaways/deck/internal/lintcli"
 )
 
-func verboseApplyStepSink() install.StepEventSink {
+func verboseApplyStepSink(env *cliEnv) install.StepEventSink {
 	return func(event install.StepEvent) {
-		_ = stderrPrintf("%s\n", formatWorkflowEventLine("apply", event))
+		_ = env.stderrPrintf("%s\n", formatWorkflowEventLine("apply", event))
 	}
 }
 
@@ -43,7 +43,7 @@ func resolveApplyWorkflowAndBundle(ctx context.Context, opts applyOptions, posit
 	})
 }
 
-func executeLint(ctx context.Context, root string, file string, scenario string, output string) error {
+func executeLint(env *cliEnv, ctx context.Context, root string, file string, scenario string, output string) error {
 	resolvedOutput, err := resolveOutputFormat(output)
 	if err != nil {
 		return err
@@ -53,9 +53,9 @@ func executeLint(ctx context.Context, root string, file string, scenario string,
 		File:            file,
 		Scenario:        scenario,
 		Output:          resolvedOutput,
-		Verbosef:        verbosef,
-		StdoutPrintf:    stdoutPrintf,
-		JSONEncoderFunc: stdoutJSONEncoder,
+		Verbosef:        env.verbosef,
+		StdoutPrintf:    env.stdoutPrintf,
+		JSONEncoderFunc: env.stdoutJSONEncoder,
 		WorkflowRootDir: workflowRootDir,
 		ScenarioDirName: workflowScenariosDir,
 	})

--- a/cmd/deck/cmd_bundle.go
+++ b/cmd/deck/cmd_bundle.go
@@ -5,15 +5,15 @@ import (
 	"github.com/Airgap-Castaways/deck/internal/initcli"
 )
 
-func executeInit(output string) error {
+func executeInit(env *cliEnv, output string) error {
 	return initcli.Run(initcli.Options{
 		Output:       output,
 		DeckWorkDir:  deckWorkDirName,
-		StdoutPrintf: stdoutPrintf,
+		StdoutPrintf: env.stdoutPrintf,
 	})
 }
 
-func executeBundleVerify(filePath string, positionalArgs []string, output string) error {
+func executeBundleVerify(env *cliEnv, filePath string, positionalArgs []string, output string) error {
 	resolvedOutput, err := resolveOutputFormat(output)
 	if err != nil {
 		return err
@@ -22,21 +22,21 @@ func executeBundleVerify(filePath string, positionalArgs []string, output string
 		FilePath:       filePath,
 		PositionalArgs: positionalArgs,
 		Output:         resolvedOutput,
-		Verbosef:       verbosef,
+		Verbosef:       env.verbosef,
 		JSONEncoder: func(v any) error {
-			enc := stdoutJSONEncoder()
+			enc := env.stdoutJSONEncoder()
 			enc.SetIndent("", "  ")
 			return enc.Encode(v)
 		},
-		StdoutPrintf: stdoutPrintf,
+		StdoutPrintf: env.stdoutPrintf,
 	})
 }
 
-func executeBundleBuild(root string, out string) error {
+func executeBundleBuild(env *cliEnv, root string, out string) error {
 	return bundlecli.Build(bundlecli.BuildOptions{
 		Root:         root,
 		Out:          out,
-		Verbosef:     verbosef,
-		StdoutPrintf: stdoutPrintf,
+		Verbosef:     env.verbosef,
+		StdoutPrintf: env.stdoutPrintf,
 	})
 }

--- a/cmd/deck/cmd_cache.go
+++ b/cmd/deck/cmd_cache.go
@@ -19,7 +19,7 @@ type cacheEntry struct {
 	ModTime   string `json:"mod_time"`
 }
 
-func executeCacheList(output string) error {
+func executeCacheList(env *cliEnv, output string) error {
 	resolvedOutput, err := resolveOutputFormat(output)
 	if err != nil {
 		return err
@@ -29,34 +29,34 @@ func executeCacheList(output string) error {
 	if err != nil {
 		return err
 	}
-	if err := verboseCLIEvent(1, ctrllogs.CLIEvent{Component: "cache", Event: "list_requested", Attrs: map[string]any{"root": root, "output": strings.TrimSpace(output)}}); err != nil {
+	if err := env.verboseCLIEvent(1, ctrllogs.CLIEvent{Component: "cache", Event: "list_requested", Attrs: map[string]any{"root": root, "output": strings.TrimSpace(output)}}); err != nil {
 		return err
 	}
 	entries, err := listCacheEntries(root)
 	if err != nil {
 		return err
 	}
-	if err := verboseCLIEvent(1, ctrllogs.CLIEvent{Component: "cache", Event: "list_loaded", Attrs: map[string]any{"entries": len(entries)}}); err != nil {
+	if err := env.verboseCLIEvent(1, ctrllogs.CLIEvent{Component: "cache", Event: "list_loaded", Attrs: map[string]any{"entries": len(entries)}}); err != nil {
 		return err
 	}
 	if resolvedOutput == "json" {
-		enc := stdoutJSONEncoder()
+		enc := env.stdoutJSONEncoder()
 		return enc.Encode(entries)
 	}
 	for _, e := range entries {
-		if err := stdoutPrintf("%s\t%d\t%s\n", e.Path, e.SizeBytes, e.ModTime); err != nil {
+		if err := env.stdoutPrintf("%s\t%d\t%s\n", e.Path, e.SizeBytes, e.ModTime); err != nil {
 			return err
 		}
 	}
 	return nil
 }
 
-func executeCacheClean(olderThan string, dryRun bool) error {
+func executeCacheClean(env *cliEnv, olderThan string, dryRun bool) error {
 	root, err := defaultDeckCacheRoot()
 	if err != nil {
 		return err
 	}
-	if err := verboseCLIEvent(1, ctrllogs.CLIEvent{Component: "cache", Event: "clean_requested", Attrs: map[string]any{"root": root, "older_than": strings.TrimSpace(olderThan), "dry_run": dryRun}}); err != nil {
+	if err := env.verboseCLIEvent(1, ctrllogs.CLIEvent{Component: "cache", Event: "clean_requested", Attrs: map[string]any{"root": root, "older_than": strings.TrimSpace(olderThan), "dry_run": dryRun}}); err != nil {
 		return err
 	}
 	cutoff, hasCutoff, err := parseOlderThan(olderThan)
@@ -67,14 +67,14 @@ func executeCacheClean(olderThan string, dryRun bool) error {
 	if err != nil {
 		return err
 	}
-	if err := verboseCLIEvent(1, ctrllogs.CLIEvent{Component: "cache", Event: "clean_planned", Attrs: map[string]any{"matches": len(plan)}}); err != nil {
+	if err := env.verboseCLIEvent(1, ctrllogs.CLIEvent{Component: "cache", Event: "clean_planned", Attrs: map[string]any{"matches": len(plan)}}); err != nil {
 		return err
 	}
 	for _, p := range plan {
-		if err := verboseCLIEvent(2, ctrllogs.CLIEvent{Component: "cache", Event: "clean_match", Attrs: map[string]any{"path": p}}); err != nil {
+		if err := env.verboseCLIEvent(2, ctrllogs.CLIEvent{Component: "cache", Event: "clean_match", Attrs: map[string]any{"path": p}}); err != nil {
 			return err
 		}
-		if err := stdoutPrintln(p); err != nil {
+		if err := env.stdoutPrintln(p); err != nil {
 			return err
 		}
 	}

--- a/cmd/deck/cmd_prepare.go
+++ b/cmd/deck/cmd_prepare.go
@@ -21,7 +21,7 @@ type prepareOptions struct {
 	varOverrides   map[string]string
 }
 
-func newPrepareCommand() *cobra.Command {
+func newPrepareCommand(env *cliEnv) *cobra.Command {
 	vars := &varFlag{}
 	binaries := &stringSliceFlag{}
 	excludes := &stringSliceFlag{}
@@ -58,7 +58,7 @@ func newPrepareCommand() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			return runPrepareWithOptions(cmd, prepareOptions{
+			return runPrepareWithOptions(env, cmd, prepareOptions{
 				preparedRoot:   preparedRoot,
 				dryRun:         dryRun,
 				refresh:        refresh,
@@ -85,8 +85,8 @@ func newPrepareCommand() *cobra.Command {
 	return cmd
 }
 
-func runPrepareWithOptions(cmd *cobra.Command, opts prepareOptions) error {
-	if err := verboseCLIEvent(1, ctrllogs.CLIEvent{Component: "prepare", Event: "run_requested", Attrs: map[string]any{"root": opts.preparedRoot, "dry_run": opts.dryRun, "refresh": opts.refresh, "clean": opts.clean}}); err != nil {
+func runPrepareWithOptions(env *cliEnv, cmd *cobra.Command, opts prepareOptions) error {
+	if err := env.verboseCLIEvent(1, ctrllogs.CLIEvent{Component: "prepare", Event: "run_requested", Attrs: map[string]any{"root": opts.preparedRoot, "dry_run": opts.dryRun, "refresh": opts.refresh, "clean": opts.clean}}); err != nil {
 		return err
 	}
 	return preparecli.Run(cmd.Context(), preparecli.Options{
@@ -100,8 +100,8 @@ func runPrepareWithOptions(cmd *cobra.Command, opts prepareOptions) error {
 		Binaries:       opts.binaries,
 		BinaryExcludes: opts.binaryExcludes,
 		VarOverrides:   varsAsAnyMap(opts.varOverrides),
-		Stdout:         stdoutWriter(),
-		Diagnosticf:    verbosef,
-		EventSink:      verbosePrepareStepSink(),
+		Stdout:         env.stdoutWriter(),
+		Diagnosticf:    env.verbosef,
+		EventSink:      verbosePrepareStepSink(env),
 	})
 }

--- a/cmd/deck/cmd_prepare_events.go
+++ b/cmd/deck/cmd_prepare_events.go
@@ -4,8 +4,8 @@ import (
 	"github.com/Airgap-Castaways/deck/internal/prepare"
 )
 
-func verbosePrepareStepSink() prepare.StepEventSink {
+func verbosePrepareStepSink(env *cliEnv) prepare.StepEventSink {
 	return func(event prepare.StepEvent) {
-		_ = stderrPrintf("%s\n", formatWorkflowEventLine("prepare", event))
+		_ = env.stderrPrintf("%s\n", formatWorkflowEventLine("prepare", event))
 	}
 }

--- a/cmd/deck/cmd_serve.go
+++ b/cmd/deck/cmd_serve.go
@@ -22,7 +22,7 @@ import (
 	"github.com/Airgap-Castaways/deck/internal/server"
 )
 
-func executeServe(ctx context.Context, root string, addr string, auditMaxSizeMB int, auditMaxFiles int, tlsCert string, tlsKey string, tlsSelfSigned bool) error {
+func executeServe(env *cliEnv, ctx context.Context, root string, addr string, auditMaxSizeMB int, auditMaxFiles int, tlsCert string, tlsKey string, tlsSelfSigned bool) error {
 	if ctx == nil {
 		return fmt.Errorf("context is nil")
 	}
@@ -83,10 +83,10 @@ func executeServe(ctx context.Context, root string, addr string, auditMaxSizeMB 
 		errCh <- httpServer.ListenAndServe()
 	}()
 	serverURL := displayServerURL(resolvedAddr, certPath != "")
-	if err := stdoutCLIEvent(ctrllogs.CLIEvent{TS: time.Now().UTC(), Level: "info", Component: "server", Event: "started", Attrs: map[string]any{"url": serverURL, "bind": resolvedAddr, "root": resolvedRoot}}); err != nil {
+	if err := env.stdoutCLIEvent(ctrllogs.CLIEvent{TS: time.Now().UTC(), Level: "info", Component: "server", Event: "started", Attrs: map[string]any{"url": serverURL, "bind": resolvedAddr, "root": resolvedRoot}}); err != nil {
 		return err
 	}
-	if err := stdoutCLIEvent(ctrllogs.CLIEvent{TS: time.Now().UTC(), Level: "info", Component: "server", Event: "open", Attrs: map[string]any{"url": strings.TrimRight(serverURL, "/") + "/"}}); err != nil {
+	if err := env.stdoutCLIEvent(ctrllogs.CLIEvent{TS: time.Now().UTC(), Level: "info", Component: "server", Event: "open", Attrs: map[string]any{"url": strings.TrimRight(serverURL, "/") + "/"}}); err != nil {
 		return err
 	}
 	select {
@@ -148,7 +148,7 @@ type healthReport struct {
 	HTTPStatus int    `json:"httpStatus"`
 }
 
-func executeHealth(ctx context.Context, server string, output string) error {
+func executeHealth(env *cliEnv, ctx context.Context, server string, output string) error {
 	if ctx == nil {
 		return fmt.Errorf("context is nil")
 	}
@@ -160,13 +160,13 @@ func executeHealth(ctx context.Context, server string, output string) error {
 	if err != nil {
 		return err
 	}
-	if err := verboseCLIEvent(1, ctrllogs.CLIEvent{TS: time.Now().UTC(), Level: "info", Component: "server", Event: "health_check", Attrs: map[string]any{"server": resolvedServer}}); err != nil {
+	if err := env.verboseCLIEvent(1, ctrllogs.CLIEvent{TS: time.Now().UTC(), Level: "info", Component: "server", Event: "health_check", Attrs: map[string]any{"server": resolvedServer}}); err != nil {
 		return err
 	}
 
 	client := &http.Client{Timeout: 5 * time.Second}
 	healthURL := strings.TrimRight(resolvedServer, "/") + "/healthz"
-	if err := verboseCLIEvent(2, ctrllogs.CLIEvent{TS: time.Now().UTC(), Level: "debug", Component: "server", Event: "health_check", Attrs: map[string]any{"server": resolvedServer, "url": healthURL}}); err != nil {
+	if err := env.verboseCLIEvent(2, ctrllogs.CLIEvent{TS: time.Now().UTC(), Level: "debug", Component: "server", Event: "health_check", Attrs: map[string]any{"server": resolvedServer, "url": healthURL}}); err != nil {
 		return err
 	}
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, healthURL, nil)
@@ -175,28 +175,28 @@ func executeHealth(ctx context.Context, server string, output string) error {
 	}
 	resp, err := client.Do(req)
 	if err != nil {
-		_ = verboseCLIEvent(2, ctrllogs.CLIEvent{TS: time.Now().UTC(), Level: "error", Component: "server", Event: "health_check_failed", Attrs: map[string]any{"server": resolvedServer, "url": healthURL, "error": err}})
+		_ = env.verboseCLIEvent(2, ctrllogs.CLIEvent{TS: time.Now().UTC(), Level: "error", Component: "server", Event: "health_check_failed", Attrs: map[string]any{"server": resolvedServer, "url": healthURL, "error": err}})
 		return fmt.Errorf("health: request failed: %w", err)
 	}
 	defer closeSilently(resp.Body)
 	if resp.StatusCode != http.StatusOK {
-		_ = verboseCLIEvent(2, ctrllogs.CLIEvent{TS: time.Now().UTC(), Level: "warn", Component: "server", Event: "health_check", Attrs: map[string]any{"server": resolvedServer, "url": healthURL, "http_status": resp.StatusCode}})
+		_ = env.verboseCLIEvent(2, ctrllogs.CLIEvent{TS: time.Now().UTC(), Level: "warn", Component: "server", Event: "health_check", Attrs: map[string]any{"server": resolvedServer, "url": healthURL, "http_status": resp.StatusCode}})
 		return fmt.Errorf("health: unexpected status %d", resp.StatusCode)
 	}
-	if err := verboseCLIEvent(2, ctrllogs.CLIEvent{TS: time.Now().UTC(), Level: "info", Component: "server", Event: "health_check", Attrs: map[string]any{"server": resolvedServer, "url": healthURL, "http_status": resp.StatusCode}}); err != nil {
+	if err := env.verboseCLIEvent(2, ctrllogs.CLIEvent{TS: time.Now().UTC(), Level: "info", Component: "server", Event: "health_check", Attrs: map[string]any{"server": resolvedServer, "url": healthURL, "http_status": resp.StatusCode}}); err != nil {
 		return err
 	}
 	report := healthReport{Status: "ok", Server: resolvedServer, HealthURL: healthURL, HTTPStatus: resp.StatusCode}
 	if resolvedOutput == "json" {
-		enc := stdoutJSONEncoder()
+		enc := env.stdoutJSONEncoder()
 		enc.SetIndent("", "  ")
 		return enc.Encode(report)
 	}
 
-	return stdoutPrintf("health: ok (%s)\n", report.Server)
+	return env.stdoutPrintf("health: ok (%s)\n", report.Server)
 }
 
-func executeLogs(ctx context.Context, root string, source string, path string, unit string, output string) error {
+func executeLogs(env *cliEnv, ctx context.Context, root string, source string, path string, unit string, output string) error {
 	if ctx == nil {
 		return fmt.Errorf("context is nil")
 	}
@@ -205,7 +205,7 @@ func executeLogs(ctx context.Context, root string, source string, path string, u
 	if err != nil {
 		return err
 	}
-	if err := verboseCLIEvent(1, ctrllogs.CLIEvent{TS: time.Now().UTC(), Level: "info", Component: "server", Event: "logs_query", Attrs: map[string]any{"root": strings.TrimSpace(root), "source": resolvedSource, "path": strings.TrimSpace(path), "unit": strings.TrimSpace(unit), "output": strings.TrimSpace(output)}}); err != nil {
+	if err := env.verboseCLIEvent(1, ctrllogs.CLIEvent{TS: time.Now().UTC(), Level: "info", Component: "server", Event: "logs_query", Attrs: map[string]any{"root": strings.TrimSpace(root), "source": resolvedSource, "path": strings.TrimSpace(path), "unit": strings.TrimSpace(unit), "output": strings.TrimSpace(output)}}); err != nil {
 		return err
 	}
 	if resolvedSource != "file" && resolvedSource != "journal" && resolvedSource != "both" {
@@ -218,14 +218,14 @@ func executeLogs(ctx context.Context, root string, source string, path string, u
 		if err != nil {
 			return err
 		}
-		if err := verboseCLIEvent(1, ctrllogs.CLIEvent{TS: time.Now().UTC(), Level: "info", Component: "server", Event: "logs_file", Attrs: map[string]any{"file": logPath}}); err != nil {
+		if err := env.verboseCLIEvent(1, ctrllogs.CLIEvent{TS: time.Now().UTC(), Level: "info", Component: "server", Event: "logs_file", Attrs: map[string]any{"file": logPath}}); err != nil {
 			return err
 		}
 		fileRecords, err := readLogsFile(logPath)
 		if err != nil {
 			return err
 		}
-		if err := verboseCLIEvent(1, ctrllogs.CLIEvent{TS: time.Now().UTC(), Level: "info", Component: "server", Event: "logs_file_loaded", Attrs: map[string]any{"file_records": len(fileRecords)}}); err != nil {
+		if err := env.verboseCLIEvent(1, ctrllogs.CLIEvent{TS: time.Now().UTC(), Level: "info", Component: "server", Event: "logs_file_loaded", Attrs: map[string]any{"file_records": len(fileRecords)}}); err != nil {
 			return err
 		}
 		records = append(records, fileRecords...)
@@ -235,28 +235,28 @@ func executeLogs(ctx context.Context, root string, source string, path string, u
 		if resolvedUnit == "" {
 			return errors.New("--unit is required when --source includes journal")
 		}
-		if err := verboseCLIEvent(1, ctrllogs.CLIEvent{TS: time.Now().UTC(), Level: "info", Component: "server", Event: "logs_journal", Attrs: map[string]any{"unit": resolvedUnit}}); err != nil {
+		if err := env.verboseCLIEvent(1, ctrllogs.CLIEvent{TS: time.Now().UTC(), Level: "info", Component: "server", Event: "logs_journal", Attrs: map[string]any{"unit": resolvedUnit}}); err != nil {
 			return err
 		}
 		journalRecords, err := readControlLogsJournal(ctx, resolvedUnit, 50, 0)
 		if err != nil {
 			return fmt.Errorf("logs: %w\nsuggestion: %s", err, suggestJournalctlCommand(resolvedUnit))
 		}
-		if err := verboseCLIEvent(1, ctrllogs.CLIEvent{TS: time.Now().UTC(), Level: "info", Component: "server", Event: "logs_journal_loaded", Attrs: map[string]any{"journal_records": len(journalRecords)}}); err != nil {
+		if err := env.verboseCLIEvent(1, ctrllogs.CLIEvent{TS: time.Now().UTC(), Level: "info", Component: "server", Event: "logs_journal_loaded", Attrs: map[string]any{"journal_records": len(journalRecords)}}); err != nil {
 			return err
 		}
 		records = append(records, journalRecords...)
 	}
-	if err := verboseCLIEvent(1, ctrllogs.CLIEvent{TS: time.Now().UTC(), Level: "info", Component: "server", Event: "logs_loaded", Attrs: map[string]any{"records": len(records)}}); err != nil {
+	if err := env.verboseCLIEvent(1, ctrllogs.CLIEvent{TS: time.Now().UTC(), Level: "info", Component: "server", Event: "logs_loaded", Attrs: map[string]any{"records": len(records)}}); err != nil {
 		return err
 	}
 
 	if resolvedOutput == "json" {
-		enc := stdoutJSONEncoder()
+		enc := env.stdoutJSONEncoder()
 		return enc.Encode(records)
 	}
 	for _, record := range records {
-		if err := stdoutPrintln(ctrllogs.FormatLogText(record)); err != nil {
+		if err := env.stdoutPrintln(ctrllogs.FormatLogText(record)); err != nil {
 			return err
 		}
 	}

--- a/cmd/deck/cmd_version.go
+++ b/cmd/deck/cmd_version.go
@@ -6,7 +6,7 @@ import (
 	"github.com/Airgap-Castaways/deck/internal/buildinfo"
 )
 
-func newVersionCommand() *cobra.Command {
+func newVersionCommand(env *cliEnv) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "version",
 		Short: "Show deck build version",
@@ -21,10 +21,10 @@ func newVersionCommand() *cobra.Command {
 				return err
 			}
 			if resolvedOutput == "text" {
-				return stdoutPrintf("%s\nrepo %s\n", buildinfo.Summary(), buildinfo.Current().Repository)
+				return env.stdoutPrintf("%s\nrepo %s\n", buildinfo.Summary(), buildinfo.Current().Repository)
 			}
 
-			enc := stdoutJSONEncoder()
+			enc := env.stdoutJSONEncoder()
 			enc.SetIndent("", "  ")
 			return enc.Encode(buildinfo.Current())
 		},

--- a/cmd/deck/cobra_ask_ai.go
+++ b/cmd/deck/cobra_ask_ai.go
@@ -19,7 +19,7 @@ var newAskBackend = func() askprovider.Client {
 	return openaiprovider.New()
 }
 
-func newAskCommand() *cobra.Command {
+func newAskCommand(env *cliEnv) *cobra.Command {
 	var fromPath string
 	var answers []string
 	var create bool
@@ -84,9 +84,9 @@ func newAskCommand() *cobra.Command {
 	cmd.Flags().StringVar(&planDir, "plan-dir", ".deck/plan", "directory for ask plan artifacts")
 
 	cmd.AddCommand(newAskPlanCommand())
-	cmd.AddCommand(newAskConfigCommand())
+	cmd.AddCommand(newAskConfigCommand(env))
 	cmd.AddCommand(newAskMCPCommand())
-	cmd.AddCommand(newAskLoginCommand(), newAskLogoutCommand(), newAskStatusCommand())
+	cmd.AddCommand(newAskLoginCommand(env), newAskLogoutCommand(env), newAskStatusCommand(env))
 	return cmd
 }
 
@@ -137,7 +137,7 @@ func newAskPlanCommand() *cobra.Command {
 	return cmd
 }
 
-func newAskConfigCommand() *cobra.Command {
+func newAskConfigCommand(env *cliEnv) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   askcontext.CurrentCommandSpec().Config.Use,
 		Short: askcontext.CurrentCommandSpec().Config.Short,
@@ -146,11 +146,11 @@ func newAskConfigCommand() *cobra.Command {
 			return cmd.Help()
 		},
 	}
-	cmd.AddCommand(newAskConfigSetCommand(), newAskConfigShowCommand(), newAskConfigHealthCommand(), newAskConfigUnsetCommand())
+	cmd.AddCommand(newAskConfigSetCommand(env), newAskConfigShowCommand(env), newAskConfigHealthCommand(env), newAskConfigUnsetCommand(env))
 	return cmd
 }
 
-func newAskConfigSetCommand() *cobra.Command {
+func newAskConfigSetCommand(env *cliEnv) *cobra.Command {
 	var apiKey string
 	var oauthToken string
 	var provider string
@@ -197,7 +197,7 @@ func newAskConfigSetCommand() *cobra.Command {
 			if err := askconfig.SaveStored(updated); err != nil {
 				return err
 			}
-			return stdoutPrintln("ask config saved")
+			return env.stdoutPrintln("ask config saved")
 		},
 	}
 	cmd.Flags().StringVar(&apiKey, "api-key", "", "save the ask api key in XDG config")
@@ -209,7 +209,7 @@ func newAskConfigSetCommand() *cobra.Command {
 	return cmd
 }
 
-func newAskConfigShowCommand() *cobra.Command {
+func newAskConfigShowCommand(env *cliEnv) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "show",
 		Short: "Show the effective ask provider, model, and masked key source",
@@ -219,36 +219,36 @@ func newAskConfigShowCommand() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			if err := stdoutPrintf("provider=%s\n", effective.Provider); err != nil {
+			if err := env.stdoutPrintf("provider=%s\n", effective.Provider); err != nil {
 				return err
 			}
-			if err := stdoutPrintf("providerSource=%s\n", effective.ProviderSource); err != nil {
+			if err := env.stdoutPrintf("providerSource=%s\n", effective.ProviderSource); err != nil {
 				return err
 			}
-			if err := stdoutPrintf("model=%s\n", effective.Model); err != nil {
+			if err := env.stdoutPrintf("model=%s\n", effective.Model); err != nil {
 				return err
 			}
-			if err := stdoutPrintf("modelSource=%s\n", effective.ModelSource); err != nil {
+			if err := env.stdoutPrintf("modelSource=%s\n", effective.ModelSource); err != nil {
 				return err
 			}
-			if err := stdoutPrintf("endpoint=%s\n", effective.Endpoint); err != nil {
+			if err := env.stdoutPrintf("endpoint=%s\n", effective.Endpoint); err != nil {
 				return err
 			}
-			if err := stdoutPrintf("endpointSource=%s\n", effective.EndpointSource); err != nil {
+			if err := env.stdoutPrintf("endpointSource=%s\n", effective.EndpointSource); err != nil {
 				return err
 			}
-			if err := stdoutPrintf("logLevel=%s\n", effective.LogLevel); err != nil {
+			if err := env.stdoutPrintf("logLevel=%s\n", effective.LogLevel); err != nil {
 				return err
 			}
-			if err := stdoutPrintf("mcpEnabled=%t\n", effective.MCP.Enabled); err != nil {
+			if err := env.stdoutPrintf("mcpEnabled=%t\n", effective.MCP.Enabled); err != nil {
 				return err
 			}
 			providers := mcpaugment.DescribeConfiguredProviders(effective.MCP)
-			if err := stdoutPrintf("mcpProviderCount=%d\n", len(providers)); err != nil {
+			if err := env.stdoutPrintf("mcpProviderCount=%d\n", len(providers)); err != nil {
 				return err
 			}
 			for idx, provider := range providers {
-				if err := printKeyValues(fmt.Sprintf("mcpProvider[%d]", idx), map[string]string{
+				if err := printKeyValues(env, fmt.Sprintf("mcpProvider[%d]", idx), map[string]string{
 					"name":            provider.ConfiguredName,
 					"id":              provider.ProviderID,
 					"transport":       provider.Transport,
@@ -259,25 +259,25 @@ func newAskConfigShowCommand() *cobra.Command {
 					return err
 				}
 			}
-			if err := stdoutPrintf("apiKey=%s\n", askconfig.MaskAPIKey(effective.APIKey)); err != nil {
+			if err := env.stdoutPrintf("apiKey=%s\n", askconfig.MaskAPIKey(effective.APIKey)); err != nil {
 				return err
 			}
-			if err := stdoutPrintf("apiKeySource=%s\n", effective.APIKeySource); err != nil {
+			if err := env.stdoutPrintf("apiKeySource=%s\n", effective.APIKeySource); err != nil {
 				return err
 			}
-			if err := stdoutPrintf("oauthToken=%s\n", askconfig.MaskAPIKey(effective.OAuthToken)); err != nil {
+			if err := env.stdoutPrintf("oauthToken=%s\n", askconfig.MaskAPIKey(effective.OAuthToken)); err != nil {
 				return err
 			}
-			if err := stdoutPrintf("oauthTokenSource=%s\n", effective.OAuthTokenSource); err != nil {
+			if err := env.stdoutPrintf("oauthTokenSource=%s\n", effective.OAuthTokenSource); err != nil {
 				return err
 			}
-			return stdoutPrintf("authStatus=%s\n", effective.AuthStatus)
+			return env.stdoutPrintf("authStatus=%s\n", effective.AuthStatus)
 		},
 	}
 	return cmd
 }
 
-func newAskConfigHealthCommand() *cobra.Command {
+func newAskConfigHealthCommand(env *cliEnv) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "health",
 		Short: "Probe built-in ask augmentation providers",
@@ -287,15 +287,15 @@ func newAskConfigHealthCommand() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			if err := stdoutPrintf("mcpEnabled=%t\n", effective.MCP.Enabled); err != nil {
+			if err := env.stdoutPrintf("mcpEnabled=%t\n", effective.MCP.Enabled); err != nil {
 				return err
 			}
 			health := mcpaugment.ProbeConfiguredProviders(cmd.Context(), effective.MCP)
-			if err := stdoutPrintf("mcpProviderCount=%d\n", len(health)); err != nil {
+			if err := env.stdoutPrintf("mcpProviderCount=%d\n", len(health)); err != nil {
 				return err
 			}
 			for idx, provider := range health {
-				if err := printKeyValues(fmt.Sprintf("mcpProvider[%d]", idx), map[string]string{
+				if err := printKeyValues(env, fmt.Sprintf("mcpProvider[%d]", idx), map[string]string{
 					"name":                provider.ConfiguredName,
 					"id":                  provider.ProviderID,
 					"transport":           provider.Transport,
@@ -316,21 +316,21 @@ func newAskConfigHealthCommand() *cobra.Command {
 	return cmd
 }
 
-func printKeyValues(prefix string, fields map[string]string) error {
+func printKeyValues(env *cliEnv, prefix string, fields map[string]string) error {
 	orderedKeys := []string{"name", "id", "transport", "transportSource", "status", "phase", "tools", "capabilities", "missingCapabilities", "message", "warning"}
 	for _, key := range orderedKeys {
 		value, ok := fields[key]
 		if !ok || value == "" {
 			continue
 		}
-		if err := stdoutPrintf("%s.%s=%s\n", prefix, key, value); err != nil {
+		if err := env.stdoutPrintf("%s.%s=%s\n", prefix, key, value); err != nil {
 			return err
 		}
 	}
 	return nil
 }
 
-func newAskConfigUnsetCommand() *cobra.Command {
+func newAskConfigUnsetCommand(env *cliEnv) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "unset",
 		Short: "Clear saved ask config settings from XDG config",
@@ -339,7 +339,7 @@ func newAskConfigUnsetCommand() *cobra.Command {
 			if err := askconfig.ClearStored(); err != nil {
 				return err
 			}
-			return stdoutPrintln("ask config cleared")
+			return env.stdoutPrintln("ask config cleared")
 		},
 	}
 	return cmd

--- a/cmd/deck/cobra_bundle.go
+++ b/cmd/deck/cobra_bundle.go
@@ -6,7 +6,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func newBundleCommand() *cobra.Command {
+func newBundleCommand(env *cliEnv) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "bundle",
 		Short: "Build or verify bundles",
@@ -17,14 +17,14 @@ func newBundleCommand() *cobra.Command {
 	}
 
 	cmd.AddCommand(
-		newBundleBuildCommand(),
-		newBundleVerifyCommand(),
+		newBundleBuildCommand(env),
+		newBundleVerifyCommand(env),
 	)
 
 	return cmd
 }
 
-func newBundleVerifyCommand() *cobra.Command {
+func newBundleVerifyCommand(env *cliEnv) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "verify [path]",
 		Short: "Verify bundle manifest integrity",
@@ -38,7 +38,7 @@ func newBundleVerifyCommand() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			return executeBundleVerify(file, args, output)
+			return executeBundleVerify(env, file, args, output)
 		},
 	}
 	cmd.Flags().String("file", "", "bundle path (directory or bundle.tar)")
@@ -46,7 +46,7 @@ func newBundleVerifyCommand() *cobra.Command {
 	return cmd
 }
 
-func newBundleBuildCommand() *cobra.Command {
+func newBundleBuildCommand(env *cliEnv) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "build",
 		Short: "Archive deck, workflows, outputs, and manifest",
@@ -60,7 +60,7 @@ func newBundleBuildCommand() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			return executeBundleBuild(root, out)
+			return executeBundleBuild(env, root, out)
 		},
 	}
 	cmd.Flags().String("root", ".", "workspace root containing deck, workflows, outputs, and .deck/manifest.json")

--- a/cmd/deck/cobra_cache.go
+++ b/cmd/deck/cobra_cache.go
@@ -4,7 +4,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func newCacheCommand() *cobra.Command {
+func newCacheCommand(env *cliEnv) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "cache",
 		Short: "Inspect or clean deck cache data",
@@ -15,8 +15,8 @@ func newCacheCommand() *cobra.Command {
 	}
 
 	cmd.AddCommand(
-		newCacheListCommand(),
-		newCacheCleanCommand(),
+		newCacheListCommand(env),
+		newCacheCleanCommand(env),
 	)
 
 	return cmd

--- a/cmd/deck/cobra_server.go
+++ b/cmd/deck/cobra_server.go
@@ -14,7 +14,7 @@ import (
 	ctrllogs "github.com/Airgap-Castaways/deck/internal/logs"
 )
 
-func newServerCommand() *cobra.Command {
+func newServerCommand(env *cliEnv) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "server",
 		Short: "Run the local content server and manage remote lookup defaults",
@@ -25,17 +25,17 @@ func newServerCommand() *cobra.Command {
 	}
 
 	cmd.AddCommand(
-		newServerUpCommand(),
-		newServerDownCommand(),
-		newServerHealthCommand(),
-		newServerLogsCommand(),
-		newServerRemoteCommand(),
+		newServerUpCommand(env),
+		newServerDownCommand(env),
+		newServerHealthCommand(env),
+		newServerLogsCommand(env),
+		newServerRemoteCommand(env),
 	)
 
 	return cmd
 }
 
-func newServerUpCommand() *cobra.Command {
+func newServerUpCommand(env *cliEnv) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "up",
 		Short: "Start the local bundle server",
@@ -77,7 +77,7 @@ func newServerUpCommand() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			return executeServerUp(cmd.Context(), serverUpOptions{
+			return executeServerUp(env, cmd.Context(), serverUpOptions{
 				root:          root,
 				addr:          addr,
 				auditMaxSize:  auditMaxSize,
@@ -102,7 +102,7 @@ func newServerUpCommand() *cobra.Command {
 	return cmd
 }
 
-func newServerDownCommand() *cobra.Command {
+func newServerDownCommand(env *cliEnv) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "down",
 		Short: "Stop the local server daemon",
@@ -112,14 +112,14 @@ func newServerDownCommand() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			return executeServerDown(cmd.Context(), unit)
+			return executeServerDown(env, cmd.Context(), unit)
 		},
 	}
 	cmd.Flags().String("unit", "deck-server", "systemd unit name to stop")
 	return cmd
 }
 
-func newServerHealthCommand() *cobra.Command {
+func newServerHealthCommand(env *cliEnv) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "health",
 		Short: "Probe an explicit server or the saved remote server URL",
@@ -133,7 +133,7 @@ func newServerHealthCommand() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			return executeHealth(cmd.Context(), server, output)
+			return executeHealth(env, cmd.Context(), server, output)
 		},
 	}
 	cmd.Flags().String("server", "", "server base URL (defaults to the saved remote server URL)")
@@ -141,7 +141,7 @@ func newServerHealthCommand() *cobra.Command {
 	return cmd
 }
 
-func newServerLogsCommand() *cobra.Command {
+func newServerLogsCommand(env *cliEnv) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "logs",
 		Short: "Read local server audit logs from file or journal",
@@ -167,7 +167,7 @@ func newServerLogsCommand() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			return executeLogs(cmd.Context(), root, source, path, unit, output)
+			return executeLogs(env, cmd.Context(), root, source, path, unit, output)
 		},
 	}
 	cmd.Flags().String("root", ".", "serve root directory")
@@ -178,7 +178,7 @@ func newServerLogsCommand() *cobra.Command {
 	return cmd
 }
 
-func newServerRemoteCommand() *cobra.Command {
+func newServerRemoteCommand(env *cliEnv) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "remote",
 		Short: "Manage the saved remote server URL for scenario lookup",
@@ -189,51 +189,51 @@ func newServerRemoteCommand() *cobra.Command {
 	}
 
 	cmd.AddCommand(
-		newServerRemoteSetCommand(),
-		newServerRemoteShowCommand(),
-		newServerRemoteUnsetCommand(),
+		newServerRemoteSetCommand(env),
+		newServerRemoteShowCommand(env),
+		newServerRemoteUnsetCommand(env),
 	)
 
 	return cmd
 }
 
-func newServerRemoteSetCommand() *cobra.Command {
+func newServerRemoteSetCommand(env *cliEnv) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "set <url>",
 		Short: "Save the default remote server URL for scenario lookup",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(_ *cobra.Command, args []string) error {
-			return executeServerRemoteSet(args[0])
+			return executeServerRemoteSet(env, args[0])
 		},
 	}
 	return cmd
 }
 
-func newServerRemoteShowCommand() *cobra.Command {
+func newServerRemoteShowCommand(env *cliEnv) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "show",
 		Short: "Show the effective saved remote server URL",
 		Args:  cobra.NoArgs,
 		RunE: func(_ *cobra.Command, _ []string) error {
-			return executeServerRemoteShow()
+			return executeServerRemoteShow(env)
 		},
 	}
 	return cmd
 }
 
-func newServerRemoteUnsetCommand() *cobra.Command {
+func newServerRemoteUnsetCommand(env *cliEnv) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "unset",
 		Short: "Clear the saved remote server URL",
 		Args:  cobra.NoArgs,
 		RunE: func(_ *cobra.Command, _ []string) error {
-			return executeServerRemoteUnset()
+			return executeServerRemoteUnset(env)
 		},
 	}
 	return cmd
 }
 
-func executeServerRemoteSet(rawURL string) error {
+func executeServerRemoteSet(env *cliEnv, rawURL string) error {
 	resolved := strings.TrimRight(strings.TrimSpace(rawURL), "/")
 	if err := validateSourceURL(resolved); err != nil {
 		return err
@@ -242,16 +242,16 @@ func executeServerRemoteSet(rawURL string) error {
 	if err != nil {
 		return err
 	}
-	if err := verboseCLIEvent(1, ctrllogs.CLIEvent{Component: "server", Event: "remote_set", Attrs: map[string]any{"url": resolved, "config": configPath}}); err != nil {
+	if err := env.verboseCLIEvent(1, ctrllogs.CLIEvent{Component: "server", Event: "remote_set", Attrs: map[string]any{"url": resolved, "config": configPath}}); err != nil {
 		return err
 	}
 	if err := saveSourceDefaults(sourceDefaults{URL: resolved}); err != nil {
 		return err
 	}
-	return stdoutPrintf("server remote set: %s\n", resolved)
+	return env.stdoutPrintf("server remote set: %s\n", resolved)
 }
 
-func executeServerRemoteShow() error {
+func executeServerRemoteShow(env *cliEnv) error {
 	configPath, err := sourceDefaultsPath()
 	if err != nil {
 		return err
@@ -260,33 +260,33 @@ func executeServerRemoteShow() error {
 	if err != nil {
 		return err
 	}
-	if err := verboseCLIEvent(1, ctrllogs.CLIEvent{Component: "server", Event: "remote_show", Attrs: map[string]any{"config": configPath, "resolved": displayValueOrDash(resolved), "origin": displayValueOrDash(source)}}); err != nil {
+	if err := env.verboseCLIEvent(1, ctrllogs.CLIEvent{Component: "server", Event: "remote_show", Attrs: map[string]any{"config": configPath, "resolved": displayValueOrDash(resolved), "origin": displayValueOrDash(source)}}); err != nil {
 		return err
 	}
 	if resolved == "" {
-		if err := stdoutPrintln("remote="); err != nil {
+		if err := env.stdoutPrintln("remote="); err != nil {
 			return err
 		}
-		return stdoutPrintln("origin=none")
+		return env.stdoutPrintln("origin=none")
 	}
-	if err := stdoutPrintf("remote=%s\n", resolved); err != nil {
+	if err := env.stdoutPrintf("remote=%s\n", resolved); err != nil {
 		return err
 	}
-	return stdoutPrintf("origin=%s\n", source)
+	return env.stdoutPrintf("origin=%s\n", source)
 }
 
-func executeServerRemoteUnset() error {
+func executeServerRemoteUnset(env *cliEnv) error {
 	configPath, err := sourceDefaultsPath()
 	if err != nil {
 		return err
 	}
-	if err := verboseCLIEvent(1, ctrllogs.CLIEvent{Component: "server", Event: "remote_unset", Attrs: map[string]any{"config": configPath}}); err != nil {
+	if err := env.verboseCLIEvent(1, ctrllogs.CLIEvent{Component: "server", Event: "remote_unset", Attrs: map[string]any{"config": configPath}}); err != nil {
 		return err
 	}
 	if err := clearSourceDefaults(); err != nil {
 		return err
 	}
-	return stdoutPrintln("server remote cleared")
+	return env.stdoutPrintln("server remote cleared")
 }
 
 type serverUpOptions struct {
@@ -301,7 +301,7 @@ type serverUpOptions struct {
 	unit          string
 }
 
-func executeServerUp(ctx context.Context, opts serverUpOptions) error {
+func executeServerUp(env *cliEnv, ctx context.Context, opts serverUpOptions) error {
 	if ctx == nil {
 		return fmt.Errorf("context is nil")
 	}
@@ -309,12 +309,12 @@ func executeServerUp(ctx context.Context, opts serverUpOptions) error {
 		return err
 	}
 	if !opts.daemon {
-		return executeServe(ctx, opts.root, opts.addr, opts.auditMaxSize, opts.auditMaxFiles, opts.tlsCert, opts.tlsKey, opts.tlsSelfSigned)
+		return executeServe(env, ctx, opts.root, opts.addr, opts.auditMaxSize, opts.auditMaxFiles, opts.tlsCert, opts.tlsKey, opts.tlsSelfSigned)
 	}
-	return runServerDaemon(ctx, opts)
+	return runServerDaemon(env, ctx, opts)
 }
 
-func executeServerDown(ctx context.Context, unit string) error {
+func executeServerDown(env *cliEnv, ctx context.Context, unit string) error {
 	if ctx == nil {
 		return fmt.Errorf("context is nil")
 	}
@@ -327,10 +327,10 @@ func executeServerDown(ctx context.Context, unit string) error {
 		}
 		return fmt.Errorf("server down: %s", msg)
 	}
-	return stdoutPrintf("server down: ok (%s)\n", resolvedUnit)
+	return env.stdoutPrintf("server down: ok (%s)\n", resolvedUnit)
 }
 
-func runServerDaemon(ctx context.Context, opts serverUpOptions) error {
+func runServerDaemon(env *cliEnv, ctx context.Context, opts serverUpOptions) error {
 	if ctx == nil {
 		return fmt.Errorf("context is nil")
 	}
@@ -352,14 +352,14 @@ func runServerDaemon(ctx context.Context, opts serverUpOptions) error {
 		}
 		return fmt.Errorf("server up: %s", msg)
 	}
-	if err := stdoutPrintf("server up: ok (%s.service)\n", resolvedUnit); err != nil {
+	if err := env.stdoutPrintf("server up: ok (%s.service)\n", resolvedUnit); err != nil {
 		return err
 	}
 	trimmed := strings.TrimSpace(string(raw))
 	if trimmed == "" {
 		return nil
 	}
-	return stdoutPrintf("%s\n", trimmed)
+	return env.stdoutPrintf("%s\n", trimmed)
 }
 
 func buildServerDaemonArgs(resolvedUnit string, execPath string, cwd string, opts serverUpOptions) []string {

--- a/cmd/deck/cobra_simple_leaf_commands.go
+++ b/cmd/deck/cobra_simple_leaf_commands.go
@@ -7,7 +7,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func newLintCommand() *cobra.Command {
+func newLintCommand(env *cliEnv) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "lint [scenario]",
 		Short: "Lint the workflow tree or a single workflow file",
@@ -29,7 +29,7 @@ func newLintCommand() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			return executeLint(cmd.Context(), root, file, scenario, output)
+			return executeLint(env, cmd.Context(), root, file, scenario, output)
 		},
 	}
 	cmd.Flags().String("root", ".", "workspace root containing workflows/")
@@ -38,7 +38,7 @@ func newLintCommand() *cobra.Command {
 	return cmd
 }
 
-func newInitCommand() *cobra.Command {
+func newInitCommand(env *cliEnv) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "init",
 		Short: "Scaffold starter deck files",
@@ -48,7 +48,7 @@ func newInitCommand() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			return executeInit(out)
+			return executeInit(env, out)
 		},
 	}
 	cmd.Flags().String("out", ".", "output directory")
@@ -56,7 +56,7 @@ func newInitCommand() *cobra.Command {
 	return cmd
 }
 
-func newCacheListCommand() *cobra.Command {
+func newCacheListCommand(env *cliEnv) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "list",
 		Short: "Show cached files",
@@ -66,14 +66,14 @@ func newCacheListCommand() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			return executeCacheList(output)
+			return executeCacheList(env, output)
 		},
 	}
 	cmd.Flags().StringP("output", "o", "text", "output format (text|json)")
 	return cmd
 }
 
-func newCacheCleanCommand() *cobra.Command {
+func newCacheCleanCommand(env *cliEnv) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "clean",
 		Short: "Delete cached entries, optionally by age",
@@ -86,7 +86,7 @@ func newCacheCleanCommand() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			return executeCacheClean(olderThan, dryRun)
+			return executeCacheClean(env, olderThan, dryRun)
 		},
 	}
 	cmd.Flags().SetInterspersed(false)

--- a/cmd/deck/command_helpers.go
+++ b/cmd/deck/command_helpers.go
@@ -11,12 +11,19 @@ import (
 	ctrllogs "github.com/Airgap-Castaways/deck/internal/logs"
 )
 
-var (
-	cliStdout    io.Writer = os.Stdout
-	cliStderr    io.Writer = os.Stderr
-	cliVerbosity int
-	cliLogFormat string = "text"
-)
+type cliEnv struct {
+	stdout    io.Writer
+	stderr    io.Writer
+	verbosity int
+	logFormat string
+}
+
+func newCLIEnv(stdout io.Writer, stderr io.Writer) *cliEnv {
+	env := &cliEnv{logFormat: "text"}
+	env.setWriters(stdout, stderr)
+	env.setLogFormat("text")
+	return env
+}
 
 type varFlag struct {
 	values map[string]string
@@ -128,86 +135,108 @@ func resolveCLILogFormat(format string) (string, error) {
 	return resolved, nil
 }
 
-func setCLIWriters(stdout io.Writer, stderr io.Writer) {
+func (e *cliEnv) setWriters(stdout io.Writer, stderr io.Writer) {
+	if e == nil {
+		return
+	}
 	if stdout == nil {
 		stdout = os.Stdout
 	}
 	if stderr == nil {
 		stderr = os.Stderr
 	}
-	cliStdout = stdout
-	cliStderr = stderr
-	refreshCLIStyle()
+	e.stdout = stdout
+	e.stderr = stderr
+	e.refreshStyle()
 }
 
-func setCLILogFormat(format string) {
+func (e *cliEnv) setLogFormat(format string) {
+	if e == nil {
+		return
+	}
 	resolved, err := resolveCLILogFormat(format)
 	if err != nil {
 		resolved = "text"
 	}
-	cliLogFormat = resolved
+	e.logFormat = resolved
 	ctrllogs.SetCLIFormat(resolved)
-	refreshCLIStyle()
+	e.refreshStyle()
 }
 
-func refreshCLIStyle() {
-	ctrllogs.SetCLIColorEnabled(cliLogFormat == "text" && (ctrllogs.WriterSupportsANSI(cliStderr) || ctrllogs.WriterSupportsANSI(cliStdout)))
+func (e *cliEnv) refreshStyle() {
+	if e == nil {
+		return
+	}
+	ctrllogs.SetCLIColorEnabled(e.logFormat == "text" && (ctrllogs.WriterSupportsANSI(e.stderr) || ctrllogs.WriterSupportsANSI(e.stdout)))
 }
 
-func stdoutWriter() io.Writer {
-	return cliStdout
+func (e *cliEnv) stdoutWriter() io.Writer {
+	if e == nil || e.stdout == nil {
+		return os.Stdout
+	}
+	return e.stdout
 }
 
-func stdoutJSONEncoder() *json.Encoder {
-	return json.NewEncoder(stdoutWriter())
+func (e *cliEnv) stdoutJSONEncoder() *json.Encoder {
+	return json.NewEncoder(e.stdoutWriter())
 }
 
-func setCLIVerbosity(level int) {
+func (e *cliEnv) setVerbosity(level int) {
+	if e == nil {
+		return
+	}
 	if level < 0 {
 		level = 0
 	}
-	cliVerbosity = level
+	e.verbosity = level
 }
 
 func formatCLIEvent(event ctrllogs.CLIEvent) string {
 	return ctrllogs.RenderCLIOrFallback(event)
 }
 
-func stderrCLIEvent(event ctrllogs.CLIEvent) error {
-	return ctrllogs.WriteCLIEvent(cliStderr, event)
+func (e *cliEnv) stderrCLIEvent(event ctrllogs.CLIEvent) error {
+	if e == nil || e.stderr == nil {
+		return ctrllogs.WriteCLIEvent(os.Stderr, event)
+	}
+	return ctrllogs.WriteCLIEvent(e.stderr, event)
 }
 
-func stdoutCLIEvent(event ctrllogs.CLIEvent) error {
-	return ctrllogs.WriteCLIEvent(stdoutWriter(), event)
+func (e *cliEnv) stdoutCLIEvent(event ctrllogs.CLIEvent) error {
+	return ctrllogs.WriteCLIEvent(e.stdoutWriter(), event)
 }
 
-func verboseCLIEvent(level int, event ctrllogs.CLIEvent) error {
-	if cliVerbosity < level {
+func (e *cliEnv) verboseCLIEvent(level int, event ctrllogs.CLIEvent) error {
+	if e == nil || e.verbosity < level {
 		return nil
 	}
-	return stderrCLIEvent(event)
+	return e.stderrCLIEvent(event)
 }
 
-func verbosef(level int, format string, args ...any) error {
-	if cliVerbosity < level {
+func (e *cliEnv) verbosef(level int, format string, args ...any) error {
+	if e == nil || e.verbosity < level {
 		return nil
 	}
-	_, err := fmt.Fprintf(cliStderr, format, args...)
+	_, err := fmt.Fprintf(e.stderr, format, args...)
 	return err
 }
 
-func stdoutPrintf(format string, args ...any) error {
-	_, err := fmt.Fprintf(stdoutWriter(), format, args...)
+func (e *cliEnv) stdoutPrintf(format string, args ...any) error {
+	_, err := fmt.Fprintf(e.stdoutWriter(), format, args...)
 	return err
 }
 
-func stdoutPrintln(args ...any) error {
-	_, err := fmt.Fprintln(stdoutWriter(), args...)
+func (e *cliEnv) stdoutPrintln(args ...any) error {
+	_, err := fmt.Fprintln(e.stdoutWriter(), args...)
 	return err
 }
 
-func stderrPrintf(format string, args ...any) error {
-	_, err := fmt.Fprintf(cliStderr, format, args...)
+func (e *cliEnv) stderrPrintf(format string, args ...any) error {
+	if e == nil || e.stderr == nil {
+		_, err := fmt.Fprintf(os.Stderr, format, args...)
+		return err
+	}
+	_, err := fmt.Fprintf(e.stderr, format, args...)
 	return err
 }
 

--- a/cmd/deck/main.go
+++ b/cmd/deck/main.go
@@ -20,9 +20,8 @@ func main() {
 }
 
 func runMain(args []string) error {
-	root := newRootCommand()
-	setCLIWriters(os.Stdout, os.Stderr)
-	defer setCLIWriters(os.Stdout, os.Stderr)
+	env := newCLIEnv(os.Stdout, os.Stderr)
+	root := newRootCommand(env)
 	root.SetOut(os.Stdout)
 	root.SetErr(os.Stderr)
 	root.SetArgs(args)
@@ -39,11 +38,10 @@ func run(args []string) error {
 }
 
 func execute(args []string) cliResult {
-	root := newRootCommand()
 	var stdout bytes.Buffer
 	var stderr bytes.Buffer
-	setCLIWriters(&stdout, &stderr)
-	defer setCLIWriters(os.Stdout, os.Stderr)
+	env := newCLIEnv(&stdout, &stderr)
+	root := newRootCommand(env)
 	root.SetOut(&stdout)
 	root.SetErr(&stderr)
 	root.SetArgs(args)

--- a/cmd/deck/root_cobra.go
+++ b/cmd/deck/root_cobra.go
@@ -7,10 +7,13 @@ const (
 	commandGroupAdditional = "additional"
 )
 
-func newRootCommand() *cobra.Command {
+func newRootCommand(env *cliEnv) *cobra.Command {
+	if env == nil {
+		env = newCLIEnv(nil, nil)
+	}
 	cobra.EnableCommandSorting = false
-	setCLIVerbosity(0)
-	setCLILogFormat("text")
+	env.setVerbosity(0)
+	env.setLogFormat("text")
 
 	cmd := &cobra.Command{
 		Use:                "deck",
@@ -20,16 +23,17 @@ func newRootCommand() *cobra.Command {
 		SilenceUsage:       true,
 		DisableSuggestions: true,
 		PersistentPreRunE: func(_ *cobra.Command, _ []string) error {
-			resolved, err := resolveCLILogFormat(cliLogFormat)
+			resolved, err := resolveCLILogFormat(env.logFormat)
 			if err != nil {
 				return err
 			}
-			setCLILogFormat(resolved)
+			env.setLogFormat(resolved)
+			env.setVerbosity(env.verbosity)
 			return nil
 		},
 	}
-	cmd.PersistentFlags().IntVar(&cliVerbosity, "v", 0, "diagnostic verbosity level")
-	cmd.PersistentFlags().StringVar(&cliLogFormat, "log-format", "text", "diagnostic log format (text|json)")
+	cmd.PersistentFlags().IntVar(&env.verbosity, "v", 0, "diagnostic verbosity level")
+	cmd.PersistentFlags().StringVar(&env.logFormat, "log-format", "text", "diagnostic log format (text|json)")
 
 	cmd.CompletionOptions.DisableDefaultCmd = true
 	cmd.SetHelpCommandGroupID(commandGroupAdditional)
@@ -39,18 +43,18 @@ func newRootCommand() *cobra.Command {
 	)
 
 	for _, child := range []*cobra.Command{
-		withGroup(newInitCommand(), commandGroupCore),
-		withGroup(newLintCommand(), commandGroupCore),
-		withGroup(newPrepareCommand(), commandGroupCore),
-		withGroup(newBundleCommand(), commandGroupCore),
-		withGroup(newPlanCommand(), commandGroupCore),
-		withGroup(newApplyCommand(), commandGroupCore),
-		withGroup(newListCommand(), commandGroupAdditional),
-		withGroup(newServerCommand(), commandGroupAdditional),
-		withGroup(newAskCommand(), commandGroupAdditional),
-		withGroup(newVersionCommand(), commandGroupAdditional),
+		withGroup(newInitCommand(env), commandGroupCore),
+		withGroup(newLintCommand(env), commandGroupCore),
+		withGroup(newPrepareCommand(env), commandGroupCore),
+		withGroup(newBundleCommand(env), commandGroupCore),
+		withGroup(newPlanCommand(env), commandGroupCore),
+		withGroup(newApplyCommand(env), commandGroupCore),
+		withGroup(newListCommand(env), commandGroupAdditional),
+		withGroup(newServerCommand(env), commandGroupAdditional),
+		withGroup(newAskCommand(env), commandGroupAdditional),
+		withGroup(newVersionCommand(env), commandGroupAdditional),
 		withGroup(newCompletionCommand(), commandGroupAdditional),
-		withGroup(newCacheCommand(), commandGroupAdditional),
+		withGroup(newCacheCommand(env), commandGroupAdditional),
 	} {
 		if child != nil {
 			cmd.AddCommand(child)

--- a/cmd/deck/scenario_cli.go
+++ b/cmd/deck/scenario_cli.go
@@ -33,7 +33,7 @@ type scenarioEntry struct {
 	Workflow string `json:"workflow"`
 }
 
-func newListCommand() *cobra.Command {
+func newListCommand(env *cliEnv) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "list",
 		Short: "List available scenarios from local workflows or the saved remote server",
@@ -47,7 +47,7 @@ func newListCommand() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			return executeList(cmd.Context(), strings.TrimSpace(source), strings.TrimSpace(output))
+			return executeList(env, cmd.Context(), strings.TrimSpace(source), strings.TrimSpace(output))
 		},
 	}
 	cmd.Flags().String("source", scenarioSourceAll, "scenario source (local|server|all)")
@@ -56,7 +56,7 @@ func newListCommand() *cobra.Command {
 	return cmd
 }
 
-func executeList(ctx context.Context, source, output string) error {
+func executeList(env *cliEnv, ctx context.Context, source, output string) error {
 	if ctx == nil {
 		return fmt.Errorf("context is nil")
 	}
@@ -68,33 +68,33 @@ func executeList(ctx context.Context, source, output string) error {
 	if err != nil {
 		return err
 	}
-	if err := verboseCLIEvent(1, ctrllogs.CLIEvent{Component: "list", Event: "list_requested", Attrs: map[string]any{"source": resolvedSource, "output": strings.TrimSpace(output)}}); err != nil {
+	if err := env.verboseCLIEvent(1, ctrllogs.CLIEvent{Component: "list", Event: "list_requested", Attrs: map[string]any{"source": resolvedSource, "output": strings.TrimSpace(output)}}); err != nil {
 		return err
 	}
 
-	entries, err := discoverScenarioEntries(ctx, resolvedSource)
+	entries, err := discoverScenarioEntries(env, ctx, resolvedSource)
 	if err != nil {
 		return err
 	}
-	if err := verboseCLIEvent(1, ctrllogs.CLIEvent{Component: "list", Event: "list_loaded", Attrs: map[string]any{"entries": len(entries)}}); err != nil {
+	if err := env.verboseCLIEvent(1, ctrllogs.CLIEvent{Component: "list", Event: "list_loaded", Attrs: map[string]any{"entries": len(entries)}}); err != nil {
 		return err
 	}
 
 	if resolvedOutput == "json" {
-		enc := stdoutJSONEncoder()
+		enc := env.stdoutJSONEncoder()
 		enc.SetIndent("", "  ")
 		return enc.Encode(entries)
 	}
 
 	for _, entry := range entries {
-		if err := stdoutPrintf("%s\t%s\t%s\n", entry.Source, entry.Name, entry.Workflow); err != nil {
+		if err := env.stdoutPrintf("%s\t%s\t%s\n", entry.Source, entry.Name, entry.Workflow); err != nil {
 			return err
 		}
 	}
 	return nil
 }
 
-func discoverScenarioEntries(ctx context.Context, source string) ([]scenarioEntry, error) {
+func discoverScenarioEntries(env *cliEnv, ctx context.Context, source string) ([]scenarioEntry, error) {
 	entries := make([]scenarioEntry, 0)
 
 	if source == scenarioSourceLocal || source == scenarioSourceAll {
@@ -103,7 +103,7 @@ func discoverScenarioEntries(ctx context.Context, source string) ([]scenarioEntr
 			if source != scenarioSourceAll {
 				return nil, err
 			}
-			_ = verboseCLIEvent(2, ctrllogs.CLIEvent{Level: "debug", Component: "list", Event: "local_skipped", Attrs: map[string]any{"error": err}})
+			_ = env.verboseCLIEvent(2, ctrllogs.CLIEvent{Level: "debug", Component: "list", Event: "local_skipped", Attrs: map[string]any{"error": err}})
 		} else {
 			entries = append(entries, localEntries...)
 		}
@@ -116,19 +116,19 @@ func discoverScenarioEntries(ctx context.Context, source string) ([]scenarioEntr
 			if source != scenarioSourceAll {
 				return nil, err
 			}
-			_ = verboseCLIEvent(2, ctrllogs.CLIEvent{Level: "debug", Component: "list", Event: "server_skipped", Attrs: map[string]any{"error": err}})
+			_ = env.verboseCLIEvent(2, ctrllogs.CLIEvent{Level: "debug", Component: "list", Event: "server_skipped", Attrs: map[string]any{"error": err}})
 		case strings.TrimSpace(serverURL) != "":
 			serverEntries, err := discoverServerScenarioEntries(ctx, serverURL)
 			if err != nil {
 				if source != scenarioSourceAll {
 					return nil, err
 				}
-				_ = verboseCLIEvent(2, ctrllogs.CLIEvent{Level: "debug", Component: "list", Event: "server_lookup_failed", Attrs: map[string]any{"server": serverURL, "error": err}})
+				_ = env.verboseCLIEvent(2, ctrllogs.CLIEvent{Level: "debug", Component: "list", Event: "server_lookup_failed", Attrs: map[string]any{"server": serverURL, "error": err}})
 			} else {
 				entries = append(entries, serverEntries...)
 			}
 		case source == scenarioSourceAll:
-			_ = verboseCLIEvent(2, ctrllogs.CLIEvent{Level: "debug", Component: "list", Event: "server_skipped", Attrs: map[string]any{"reason": "no-remote"}})
+			_ = env.verboseCLIEvent(2, ctrllogs.CLIEvent{Level: "debug", Component: "list", Event: "server_skipped", Attrs: map[string]any{"reason": "no-remote"}})
 		case source == scenarioSourceServer:
 			return nil, errors.New("saved remote server URL is required; set one with \"deck server remote set <url>\"")
 		}

--- a/cmd/deck/server_misc_cli_test.go
+++ b/cmd/deck/server_misc_cli_test.go
@@ -423,12 +423,12 @@ func TestCache(t *testing.T) {
 }
 
 func TestRunServerAuditRotationFlagValidation(t *testing.T) {
-	err := executeServe(context.Background(), "./bundle", ":8080", 0, 10, "", "", false)
+	err := executeServe(newCLIEnv(nil, nil), context.Background(), "./bundle", ":8080", 0, 10, "", "", false)
 	if err == nil || !strings.Contains(err.Error(), "--audit-max-size-mb must be > 0") {
 		t.Fatalf("expected audit max size validation error, got %v", err)
 	}
 
-	err = executeServe(context.Background(), "./bundle", ":8080", 50, 0, "", "", false)
+	err = executeServe(newCLIEnv(nil, nil), context.Background(), "./bundle", ":8080", 50, 0, "", "", false)
 	if err == nil || !strings.Contains(err.Error(), "--audit-max-files must be > 0") {
 		t.Fatalf("expected audit max files validation error, got %v", err)
 	}


### PR DESCRIPTION
## Summary
- replace mutable package-global CLI stdout/stderr, verbosity, and log-format state with an explicit `cliEnv`
- thread the command-scoped environment through root/child command constructors and command execution helpers
- keep CLI output, diagnostics, and log-format behavior unchanged while removing hidden shared state

## Verification
- `go test ./cmd/deck`
- `go test ./...`
- `make test`
- `make lint`
- `make build && ./bin/deck --help && ./bin/deck version`

Closes #166