### PR TITLE
Share ask workspace scaffold setup

### DIFF
--- a/docs/contributing/ask-agent-runtime.md
+++ b/docs/contributing/ask-agent-runtime.md
@@ -56,6 +56,7 @@ The important boundary is that the model operates on file tools, not on a deck-s
 - write scope is derived during preflight and enforced before candidate state mutates
 - refine stays inside the anchor and any code-approved companion paths
 - `file_write` updates candidate state first; disk writes happen only after successful finish
+- the internal `init` tool is the exception: in an empty workflow workspace it may create the minimal scaffold directories, ignore files, and output `.keep` files needed before final workflow writes
 - `finish` is rejected until `deck_lint` succeeds in the current session
 - tool calls and verifier output are persisted in `.deck/ask/last-agent-session.json`
 - final disk writes still go through normal scaffold and validation helpers
@@ -66,6 +67,7 @@ Ask may project deck facts into prompts and runtime tools, but it must not becom
 
 - step and field validity belong to `internal/stepmeta`, generated schema, and `internal/validate`
 - canonical workflow path rules belong to workspace/path helpers, not ask prompts
+- workspace scaffold primitives belong to `internal/initcli`; ask must not maintain a parallel copy of `deck init` layout logic
 - evidence planning decides when upstream docs are needed, but external docs do not override deck-owned workflow truth
 - clarification decisions, path scope, and finish gating stay code-driven
 

--- a/docs/guides/ask.md
+++ b/docs/guides/ask.md
@@ -71,14 +71,15 @@ Before the model can edit anything, code performs preflight work to decide:
 
 The model then works through a small tool set over the real workspace:
 
-- `file_search`
-- `file_read`
+- `glob`
+- `read`
 - `file_write`
-- `deck_init`
-- `deck_lint`
+- `file_edit`
+- `init`
+- `validate`
 - `mcp_web_search` when external evidence is allowed and needed
 
-`file_write` does not write to disk immediately. It updates session-owned candidate state first, then `deck ask` writes files only after the session finishes successfully.
+`file_write` and `file_edit` do not write workflow files to disk immediately. They update session-owned candidate state first, then `deck ask` writes files only after the session finishes successfully. In an empty workspace, the authoring runtime may call its internal `init` tool first; that tool prepares only the minimal directories, ignore files, and output `.keep` files needed for generated workflow files. It does not run full `deck init` or create starter workflow templates.
 
 ### Step 4: Lint gates the final write
 

--- a/internal/askcli/author_runtime.go
+++ b/internal/askcli/author_runtime.go
@@ -583,7 +583,6 @@ func relativeScaffoldPaths(root string, paths []string) []string {
 		}
 		relative = append(relative, filepath.ToSlash(rel))
 	}
-	sort.Strings(relative)
 	return relative
 }
 

--- a/internal/askcli/author_runtime.go
+++ b/internal/askcli/author_runtime.go
@@ -24,6 +24,7 @@ import (
 	"github.com/Airgap-Castaways/deck/internal/askretrieve"
 	"github.com/Airgap-Castaways/deck/internal/askstate"
 	"github.com/Airgap-Castaways/deck/internal/fsutil"
+	"github.com/Airgap-Castaways/deck/internal/initcli"
 	"github.com/Airgap-Castaways/deck/internal/stepmeta"
 )
 
