### PR TITLE
Centralize ask authoring defaults

### DIFF
--- a/docs/contributing/ask-agent-runtime.md
+++ b/docs/contributing/ask-agent-runtime.md
@@ -66,6 +66,7 @@ The important boundary is that the model operates on file tools, not on a deck-s
 Ask may project deck facts into prompts and runtime tools, but it must not become a second schema system.
 
 - step and field validity belong to `internal/stepmeta`, generated schema, and `internal/validate`
+- shared ask authoring defaults belong to `internal/askdefaults`, not duplicated in prompt, policy, or repair code
 - canonical workflow path rules belong to workspace/path helpers, not ask prompts
 - workspace scaffold primitives belong to `internal/initcli`; ask must not maintain a parallel copy of `deck init` layout logic
 - evidence planning decides when upstream docs are needed, but external docs do not override deck-owned workflow truth

--- a/internal/askdefaults/defaults.go
+++ b/internal/askdefaults/defaults.go
@@ -1,0 +1,91 @@
+package askdefaults
+
+import (
+	"path/filepath"
+	"strings"
+
+	"github.com/Airgap-Castaways/deck/internal/askcontract"
+)
+
+const (
+	ImageOutputDir                = "images/control-plane"
+	JoinFile                      = "/tmp/deck/join.txt"
+	PodCIDR                       = "10.244.0.0/16"
+	CRISocket                     = "unix:///run/containerd/containerd.sock"
+	VerificationInterval          = "5s"
+	SingleNodeVerificationTimeout = "5m"
+	MultiNodeVerificationTimeout  = "10m"
+	DefaultKubernetesVersion      = "1.30.0"
+)
+
+func RepoType(family string) string {
+	if strings.EqualFold(strings.TrimSpace(family), "debian") {
+		return "deb-flat"
+	}
+	return "rpm"
+}
+
+func BackendImage(family string) string {
+	if strings.EqualFold(strings.TrimSpace(family), "debian") {
+		return "ubuntu:22.04"
+	}
+	return "rockylinux:9"
+}
+
+func PackageOutputDir(family string, release string, repoType string) string {
+	family = strings.ToLower(strings.TrimSpace(family))
+	release = strings.TrimSpace(release)
+	repoType = strings.ToLower(strings.TrimSpace(repoType))
+	if release == "" {
+		return "packages/"
+	}
+	if repoType == "deb-flat" || family == "debian" {
+		return filepath.ToSlash(filepath.Join("packages", "deb", release))
+	}
+	return filepath.ToSlash(filepath.Join("packages", "rpm", release))
+}
+
+func KubeadmPackages() []string {
+	return []string{"kubeadm", "kubelet", "kubectl", "cri-tools", "containerd"}
+}
+
+func KubeadmImages(version string) []string {
+	version = strings.TrimSpace(strings.TrimPrefix(version, "v"))
+	if version == "" || strings.EqualFold(version, "stable") {
+		version = DefaultKubernetesVersion
+	}
+	return []string{
+		"registry.k8s.io/kube-apiserver:v" + version,
+		"registry.k8s.io/kube-controller-manager:v" + version,
+		"registry.k8s.io/kube-scheduler:v" + version,
+		"registry.k8s.io/kube-proxy:v" + version,
+		"registry.k8s.io/pause:3.9",
+	}
+}
+
+func VerificationTimeout(expectedNodeCount int) string {
+	if expectedNodeCount > 1 {
+		return MultiNodeVerificationTimeout
+	}
+	return SingleNodeVerificationTimeout
+}
+
+func ExpectedReadyCount(program askcontract.AuthoringProgram) (int, bool) {
+	if program.Verification.ExpectedReadyCount > 0 {
+		return program.Verification.ExpectedReadyCount, true
+	}
+	if program.Verification.ExpectedNodeCount > 0 {
+		return program.Verification.ExpectedNodeCount, true
+	}
+	return 0, false
+}
+
+func ExpectedControlPlaneReady(program askcontract.AuthoringProgram) int {
+	if program.Verification.ExpectedControlPlaneReady > 0 {
+		return program.Verification.ExpectedControlPlaneReady
+	}
+	if program.Cluster.ControlPlaneCount > 0 {
+		return program.Cluster.ControlPlaneCount
+	}
+	return 1
+}

