### PR TITLE
refactor: unify step dispatch registration

### DIFF
--- a/internal/install/dispatch.go
+++ b/internal/install/dispatch.go
@@ -21,7 +21,7 @@ func (installLookPathRunner) LookPath(file string) (string, error) {
 
 type installStepHandler func(ctx context.Context, step config.Step, rendered map[string]any, effectiveSpec map[string]any, execCtx ExecutionContext) (map[string]any, error)
 
-var installStepHandlers = map[string]installStepHandler{
+var installStepHandlers = workflowexec.MustStepRoleHandlers("apply", map[string]installStepHandler{
 	"CheckHost":                    installCheckHost,
 	"CheckKubernetesCluster":       installCheckKubernetesCluster,
 	"Command":                      installCommand,
@@ -56,19 +56,15 @@ var installStepHandlers = map[string]installStepHandler{
 	"WriteContainerdRegistryHosts": installWriteContainerdRegistryHosts,
 	"WriteFile":                    installWriteFile,
 	"WriteSystemdUnit":             installWriteSystemdUnit,
-}
+})
 
 func executeWorkflowStep(ctx context.Context, step config.Step, rendered map[string]any, key workflowexec.StepTypeKey, execCtx ExecutionContext) (map[string]any, error) {
 	kind := step.Kind
 	effectiveSpec := specWithStepTimeout(rendered, step.Timeout)
-	allowed, err := workflowexec.StepAllowedForRoleForKey("apply", key)
+	handler, ok, err := workflowexec.StepRoleHandlerForKey("apply", installStepHandlers, key)
 	if err != nil {
 		return nil, err
 	}
-	if !allowed {
-		return nil, errcode.Newf(errCodeInstallKindUnsupported, "unsupported step kind %s", kind)
-	}
-	handler, ok := installStepHandlers[kind]
 	if !ok {
 		return nil, errcode.Newf(errCodeInstallKindUnsupported, "unsupported step kind %s", kind)
 	}

--- a/internal/install/dispatch_contract_test.go
+++ b/internal/install/dispatch_contract_test.go
@@ -7,16 +7,7 @@ import (
 )
 
 func TestInstallStepHandlersCoverApplyKinds(t *testing.T) {
-	defs, err := workflowexec.StepDefinitions()
-	if err != nil {
-		t.Fatalf("StepDefinitions: %v", err)
-	}
-	for _, def := range defs {
-		if !contains(def.Roles, "apply") {
-			continue
-		}
-		if _, ok := installStepHandlers[def.Kind]; !ok {
-			t.Fatalf("missing install handler for apply kind %s", def.Kind)
-		}
+	if _, err := workflowexec.StepRoleHandlers("apply", installStepHandlers); err != nil {
+		t.Fatalf("install step handler registration: %v", err)
 	}
 }

--- a/internal/prepare/dispatch_contract_test.go
+++ b/internal/prepare/dispatch_contract_test.go
@@ -7,16 +7,7 @@ import (
 )
 
 func TestPrepareStepHandlersCoverPrepareKinds(t *testing.T) {
-	defs, err := workflowexec.StepDefinitions()
-	if err != nil {
-		t.Fatalf("StepDefinitions: %v", err)
-	}
-	for _, def := range defs {
-		if !contains(def.Roles, "prepare") {
-			continue
-		}
-		if _, ok := prepareStepHandlers[def.Kind]; !ok {
-			t.Fatalf("missing prepare handler for prepare kind %s", def.Kind)
-		}
+	if _, err := workflowexec.StepRoleHandlers("prepare", prepareStepHandlers); err != nil {
+		t.Fatalf("prepare step handler registration: %v", err)
 	}
 }

--- a/internal/prepare/step_dispatch.go
+++ b/internal/prepare/step_dispatch.go
@@ -14,23 +14,19 @@ import (
 
 type prepareStepHandler func(ctx context.Context, runner CommandRunner, bundleRoot string, step config.Step, rendered map[string]any, inputVars map[string]string, opts RunOptions) ([]string, map[string]any, error)
 
-var prepareStepHandlers = map[string]prepareStepHandler{
+var prepareStepHandlers = workflowexec.MustStepRoleHandlers("prepare", map[string]prepareStepHandler{
 	"CheckHost":       prepareCheckHost,
 	"DownloadFile":    prepareDownloadFile,
 	"DownloadImage":   prepareDownloadImage,
 	"DownloadPackage": prepareDownloadPackage,
-}
+})
 
 func runPrepareRenderedStepWithKey(ctx context.Context, runner CommandRunner, bundleRoot string, step config.Step, rendered map[string]any, key workflowexec.StepTypeKey, inputVars map[string]string, opts RunOptions) ([]string, map[string]any, error) {
 	kind := step.Kind
-	allowed, err := workflowexec.StepAllowedForRoleForKey("prepare", key)
+	handler, ok, err := workflowexec.StepRoleHandlerForKey("prepare", prepareStepHandlers, key)
 	if err != nil {
 		return nil, nil, err
 	}
-	if !allowed {
-		return nil, nil, errcode.Newf(errCodePrepareKindUnsupported, "unsupported step kind %s", kind)
-	}
-	handler, ok := prepareStepHandlers[kind]
 	if !ok {
 		return nil, nil, errcode.Newf(errCodePrepareKindUnsupported, "unsupported step kind %s", kind)
 	}

--- a/internal/workflowexec/runtime_registry.go
+++ b/internal/workflowexec/runtime_registry.go
@@ -15,20 +15,25 @@ func MustStepRoleHandlers[T any](role string, handlers map[string]T) map[string]
 }
 
 func StepRoleHandlers[T any](role string, handlers map[string]T) (map[string]T, error) {
-	role = strings.TrimSpace(role)
-	if role == "" {
-		return nil, fmt.Errorf("step role is required")
-	}
 	defs, err := StepDefinitions()
 	if err != nil {
 		return nil, err
 	}
+	return stepRoleHandlersForDefinitions(role, handlers, defs)
+}
+
+func stepRoleHandlersForDefinitions[T any](role string, handlers map[string]T, defs []StepDefinition) (map[string]T, error) {
+	role = strings.TrimSpace(role)
+	if role == "" {
+		return nil, fmt.Errorf("step role is required")
+	}
 	required := map[string]struct{}{}
 	rolesByKind := map[string][]string{}
 	for _, def := range defs {
-		rolesByKind[def.Kind] = def.Roles
+		kind := strings.TrimSpace(def.Kind)
+		rolesByKind[kind] = append(rolesByKind[kind], def.Roles...)
 		if containsString(def.Roles, role) {
-			required[def.Kind] = struct{}{}
+			required[kind] = struct{}{}
 		}
 	}
 	if len(required) == 0 {
@@ -46,7 +51,7 @@ func StepRoleHandlers[T any](role string, handlers map[string]T) (map[string]T, 
 			return nil, fmt.Errorf("step handler for role %q references unknown kind %q", role, kind)
 		}
 		if !containsString(roles, role) {
-			return nil, fmt.Errorf("step handler for kind %q is registered for role %q, but metadata roles are %s", kind, role, strings.Join(roles, ","))
+			return nil, fmt.Errorf("step handler for kind %q is registered for role %q, but metadata roles are %s", kind, role, strings.Join(roles, ", "))
 		}
 		if _, exists := registered[kind]; exists {
 			return nil, fmt.Errorf("duplicate step handler for role %q and kind %q", role, kind)

--- a/internal/workflowexec/runtime_registry.go
+++ b/internal/workflowexec/runtime_registry.go
@@ -1,0 +1,82 @@
+package workflowexec
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+func MustStepRoleHandlers[T any](role string, handlers map[string]T) map[string]T {
+	registered, err := StepRoleHandlers(role, handlers)
+	if err != nil {
+		panic(err)
+	}
+	return registered
+}
+
+func StepRoleHandlers[T any](role string, handlers map[string]T) (map[string]T, error) {
+	role = strings.TrimSpace(role)
+	if role == "" {
+		return nil, fmt.Errorf("step role is required")
+	}
+	defs, err := StepDefinitions()
+	if err != nil {
+		return nil, err
+	}
+	required := map[string]struct{}{}
+	rolesByKind := map[string][]string{}
+	for _, def := range defs {
+		rolesByKind[def.Kind] = def.Roles
+		if containsString(def.Roles, role) {
+			required[def.Kind] = struct{}{}
+		}
+	}
+	if len(required) == 0 {
+		return nil, fmt.Errorf("no step definitions registered for role %q", role)
+	}
+
+	registered := make(map[string]T, len(handlers))
+	for rawKind, handler := range handlers {
+		kind := strings.TrimSpace(rawKind)
+		if kind == "" {
+			return nil, fmt.Errorf("step handler kind is required for role %q", role)
+		}
+		roles, ok := rolesByKind[kind]
+		if !ok {
+			return nil, fmt.Errorf("step handler for role %q references unknown kind %q", role, kind)
+		}
+		if !containsString(roles, role) {
+			return nil, fmt.Errorf("step handler for kind %q is registered for role %q, but metadata roles are %s", kind, role, strings.Join(roles, ","))
+		}
+		if _, exists := registered[kind]; exists {
+			return nil, fmt.Errorf("duplicate step handler for role %q and kind %q", role, kind)
+		}
+		registered[kind] = handler
+	}
+
+	missing := make([]string, 0)
+	for kind := range required {
+		if _, ok := registered[kind]; !ok {
+			missing = append(missing, kind)
+		}
+	}
+	if len(missing) > 0 {
+		sort.Strings(missing)
+		return nil, fmt.Errorf("missing step handlers for role %q: %s", role, strings.Join(missing, ", "))
+	}
+	return registered, nil
+}
+
+func StepRoleHandlerForKey[T any](role string, handlers map[string]T, key StepTypeKey) (T, bool, error) {
+	var zero T
+	normalized := normalizeStepKey(key)
+	allowed, err := StepAllowedForRoleForKey(role, normalized)
+	if err != nil {
+		return zero, false, err
+	}
+	if !allowed {
+		return zero, false, nil
+	}
+	handler, ok := handlers[normalized.Kind]
+	return handler, ok, nil
+}

--- a/internal/workflowexec/runtime_registry_test.go
+++ b/internal/workflowexec/runtime_registry_test.go
@@ -31,6 +31,19 @@ func TestStepRoleHandlersRejectWrongRole(t *testing.T) {
 	}
 }
 
+func TestStepRoleHandlersAggregateRolesForDuplicateKinds(t *testing.T) {
+	registered, err := stepRoleHandlersForDefinitions("apply", map[string]string{"Shared": "handler"}, []StepDefinition{
+		{Kind: "Shared ", Roles: []string{"apply"}},
+		{Kind: "Shared", Roles: []string{"prepare"}},
+	})
+	if err != nil {
+		t.Fatalf("StepRoleHandlers: %v", err)
+	}
+	if got := registered["Shared"]; got != "handler" {
+		t.Fatalf("handler mismatch: got %q", got)
+	}
+}
+
 func TestStepRoleHandlerForKeyRejectsUnsupportedRole(t *testing.T) {
 	handlers := MustStepRoleHandlers("apply", handlersForRole(t, "apply"))
 

--- a/internal/workflowexec/runtime_registry_test.go
+++ b/internal/workflowexec/runtime_registry_test.go
@@ -1,0 +1,59 @@
+package workflowexec
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestStepRoleHandlersRequireCompleteRoleCoverage(t *testing.T) {
+	handlers := handlersForRole(t, "apply")
+	delete(handlers, "Command")
+
+	_, err := StepRoleHandlers("apply", handlers)
+	if err == nil {
+		t.Fatal("expected missing handler error")
+	}
+	if !strings.Contains(err.Error(), "missing step handlers for role \"apply\"") || !strings.Contains(err.Error(), "Command") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestStepRoleHandlersRejectWrongRole(t *testing.T) {
+	handlers := handlersForRole(t, "apply")
+	handlers["DownloadFile"] = "DownloadFile"
+
+	_, err := StepRoleHandlers("apply", handlers)
+	if err == nil {
+		t.Fatal("expected wrong role error")
+	}
+	if !strings.Contains(err.Error(), "DownloadFile") || !strings.Contains(err.Error(), "metadata roles are prepare") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestStepRoleHandlerForKeyRejectsUnsupportedRole(t *testing.T) {
+	handlers := MustStepRoleHandlers("apply", handlersForRole(t, "apply"))
+
+	_, ok, err := StepRoleHandlerForKey("apply", handlers, StepTypeKey{APIVersion: "deck/v1", Kind: "DownloadFile"})
+	if err != nil {
+		t.Fatalf("StepRoleHandlerForKey: %v", err)
+	}
+	if ok {
+		t.Fatal("expected prepare-only kind to be unsupported for apply")
+	}
+}
+
+func handlersForRole(t *testing.T, role string) map[string]string {
+	t.Helper()
+	defs, err := StepDefinitions()
+	if err != nil {
+		t.Fatalf("StepDefinitions: %v", err)
+	}
+	handlers := map[string]string{}
+	for _, def := range defs {
+		if containsString(def.Roles, role) {
+			handlers[def.Kind] = def.Kind
+		}
+	}
+	return handlers
+}

--- a/internal/workflowexec/step_registry.go
+++ b/internal/workflowexec/step_registry.go
@@ -7,6 +7,8 @@ import (
 )
 
 type (
+	// StepDefinition is re-exported so runtime packages can use workflowexec as
+	// the facade for step keys, role checks, and dispatch registration.
 	StepDefinition = workflowcontract.StepDefinition
 	StepTypeKey    = workflowcontract.StepTypeKey
 )

--- a/internal/workflowexec/type_registry.go
+++ b/internal/workflowexec/type_registry.go
@@ -3,6 +3,8 @@ package workflowexec
 import "github.com/Airgap-Castaways/deck/internal/workflowcontract"
 
 type (
+	// These aliases keep schema/documentation callers on the workflowexec facade
+	// when they need runtime step keys and contract projections together.
 	FieldDoc              = workflowcontract.FieldDoc
 	ToolMetadata          = workflowcontract.ToolMetadata
 	SchemaMetadata        = workflowcontract.SchemaMetadata


### PR DESCRIPTION
## Summary
- add workflowexec role-based step handler registration that validates runtime handlers against step metadata
- initialize apply and prepare dispatch maps through the shared registration flow
- simplify dispatch contract tests and add negative coverage for missing or role-mismatched handlers

## Verification
- `go test ./internal/workflowexec ./internal/install ./internal/prepare`
- `go test ./...`
- `make test`
- `make lint`

Closes #168