@@ -565,11 +566,25 @@ func (s *authoringAgentSession) runInit() agentToolResult {
 	if s.workspace.HasWorkflowTree {
 		return agentToolResult{OK: false, Summary: "init is disabled", Payload: map[string]any{"ok": false, "error": "init is disabled because the workspace already has a workflow tree"}}
 	}
-	if err := ensureScaffold(s.root); err != nil {
+	scaffold, err := initcli.EnsureWorkspaceScaffold(s.root, ".deck")
+	if err != nil {
 		return agentToolResult{OK: false, Summary: "init failed", Payload: map[string]any{"ok": false, "error": err.Error()}}
 	}
 	s.scaffoldRequested = true
-	return agentToolResult{OK: true, Summary: "prepared default workspace scaffold", Payload: map[string]any{"ok": true, "createdDirectories": []string{"workflows/scenarios", "workflows/components", "outputs/files", "outputs/images", "outputs/packages"}, "createdFiles": []string{".gitignore", ".deckignore", "outputs/files/.keep", "outputs/images/.keep", "outputs/packages/.keep"}}}
+	return agentToolResult{OK: true, Summary: "prepared minimal workspace scaffold", Payload: map[string]any{"ok": true, "createdDirectories": relativeScaffoldPaths(s.root, scaffold.Directories), "createdFiles": relativeScaffoldPaths(s.root, scaffold.Files)}}
+}
+
+func relativeScaffoldPaths(root string, paths []string) []string {
+	relative := make([]string, 0, len(paths))
+	for _, path := range paths {
+		rel, err := filepath.Rel(root, path)
+		if err != nil {
+			rel = path
+		}
+		relative = append(relative, filepath.ToSlash(rel))
+	}
+	sort.Strings(relative)
+	return relative
 }
 
 func (s *authoringAgentSession) runValidate(ctx context.Context, call authorToolCall) agentToolResult {

--- a/internal/askcli/author_runtime_test.go
+++ b/internal/askcli/author_runtime_test.go
@@ -258,7 +258,7 @@ func TestAuthoringAgentGlobAndReadSupportCandidateState(t *testing.T) {
 	}
 }
 
-func TestAuthoringAgentInitCreatesScaffoldInEmptyWorkspace(t *testing.T) {
+func TestAuthoringAgentInitCreatesMinimalScaffoldInEmptyWorkspace(t *testing.T) {
 	root := t.TempDir()
 	session := newTestAgentSession(t, root, "create a simple apply workflow", askintent.Decision{Route: askintent.RouteDraft, Target: askintent.Target{Kind: "workspace"}})
 	result := session.runInit()
@@ -266,14 +266,27 @@ func TestAuthoringAgentInitCreatesScaffoldInEmptyWorkspace(t *testing.T) {
 		t.Fatalf("expected init to succeed, got %s", renderAgentPayload(result.Payload))
 	}
 	for _, rel := range []string{
+		".deck",
 		".gitignore",
 		".deckignore",
+		filepath.Join("workflows", "scenarios"),
+		filepath.Join("workflows", "components"),
 		filepath.Join("outputs", "files", ".keep"),
 		filepath.Join("outputs", "images", ".keep"),
 		filepath.Join("outputs", "packages", ".keep"),
 	} {
 		if _, err := os.Stat(filepath.Join(root, rel)); err != nil {
 			t.Fatalf("expected scaffold path %s to exist: %v", rel, err)
+		}
+	}
+	for _, rel := range []string{
+		workspacepaths.CanonicalPrepareWorkflow,
+		workspacepaths.CanonicalApplyWorkflow,
+		workspacepaths.CanonicalVarsWorkflow,
+		filepath.Join("workflows", "components", "example-apply.yaml"),
+	} {
+		if _, err := os.Stat(filepath.Join(root, rel)); !os.IsNotExist(err) {
+			t.Fatalf("ask init must not create starter workflow file %s, stat err=%v", rel, err)
 		}
 	}
 }
@@ -348,7 +361,7 @@ func TestAuthoringAgentStagesInvalidCandidateForRepair(t *testing.T) {
 	}
 }
 
-func TestAuthoringAgentDeckInitIsDisabledWhenWorkflowTreeExists(t *testing.T) {
+func TestAuthoringAgentInitIsDisabledWhenWorkflowTreeExists(t *testing.T) {
 	root := t.TempDir()
 	if err := os.MkdirAll(filepath.Join(root, "workflows", "scenarios"), 0o755); err != nil {
 		t.Fatalf("mkdir workflow dir: %v", err)
@@ -359,7 +372,7 @@ func TestAuthoringAgentDeckInitIsDisabledWhenWorkflowTreeExists(t *testing.T) {
 	session := newTestAgentSession(t, root, "refine workflows/scenarios/apply.yaml", askintent.Decision{Route: askintent.RouteRefine, Target: askintent.Target{Kind: "scenario", Path: workspacepaths.CanonicalApplyWorkflow}})
 	result := session.runInit()
 	if result.OK {
-		t.Fatalf("expected deck_init to be disabled when workflow tree exists")
+		t.Fatalf("expected ask init to be disabled when workflow tree exists")
 	}
 }
 

--- a/internal/askcli/author_runtime_tools.go
+++ b/internal/askcli/author_runtime_tools.go
@@ -154,7 +154,7 @@ func authorToolDescription(name string) string {
 	case "schema":
 		return "Read repo-owned workflow rules or exact typed step schema/example data."
 	case "init":
-		return "Prepare the default workspace scaffold for an empty workflow workspace."
+		return "Prepare the minimal workspace scaffold for ask-generated files in an empty workflow workspace; this is not full deck init."
 	case "web_search":
 		return "Look up optional external evidence when policy allows it."
 	default:

--- a/internal/askcli/files.go
+++ b/internal/askcli/files.go
@@ -20,6 +20,7 @@ import (
 	"github.com/Airgap-Castaways/deck/internal/askretrieve"
 	"github.com/Airgap-Castaways/deck/internal/askreview"
 	"github.com/Airgap-Castaways/deck/internal/fsutil"
+	"github.com/Airgap-Castaways/deck/internal/initcli"
 	"github.com/Airgap-Castaways/deck/internal/validate"
 	"github.com/Airgap-Castaways/deck/internal/workspacepaths"
 )
@@ -205,34 +206,9 @@ func localFindings(files []askcontract.GeneratedFile) []askreview.Finding {
 }
 
 func ensureScaffold(root string) error {
-	for _, dir := range []string{
-		filepath.Join(root, ".deck"),
-		filepath.Join(root, workspacepaths.WorkflowRootDir, workspacepaths.WorkflowScenariosDir),
-		filepath.Join(root, workspacepaths.WorkflowRootDir, workspacepaths.WorkflowComponentsDir),
-		filepath.Join(root, workspacepaths.PreparedDirRel, "files"),
-		filepath.Join(root, workspacepaths.PreparedDirRel, "images"),
-		filepath.Join(root, workspacepaths.PreparedDirRel, "packages"),
-	} {
-		if err := os.MkdirAll(dir, 0o750); err != nil {
-			return fmt.Errorf("create workspace scaffold: %w", err)
-		}
-	}
-	defaults := map[string]string{
-		filepath.Join(root, ".gitignore"):                                       strings.Join([]string{"/.deck/", "/deck", "/outputs/", "*.tar", ""}, "\n"),
-		filepath.Join(root, ".deckignore"):                                      strings.Join([]string{".git/", ".gitignore", ".deckignore", "/*.tar", ""}, "\n"),
-		filepath.Join(root, workspacepaths.PreparedDirRel, "files", ".keep"):    "",
-		filepath.Join(root, workspacepaths.PreparedDirRel, "images", ".keep"):   "",
-		filepath.Join(root, workspacepaths.PreparedDirRel, "packages", ".keep"): "",
-	}
-	for path, content := range defaults {
-		if _, err := os.Stat(path); err == nil {
-			continue
-		} else if !os.IsNotExist(err) {
-			return fmt.Errorf("stat scaffold file %s: %w", path, err)
-		}
-		if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
-			return fmt.Errorf("write scaffold file %s: %w", path, err)
-		}
+	_, err := initcli.EnsureWorkspaceScaffold(root, ".deck")
+	if err != nil {
+		return fmt.Errorf("create workspace scaffold: %w", err)
 	}
 	return nil
 }

--- a/internal/initcli/service.go
+++ b/internal/initcli/service.go
@@ -17,6 +17,11 @@ type Options struct {
 	StdoutPrintf func(format string, args ...any) error
 }
 
+type ScaffoldResult struct {
+	Directories []string
+	Files       []string
+}
+
 func Run(opts Options) error {
 	resolvedOutput := strings.TrimSpace(opts.Output)
 	if resolvedOutput == "" {
@@ -42,15 +47,7 @@ func Run(opts Options) error {
 		return fmt.Errorf("init: starter layout already contains target paths; refusing to overwrite: %s (choose another --out or remove these files)", strings.Join(overwriteTargets, ", "))
 	}
 
-	for _, dir := range templateDirs(resolvedOutput, deckWorkDir) {
-		if err := filemode.EnsureArtifactDir(dir); err != nil {
-			return fmt.Errorf("init: create directory %s: %w", dir, err)
-		}
-	}
-	if err := ensureFileWithDefault(gitignorePath, defaultGitignoreContent()); err != nil {
-		return err
-	}
-	if err := ensureFileWithDefault(deckignorePath, defaultDeckignoreContent()); err != nil {
+	if _, err := EnsureWorkspaceScaffold(resolvedOutput, deckWorkDir); err != nil {
 		return err
 	}
 	for path, body := range templates {
@@ -71,7 +68,35 @@ func Run(opts Options) error {
 	return opts.StdoutPrintf("init: wrote %s\n", strings.Join(created, ", "))
 }
 
-func templateDirs(root string, deckWorkDir string) []string {
+func EnsureWorkspaceScaffold(root string, deckWorkDir string) (ScaffoldResult, error) {
+	resolvedRoot := strings.TrimSpace(root)
+	if resolvedRoot == "" {
+		resolvedRoot = "."
+	}
+	resolvedDeckWorkDir := strings.TrimSpace(deckWorkDir)
+	if resolvedDeckWorkDir == "" {
+		resolvedDeckWorkDir = ".deck"
+	}
+	result := ScaffoldResult{
+		Directories: scaffoldDirs(resolvedRoot, resolvedDeckWorkDir),
+		Files:       scaffoldFiles(resolvedRoot),
+	}
+	for _, dir := range result.Directories {
+		if err := filemode.EnsureArtifactDir(dir); err != nil {
+			return ScaffoldResult{}, fmt.Errorf("init: create directory %s: %w", dir, err)
+		}
+	}
+	for path, content := range scaffoldFileDefaults(resolvedRoot) {
+		if err := ensureFileWithDefault(path, content); err != nil {
+			return ScaffoldResult{}, err
+		}
+	}
+	sort.Strings(result.Directories)
+	sort.Strings(result.Files)
+	return result, nil
+}
+
+func scaffoldDirs(root string, deckWorkDir string) []string {
 	return []string{
 		filepath.Join(root, deckWorkDir),
 		filepath.Join(root, workspacepaths.WorkflowRootDir),
@@ -81,6 +106,29 @@ func templateDirs(root string, deckWorkDir string) []string {
 		filepath.Join(root, workspacepaths.PreparedDirRel, workspacepaths.PreparedFilesRoot),
 		filepath.Join(root, workspacepaths.PreparedDirRel, workspacepaths.PreparedImagesRoot),
 		filepath.Join(root, workspacepaths.PreparedDirRel, workspacepaths.PreparedPackagesRoot),
+	}
+}
+
+func templateDirs(root string, deckWorkDir string) []string {
+	return scaffoldDirs(root, deckWorkDir)
+}
+
+func scaffoldFiles(root string) []string {
+	files := make([]string, 0, len(scaffoldFileDefaults(root)))
+	for path := range scaffoldFileDefaults(root) {
+		files = append(files, path)
+	}
+	sort.Strings(files)
+	return files
+}
+
+func scaffoldFileDefaults(root string) map[string]string {
+	return map[string]string{
+		filepath.Join(root, ".gitignore"):  defaultGitignoreContent(),
+		filepath.Join(root, ".deckignore"): defaultDeckignoreContent(),
+		filepath.Join(root, workspacepaths.PreparedDirRel, workspacepaths.PreparedFilesRoot, ".keep"):    "",
+		filepath.Join(root, workspacepaths.PreparedDirRel, workspacepaths.PreparedImagesRoot, ".keep"):   "",
+		filepath.Join(root, workspacepaths.PreparedDirRel, workspacepaths.PreparedPackagesRoot, ".keep"): "",
 	}
 }
 

--- a/internal/initcli/service.go
+++ b/internal/initcli/service.go
@@ -31,8 +31,6 @@ func Run(opts Options) error {
 	if deckWorkDir == "" {
 		deckWorkDir = ".deck"
 	}
-	gitignorePath := filepath.Join(resolvedOutput, ".gitignore")
-	deckignorePath := filepath.Join(resolvedOutput, ".deckignore")
 	templates := templateFiles(resolvedOutput)
 	overwriteTargets := make([]string, 0, len(templates))
 	for path := range templates {
@@ -47,7 +45,8 @@ func Run(opts Options) error {
 		return fmt.Errorf("init: starter layout already contains target paths; refusing to overwrite: %s (choose another --out or remove these files)", strings.Join(overwriteTargets, ", "))
 	}
 
-	if _, err := EnsureWorkspaceScaffold(resolvedOutput, deckWorkDir); err != nil {
+	scaffold, err := EnsureWorkspaceScaffold(resolvedOutput, deckWorkDir)
+	if err != nil {
 		return err
 	}
 	for path, body := range templates {
@@ -55,9 +54,9 @@ func Run(opts Options) error {
 			return fmt.Errorf("init: write %s: %w", path, err)
 		}
 	}
-	created := make([]string, 0, len(templates)+2)
-	created = append(created, templateDirs(resolvedOutput, deckWorkDir)...)
-	created = append(created, gitignorePath, deckignorePath)
+	created := make([]string, 0, len(templates)+len(scaffold.Directories)+len(scaffold.Files))
+	created = append(created, scaffold.Directories...)
+	created = append(created, scaffold.Files...)
 	for path := range templates {
 		created = append(created, path)
 	}
@@ -92,7 +91,6 @@ func EnsureWorkspaceScaffold(root string, deckWorkDir string) (ScaffoldResult, e
 		}
 	}
 	sort.Strings(result.Directories)
-	sort.Strings(result.Files)
 	return result, nil
 }
 
@@ -109,13 +107,10 @@ func scaffoldDirs(root string, deckWorkDir string) []string {
 	}
 }
 
-func templateDirs(root string, deckWorkDir string) []string {
-	return scaffoldDirs(root, deckWorkDir)
-}
-
 func scaffoldFiles(root string) []string {
-	files := make([]string, 0, len(scaffoldFileDefaults(root)))
-	for path := range scaffoldFileDefaults(root) {
+	defaults := scaffoldFileDefaults(root)
+	files := make([]string, 0, len(defaults))
+	for path := range defaults {
 		files = append(files, path)
 	}
 	sort.Strings(files)
@@ -142,9 +137,6 @@ func templateFiles(root string) map[string]string {
 		workspacepaths.CanonicalPrepareWorkflowPath(root): prepareScenarioContent,
 		workspacepaths.CanonicalApplyWorkflowPath(root):   applyScenarioContent,
 		filepath.Join(root, workspacepaths.WorkflowRootDir, workspacepaths.WorkflowComponentsDir, "example-apply.yaml"): applyComponentContent,
-		filepath.Join(root, workspacepaths.PreparedDirRel, workspacepaths.PreparedFilesRoot, ".keep"):                   "",
-		filepath.Join(root, workspacepaths.PreparedDirRel, workspacepaths.PreparedImagesRoot, ".keep"):                  "",
-		filepath.Join(root, workspacepaths.PreparedDirRel, workspacepaths.PreparedPackagesRoot, ".keep"):                "",
 	}
 }
 

--- a/internal/initcli/service_test.go
+++ b/internal/initcli/service_test.go
@@ -46,3 +46,26 @@ func TestEnsureWorkspaceScaffoldCreatesMinimalLayoutOnly(t *testing.T) {
 		}
 	}
 }
+
+func TestRunUpgradesMinimalScaffoldToFullStarterLayout(t *testing.T) {
+	root := t.TempDir()
+	if _, err := EnsureWorkspaceScaffold(root, ".deck"); err != nil {
+		t.Fatalf("EnsureWorkspaceScaffold: %v", err)
+	}
+	if err := Run(Options{Output: root}); err != nil {
+		t.Fatalf("Run after minimal scaffold: %v", err)
+	}
+	for _, rel := range []string{
+		workspacepaths.CanonicalPrepareWorkflow,
+		workspacepaths.CanonicalApplyWorkflow,
+		workspacepaths.CanonicalVarsWorkflow,
+		filepath.Join(workspacepaths.WorkflowRootDir, workspacepaths.WorkflowComponentsDir, "example-apply.yaml"),
+		filepath.Join(workspacepaths.PreparedDirRel, workspacepaths.PreparedFilesRoot, ".keep"),
+		filepath.Join(workspacepaths.PreparedDirRel, workspacepaths.PreparedImagesRoot, ".keep"),
+		filepath.Join(workspacepaths.PreparedDirRel, workspacepaths.PreparedPackagesRoot, ".keep"),
+	} {
+		if _, err := os.Stat(filepath.Join(root, rel)); err != nil {
+			t.Fatalf("expected full starter path %s: %v", rel, err)
+		}
+	}
+}

--- a/internal/initcli/service_test.go
+++ b/internal/initcli/service_test.go
@@ -1,0 +1,48 @@
+package initcli
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/Airgap-Castaways/deck/internal/workspacepaths"
+)
+
+func TestEnsureWorkspaceScaffoldCreatesMinimalLayoutOnly(t *testing.T) {
+	root := t.TempDir()
+	result, err := EnsureWorkspaceScaffold(root, ".deck")
+	if err != nil {
+		t.Fatalf("EnsureWorkspaceScaffold: %v", err)
+	}
+	if len(result.Directories) == 0 || len(result.Files) == 0 {
+		t.Fatalf("expected scaffold result to include directories and files: %+v", result)
+	}
+	for _, rel := range []string{
+		".deck",
+		workspacepaths.WorkflowRootDir,
+		filepath.Join(workspacepaths.WorkflowRootDir, workspacepaths.WorkflowScenariosDir),
+		filepath.Join(workspacepaths.WorkflowRootDir, workspacepaths.WorkflowComponentsDir),
+		filepath.Join(workspacepaths.PreparedDirRel, workspacepaths.PreparedFilesRoot),
+		filepath.Join(workspacepaths.PreparedDirRel, workspacepaths.PreparedImagesRoot),
+		filepath.Join(workspacepaths.PreparedDirRel, workspacepaths.PreparedPackagesRoot),
+		".gitignore",
+		".deckignore",
+		filepath.Join(workspacepaths.PreparedDirRel, workspacepaths.PreparedFilesRoot, ".keep"),
+		filepath.Join(workspacepaths.PreparedDirRel, workspacepaths.PreparedImagesRoot, ".keep"),
+		filepath.Join(workspacepaths.PreparedDirRel, workspacepaths.PreparedPackagesRoot, ".keep"),
+	} {
+		if _, err := os.Stat(filepath.Join(root, rel)); err != nil {
+			t.Fatalf("expected scaffold path %s: %v", rel, err)
+		}
+	}
+	for _, rel := range []string{
+		workspacepaths.CanonicalPrepareWorkflow,
+		workspacepaths.CanonicalApplyWorkflow,
+		workspacepaths.CanonicalVarsWorkflow,
+		filepath.Join(workspacepaths.WorkflowRootDir, workspacepaths.WorkflowComponentsDir, "example-apply.yaml"),
+	} {
+		if _, err := os.Stat(filepath.Join(root, rel)); !os.IsNotExist(err) {
+			t.Fatalf("minimal scaffold must not create starter workflow file %s, stat err=%v", rel, err)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- Add a shared `initcli.EnsureWorkspaceScaffold` helper for minimal workspace scaffold setup.
- Make `deck init` and ask authoring use the shared scaffold primitive while keeping ask init distinct from full `deck init` templates.
- Document ask init filesystem side effects and add tests for minimal scaffold behavior.

## Tests
- `go test -count=1 ./internal/initcli ./internal/askcli ./cmd/deck`
- `make test`
- `make lint`
- `make vuln`

Closes #180