--- a/internal/askdefaults/defaults.go
+++ b/internal/askdefaults/defaults.go
@@ -50,7 +50,9 @@ func KubeadmPackages() []string {
 }
 
 func KubeadmImages(version string) []string {
-	version = strings.TrimSpace(strings.TrimPrefix(version, "v"))
+	version = strings.TrimSpace(version)
+	version = strings.TrimPrefix(version, "v")
+	version = strings.TrimPrefix(version, "V")
 	if version == "" || strings.EqualFold(version, "stable") {
 		version = DefaultKubernetesVersion
 	}

--- a/internal/askdefaults/defaults_test.go
+++ b/internal/askdefaults/defaults_test.go
@@ -1,0 +1,34 @@
+package askdefaults
+
+import "testing"
+
+func TestPackageOutputDirDefaults(t *testing.T) {
+	tests := []struct {
+		name    string
+		family  string
+		release string
+		repo    string
+		want    string
+	}{
+		{name: "rpm release", family: "rhel", release: "9", repo: "rpm", want: "packages/rpm/9"},
+		{name: "deb release", family: "debian", release: "12", repo: "deb-flat", want: "packages/deb/12"},
+		{name: "empty release", family: "rhel", repo: "rpm", want: "packages/"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := PackageOutputDir(tt.family, tt.release, tt.repo); got != tt.want {
+				t.Fatalf("PackageOutputDir()=%q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestKubeadmImagesDefaultVersion(t *testing.T) {
+	images := KubeadmImages("")
+	if len(images) != 5 {
+		t.Fatalf("expected 5 images, got %d", len(images))
+	}
+	if images[0] != "registry.k8s.io/kube-apiserver:v"+DefaultKubernetesVersion {
+		t.Fatalf("unexpected first image: %q", images[0])
+	}
+}

--- a/internal/askdefaults/defaults_test.go
+++ b/internal/askdefaults/defaults_test.go
@@ -32,3 +32,12 @@ func TestKubeadmImagesDefaultVersion(t *testing.T) {
 		t.Fatalf("unexpected first image: %q", images[0])
 	}
 }
+
+func TestKubeadmImagesNormalizesVersionPrefix(t *testing.T) {
+	for _, version := range []string{"1.30.0", "v1.30.0", "V1.30.0", " v1.30.0 "} {
+		images := KubeadmImages(version)
+		if images[0] != "registry.k8s.io/kube-apiserver:v1.30.0" {
+			t.Fatalf("KubeadmImages(%q)[0]=%q", version, images[0])
+		}
+	}
+}

--- a/internal/askpolicy/authoring_contract_graph.go
+++ b/internal/askpolicy/authoring_contract_graph.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 
 	"github.com/Airgap-Castaways/deck/internal/askcontract"
+	"github.com/Airgap-Castaways/deck/internal/askdefaults"
 	"github.com/Airgap-Castaways/deck/internal/askretrieve"
 	"github.com/Airgap-Castaways/deck/internal/workspacepaths"
 )
@@ -44,7 +45,7 @@ func BuildContractGraph(facts Facts, req RequirementLike, workspace askretrieve.
 		}
 	}
 	if facts.MultiRoleRequested || facts.Topology == "multi-node" || facts.Topology == "ha" || facts.NodeCount > 1 {
-		graph.SharedState = append(graph.SharedState, askcontract.SharedStateContract{Name: "join-file", ProducerPath: "/tmp/deck/join.txt", ConsumerPaths: []string{"/tmp/deck/join.txt"}, AvailabilityModel: "published-for-worker-consumption", Description: "bootstrap flow publishes join data before join flows consume it"})
+		graph.SharedState = append(graph.SharedState, askcontract.SharedStateContract{Name: "join-file", ProducerPath: askdefaults.JoinFile, ConsumerPaths: []string{askdefaults.JoinFile}, AvailabilityModel: "published-for-worker-consumption", Description: "bootstrap flow publishes join data before join flows consume it"})
 		graph.RoleExecution = askcontract.RoleExecutionModel{RoleSelector: "vars.role", ControlPlaneFlow: "preflight -> runtime setup -> bootstrap", WorkerFlow: "preflight -> runtime setup -> join", PerNodeInvocation: true}
 	}
 	graph.Verification = askcontract.VerificationStrategy{BootstrapPhase: "bootstrap", FinalPhase: "verify-cluster", FinalVerificationRole: "control-plane"}

--- a/internal/askpolicy/plan.go
+++ b/internal/askpolicy/plan.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/Airgap-Castaways/deck/internal/askcatalog"
 	"github.com/Airgap-Castaways/deck/internal/askcontract"
+	"github.com/Airgap-Castaways/deck/internal/askdefaults"
 	"github.com/Airgap-Castaways/deck/internal/askintent"
 	"github.com/Airgap-Castaways/deck/internal/askretrieve"
 	"github.com/Airgap-Castaways/deck/internal/workspacepaths"
@@ -686,16 +687,16 @@ func normalizeAuthoringProgram(program askcontract.AuthoringProgram, brief askco
 		program.Platform.Release = defaultPlatformRelease(program.Platform.Family)
 	}
 	if strings.TrimSpace(program.Platform.RepoType) == "" && !minimalSingleNodeBootstrap {
-		program.Platform.RepoType = defaultRepoType(program.Platform.Family)
+		program.Platform.RepoType = askdefaults.RepoType(program.Platform.Family)
 	}
 	if strings.TrimSpace(program.Platform.BackendImage) == "" && !minimalSingleNodeBootstrap {
-		program.Platform.BackendImage = defaultBackendImage(program.Platform.Family, program.Platform.Release)
+		program.Platform.BackendImage = askdefaults.BackendImage(program.Platform.Family)
 	}
 	if strings.TrimSpace(program.Artifacts.PackageOutputDir) == "" && !minimalSingleNodeBootstrap {
-		program.Artifacts.PackageOutputDir = defaultPackageOutputDir(program.Platform.Family, program.Platform.Release, program.Platform.RepoType)
+		program.Artifacts.PackageOutputDir = askdefaults.PackageOutputDir(program.Platform.Family, program.Platform.Release, program.Platform.RepoType)
 	}
 	if strings.TrimSpace(program.Artifacts.ImageOutputDir) == "" && !minimalSingleNodeBootstrap {
-		program.Artifacts.ImageOutputDir = "images/control-plane"
+		program.Artifacts.ImageOutputDir = askdefaults.ImageOutputDir
 	}
 	if len(program.Artifacts.Packages) == 0 && (hasBriefCapability(brief, "package-staging") || hasBriefCapability(brief, "prepare-artifacts")) {
 		program.Artifacts.Packages = defaultKubeadmPackages(prompt, brief)
@@ -704,16 +705,16 @@ func normalizeAuthoringProgram(program askcontract.AuthoringProgram, brief askco
 		program.Artifacts.Images = defaultKubeadmImages(program.Cluster.KubernetesVersion, brief)
 	}
 	if strings.TrimSpace(program.Cluster.JoinFile) == "" {
-		program.Cluster.JoinFile = "/tmp/deck/join.txt"
+		program.Cluster.JoinFile = askdefaults.JoinFile
 	}
 	if strings.TrimSpace(program.Cluster.PodCIDR) == "" {
-		program.Cluster.PodCIDR = "10.244.0.0/16"
+		program.Cluster.PodCIDR = askdefaults.PodCIDR
 	}
 	if strings.TrimSpace(program.Cluster.KubernetesVersion) == "" {
 		program.Cluster.KubernetesVersion = inferKubernetesVersion(prompt)
 	}
 	if strings.TrimSpace(program.Cluster.CriSocket) == "" && hasBriefCapability(brief, "kubeadm-bootstrap") {
-		program.Cluster.CriSocket = "unix:///run/containerd/containerd.sock"
+		program.Cluster.CriSocket = askdefaults.CRISocket
 	}
 	program.Cluster.RoleSelector = normalizeRoleSelector(firstNonEmpty(strings.TrimSpace(program.Cluster.RoleSelector), strings.TrimSpace(execution.RoleExecution.RoleSelector)))
 	if !briefNeedsRoleSelector(brief) {
@@ -758,14 +759,10 @@ func normalizeAuthoringProgram(program askcontract.AuthoringProgram, brief askco
 		}
 	}
 	if strings.TrimSpace(program.Verification.Interval) == "" {
-		program.Verification.Interval = "5s"
+		program.Verification.Interval = askdefaults.VerificationInterval
 	}
 	if strings.TrimSpace(program.Verification.Timeout) == "" {
-		if program.Verification.ExpectedNodeCount > 1 {
-			program.Verification.Timeout = "10m"
-		} else {
-			program.Verification.Timeout = "5m"
-		}
+		program.Verification.Timeout = askdefaults.VerificationTimeout(program.Verification.ExpectedNodeCount)
 	}
 	return program
 }
@@ -789,24 +786,14 @@ func defaultKubeadmPackages(prompt string, brief askcontract.AuthoringBrief) []s
 	if !hasBriefCapability(brief, "kubeadm-bootstrap") && !hasBriefCapability(brief, "kubeadm-join") && !strings.Contains(strings.ToLower(strings.TrimSpace(prompt)), "kubeadm") {
 		return nil
 	}
-	return []string{"kubeadm", "kubelet", "kubectl", "cri-tools", "containerd"}
+	return askdefaults.KubeadmPackages()
 }
 
 func defaultKubeadmImages(version string, brief askcontract.AuthoringBrief) []string {
 	if !hasBriefCapability(brief, "kubeadm-bootstrap") && !hasBriefCapability(brief, "kubeadm-join") {
 		return nil
 	}
-	version = strings.TrimSpace(strings.TrimPrefix(version, "v"))
-	if version == "" || strings.EqualFold(version, "stable") {
-		version = "1.30.0"
-	}
-	return []string{
-		"registry.k8s.io/kube-apiserver:v" + version,
-		"registry.k8s.io/kube-controller-manager:v" + version,
-		"registry.k8s.io/kube-scheduler:v" + version,
-		"registry.k8s.io/kube-proxy:v" + version,
-		"registry.k8s.io/pause:3.9",
-	}
+	return askdefaults.KubeadmImages(version)
 }
 
 func isMinimalSingleNodeBootstrapPrompt(prompt string, brief askcontract.AuthoringBrief) bool {
@@ -873,34 +860,6 @@ func inferKubernetesVersion(prompt string) string {
 		return "v" + strings.TrimPrefix(version, "v")
 	}
 	return ""
-}
-
-func defaultRepoType(family string) string {
-	if strings.EqualFold(strings.TrimSpace(family), "debian") {
-		return "deb-flat"
-	}
-	return "rpm"
-}
-
-func defaultBackendImage(family string, release string) string {
-	if strings.EqualFold(strings.TrimSpace(family), "debian") {
-		return "ubuntu:22.04"
-	}
-	_ = release
-	return "rockylinux:9"
-}
-
-func defaultPackageOutputDir(family string, release string, repoType string) string {
-	family = strings.ToLower(strings.TrimSpace(family))
-	release = strings.TrimSpace(release)
-	repoType = strings.ToLower(strings.TrimSpace(repoType))
-	if release == "" {
-		return "packages/"
-	}
-	if repoType == "deb-flat" || family == "debian" {
-		return filepath.ToSlash(filepath.Join("packages", "deb", release))
-	}
-	return filepath.ToSlash(filepath.Join("packages", "rpm", release))
 }
 
 func normalizeRoleSelector(value string) string {

--- a/internal/askpolicy/program_test.go
+++ b/internal/askpolicy/program_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/Airgap-Castaways/deck/internal/askcontract"
+	"github.com/Airgap-Castaways/deck/internal/askdefaults"
 )
 
 func TestNormalizeAuthoringProgramBuildsDefaultsFromBriefAndExecution(t *testing.T) {
@@ -11,10 +12,10 @@ func TestNormalizeAuthoringProgramBuildsDefaultsFromBriefAndExecution(t *testing
 	if program.Platform.Family != "rhel" || program.Platform.Release != "9" || program.Platform.RepoType != "rpm" {
 		t.Fatalf("expected normalized platform defaults, got %#v", program.Platform)
 	}
-	if program.Cluster.JoinFile != "/tmp/deck/join.txt" || program.Cluster.RoleSelector != "role" {
+	if program.Cluster.JoinFile != askdefaults.JoinFile || program.Cluster.RoleSelector != "role" {
 		t.Fatalf("expected normalized cluster defaults, got %#v", program.Cluster)
 	}
-	if program.Verification.ExpectedReadyCount != 2 || program.Verification.Timeout != "10m" {
+	if program.Verification.ExpectedReadyCount != 2 || program.Verification.Timeout != askdefaults.MultiNodeVerificationTimeout {
 		t.Fatalf("expected normalized verification defaults, got %#v", program.Verification)
 	}
 }
@@ -39,7 +40,7 @@ func TestNormalizeAuthoringProgramUsesPreinstalledDefaultsForMinimalSingleNodeBo
 	if program.Cluster.KubernetesVersion != "v1.35.1" {
 		t.Fatalf("expected inferred kubernetes version for minimal flow, got %#v", program.Cluster)
 	}
-	if program.Cluster.CriSocket != "unix:///run/containerd/containerd.sock" {
+	if program.Cluster.CriSocket != askdefaults.CRISocket {
 		t.Fatalf("expected default cri socket for kubeadm flow, got %#v", program.Cluster)
 	}
 }
@@ -60,7 +61,7 @@ func TestNormalizeAuthoringProgramSeedsPrepareArtifactsForKubeadmDraft(t *testin
 	if len(program.Artifacts.Packages) == 0 || len(program.Artifacts.Images) == 0 {
 		t.Fatalf("expected seeded kubeadm prepare artifacts, got %#v", program.Artifacts)
 	}
-	if program.Artifacts.PackageOutputDir == "" || program.Artifacts.ImageOutputDir == "" {
+	if program.Artifacts.PackageOutputDir == "" || program.Artifacts.ImageOutputDir != askdefaults.ImageOutputDir {
 		t.Fatalf("expected canonical artifact output dirs, got %#v", program.Artifacts)
 	}
 }

--- a/internal/askrepair/repair.go
+++ b/internal/askrepair/repair.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/Airgap-Castaways/deck/internal/askcatalog"
 	"github.com/Airgap-Castaways/deck/internal/askcontract"
+	"github.com/Airgap-Castaways/deck/internal/askdefaults"
 	"github.com/Airgap-Castaways/deck/internal/askdiagnostic"
 	"github.com/Airgap-Castaways/deck/internal/askir"
 	"github.com/Airgap-Castaways/deck/internal/stepmeta"
@@ -279,57 +280,29 @@ func bindingSourceValue(source string, program askcontract.AuthoringProgram) (an
 func deriveRepairValue(name string, program askcontract.AuthoringProgram) (any, bool) {
 	switch strings.TrimSpace(name) {
 	case "platform.repoType":
-		if strings.EqualFold(strings.TrimSpace(program.Platform.Family), "debian") {
-			return "deb-flat", true
-		}
-		return "rpm", true
+		return askdefaults.RepoType(program.Platform.Family), true
 	case "platform.backendImage":
-		if strings.EqualFold(strings.TrimSpace(program.Platform.Family), "debian") {
-			return "ubuntu:22.04", true
-		}
-		return "rockylinux:9", true
+		return askdefaults.BackendImage(program.Platform.Family), true
 	case "artifacts.packageOutputDir":
-		family := strings.ToLower(strings.TrimSpace(program.Platform.Family))
-		release := strings.TrimSpace(program.Platform.Release)
-		repoType := strings.ToLower(strings.TrimSpace(program.Platform.RepoType))
-		if family == "debian" || repoType == "deb-flat" {
-			if release == "" {
-				return "packages/", true
-			}
-			return filepath.ToSlash(filepath.Join("packages", "deb", release)), true
-		}
-		if release == "" {
-			return "packages/", true
-		}
-		return filepath.ToSlash(filepath.Join("packages", "rpm", release)), true
+		return askdefaults.PackageOutputDir(program.Platform.Family, program.Platform.Release, program.Platform.RepoType), true
 	case "artifacts.imageOutputDir":
-		return "images/control-plane", true
+		return askdefaults.ImageOutputDir, true
 	case "cluster.joinFile":
-		return "/tmp/deck/join.txt", true
+		return askdefaults.JoinFile, true
 	case "cluster.podCIDR":
-		return "10.244.0.0/16", true
+		return askdefaults.PodCIDR, true
+	case "cluster.criSocket":
+		return askdefaults.CRISocket, true
 	case "verification.expectedReadyCount":
-		if program.Verification.ExpectedReadyCount > 0 {
-			return program.Verification.ExpectedReadyCount, true
-		}
-		if program.Verification.ExpectedNodeCount > 0 {
-			return program.Verification.ExpectedNodeCount, true
+		if value, ok := askdefaults.ExpectedReadyCount(program); ok {
+			return value, true
 		}
 	case "verification.expectedControlPlaneReady":
-		if program.Verification.ExpectedControlPlaneReady > 0 {
-			return program.Verification.ExpectedControlPlaneReady, true
-		}
-		if program.Cluster.ControlPlaneCount > 0 {
-			return program.Cluster.ControlPlaneCount, true
-		}
-		return 1, true
+		return askdefaults.ExpectedControlPlaneReady(program), true
 	case "verification.interval":
-		return "5s", true
+		return askdefaults.VerificationInterval, true
 	case "verification.timeout":
-		if program.Verification.ExpectedNodeCount > 1 {
-			return "10m", true
-		}
-		return "5m", true
+		return askdefaults.VerificationTimeout(program.Verification.ExpectedNodeCount), true
 	}
 	return nil, false
 }

--- a/internal/askrepair/repair_test.go
+++ b/internal/askrepair/repair_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/Airgap-Castaways/deck/internal/askcatalog"
 	"github.com/Airgap-Castaways/deck/internal/askcontract"
+	"github.com/Airgap-Castaways/deck/internal/askdefaults"
 	"github.com/Airgap-Castaways/deck/internal/askdiagnostic"
 	_ "github.com/Airgap-Castaways/deck/internal/stepspec"
 )
@@ -117,6 +118,38 @@ func TestTryAutoRepairRestoresTypedLiteralsFromProgramDefaults(t *testing.T) {
 		if !strings.Contains(content, want) {
 			t.Fatalf("expected %q in repaired content, got %q", want, content)
 		}
+	}
+}
+
+func TestDeriveRepairValueUsesAskDefaults(t *testing.T) {
+	program := askcontract.AuthoringProgram{
+		Platform:     askcontract.ProgramPlatform{Family: "debian", Release: "12", RepoType: "deb-flat"},
+		Cluster:      askcontract.ProgramCluster{ControlPlaneCount: 2},
+		Verification: askcontract.ProgramVerification{ExpectedNodeCount: 3},
+	}
+	tests := []struct {
+		name string
+		want any
+	}{
+		{name: "platform.repoType", want: askdefaults.RepoType(program.Platform.Family)},
+		{name: "platform.backendImage", want: askdefaults.BackendImage(program.Platform.Family)},
+		{name: "artifacts.packageOutputDir", want: askdefaults.PackageOutputDir(program.Platform.Family, program.Platform.Release, program.Platform.RepoType)},
+		{name: "artifacts.imageOutputDir", want: askdefaults.ImageOutputDir},
+		{name: "cluster.joinFile", want: askdefaults.JoinFile},
+		{name: "cluster.podCIDR", want: askdefaults.PodCIDR},
+		{name: "cluster.criSocket", want: askdefaults.CRISocket},
+		{name: "verification.expectedReadyCount", want: 3},
+		{name: "verification.expectedControlPlaneReady", want: 2},
+		{name: "verification.interval", want: askdefaults.VerificationInterval},
+		{name: "verification.timeout", want: askdefaults.MultiNodeVerificationTimeout},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := deriveRepairValue(tt.name, program)
+			if !ok || got != tt.want {
+				t.Fatalf("deriveRepairValue(%s)=(%#v,%t), want %#v,true", tt.name, got, ok, tt.want)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Summary
- Add `internal/askdefaults` as the shared source of truth for ask authoring default values.
- Update ask policy normalization and repair derivation to use the same defaults for artifacts, cluster settings, platform values, and verification timing.
- Add tests for the shared defaults and repair derivation consistency.

## Tests
- `go test -count=1 ./internal/askdefaults ./internal/askpolicy ./internal/askrepair`
- `make test`
- `make lint`
- `make vuln`

Closes #182