### PR TITLE
Expand local ask review coverage

### DIFF
--- a/internal/askcli/fallbacks.go
+++ b/internal/askcli/fallbacks.go
@@ -377,3 +377,15 @@ func findingsToLines(findings []askreview.Finding) []string {
 	}
 	return out
 }
+
+func localReviewFindingsChunk(findings []askreview.Finding) askretrieve.Chunk {
+	lines := []string{"Local review findings:", "Address each blocking local finding explicitly in the review.", "Preserve local severity labels: warn findings are advisory and must not be restated as blocking unless another blocking validator finding supports that severity."}
+	lines = append(lines, findingsToLines(findings)...)
+	return askretrieve.Chunk{
+		ID:      "local-review-findings",
+		Source:  "local-review",
+		Label:   "local-review-findings",
+		Content: strings.Join(lines, "\n"),
+		Score:   95,
+	}
+}

--- a/internal/askcli/prompts_info.go
+++ b/internal/askcli/prompts_info.go
@@ -11,6 +11,7 @@ import (
 	"github.com/Airgap-Castaways/deck/internal/askir"
 	"github.com/Airgap-Castaways/deck/internal/askretrieve"
 	"github.com/Airgap-Castaways/deck/internal/validate"
+	"github.com/Airgap-Castaways/deck/internal/workspacepaths"
 )
 
 func infoPrompts(route askintent.Route, target askintent.Target, retrieval askretrieve.RetrievalResult, workspace askretrieve.WorkspaceSummary, prompt string) (string, string) {
@@ -40,6 +41,7 @@ func buildInfoSystemPrompt(route askintent.Route, target askintent.Target, retri
 		b.WriteString("You are deck ask reviewing an existing deck workspace.\n")
 		b.WriteString("Use the retrieved evidence and any local findings to produce a scoped review with practical concerns and suggested changes.\n")
 		b.WriteString("Narrate the findings instead of only repeating raw warnings.\n")
+		b.WriteString("Preserve local severity labels: do not convert advisory warn findings into blocking findings unless schema or validation evidence marks them blocking.\n")
 	default:
 		b.WriteString("You are deck ask.\n")
 		b.WriteString("Route: ")
@@ -139,7 +141,7 @@ func workspaceStructuredIssuePromptBlock(workspace askretrieve.WorkspaceSummary,
 	issues := []validate.Issue{}
 	for _, file := range workspace.Files {
 		path := filepath.ToSlash(strings.TrimSpace(file.Path))
-		if path == "" || !strings.HasPrefix(path, workflowRootPrefix) {
+		if !structuredIssueReviewPath(path) {
 			continue
 		}
 		if target.Path != "" && path != filepath.ToSlash(strings.TrimSpace(target.Path)) {
@@ -171,6 +173,13 @@ func workspaceStructuredIssuePromptBlock(workspace askretrieve.WorkspaceSummary,
 		b.WriteString("\n")
 	}
 	return strings.TrimSpace(b.String())
+}
+
+func structuredIssueReviewPath(path string) bool {
+	if path == "" || !strings.HasPrefix(path, workflowRootPrefix) {
+		return false
+	}
+	return workspacepaths.IsCanonicalPrepareWorkflowPath(path) || workspacepaths.IsScenarioAuthoringPath(path)
 }
 
 func retrievalDocumentSummaryBlock(retrieval askretrieve.RetrievalResult) string {

--- a/internal/askcli/service.go
+++ b/internal/askcli/service.go
@@ -384,6 +384,8 @@ func Execute(ctx context.Context, opts Options, client askprovider.Client) error
 	if decision.Route == askintent.RouteReview {
 		result.LocalFindings = askreview.Workspace(resolvedRoot)
 		result.ReviewLines = append(result.ReviewLines, findingsToLines(result.LocalFindings)...)
+		retrieval.Chunks = append(retrieval.Chunks, localReviewFindingsChunk(result.LocalFindings))
+		result.Chunks = retrieval.Chunks
 	}
 	switch {
 	case decision.Route == askintent.RouteClarify:

--- a/internal/askcli/service_test.go
+++ b/internal/askcli/service_test.go
@@ -686,6 +686,17 @@ func TestReviewSystemPromptIncludesStructuredValidationIssues(t *testing.T) {
 	}
 }
 
+func TestReviewSystemPromptIgnoresComponentAndVarsValidationIssues(t *testing.T) {
+	workspace := askretrieve.WorkspaceSummary{Files: []askretrieve.WorkspaceFile{
+		{Path: "workflows/components/k8s/runtime.yaml", Content: "steps:\n  - id: install\n    kind: InstallPackage\n    spec:\n      packages: \"{{ .vars.runtimePackages }}\"\n"},
+		{Path: "workflows/vars.yaml", Content: "runtimePackages: [containerd]\n"},
+	}}
+	prompt := buildInfoSystemPrompt(askintent.RouteReview, askintent.Target{Kind: "workspace"}, askretrieve.RetrievalResult{}, workspace)
+	if strings.Contains(prompt, "Structured validation issues:") {
+		t.Fatalf("expected review prompt to avoid context-free component and vars validation issues, got %q", prompt)
+	}
+}
+
 func TestRequiredFixesForValidationFlagsTemplatedCollections(t *testing.T) {
 	fixes := requiredFixesForValidation("parse yaml: yaml: invalid map key: map[string]interface {}{\".vars.dockerPackages\":interface {}(nil)}")
 	if len(fixes) < 2 {

--- a/internal/askreview/review.go
+++ b/internal/askreview/review.go
@@ -104,7 +104,7 @@ func reviewValidationErrors(path string, raw []byte) []error {
 	if err := validate.Bytes(path, raw); err != nil {
 		errs = append(errs, err)
 	}
-	if workspacepaths.IsScenarioWorkflowPath(path) {
+	if workspacepaths.IsScenarioWorkflowPath(path) || workspacepaths.IsCanonicalPrepareWorkflowPath(path) {
 		if _, err := validate.Entrypoint(path); err != nil && !hasErrorMessage(errs, err) {
 			errs = append(errs, err)
 		}
@@ -138,7 +138,7 @@ func yamlFilesUnder(root string) []string {
 		}
 		return nil
 	}); err != nil && !errors.Is(err, os.ErrNotExist) {
-		return nil
+		return paths
 	}
 	return paths
 }

--- a/internal/askreview/review.go
+++ b/internal/askreview/review.go
@@ -1,13 +1,17 @@
 package askreview
 
 import (
+	"errors"
 	"fmt"
+	"io/fs"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 
 	"gopkg.in/yaml.v3"
 
+	"github.com/Airgap-Castaways/deck/internal/validate"
 	"github.com/Airgap-Castaways/deck/internal/workspacepaths"
 )
 
@@ -18,15 +22,22 @@ type Finding struct {
 
 func Workspace(root string) []Finding {
 	findings := make([]Finding, 0)
-	preparePath := workspacepaths.CanonicalPrepareWorkflowPath(root)
-	applyPath := workspacepaths.CanonicalApplyWorkflowPath(root)
-	files := []string{preparePath, applyPath}
+	files := workspaceReviewPaths(root)
 	commandCount := 0
+	validFiles := make([]string, 0, len(files))
 	for _, path := range files {
 		//nolint:gosec // Review paths are derived from the current workspace layout.
 		raw, err := os.ReadFile(path)
 		if err != nil {
 			continue
+		}
+		hasValidationError := false
+		for _, err := range reviewValidationErrors(path, raw) {
+			findings = append(findings, validationFindings(path, err)...)
+			hasValidationError = true
+		}
+		if !hasValidationError {
+			validFiles = append(validFiles, path)
 		}
 		count, hasTopLevelSteps := inspectWorkflow(raw)
 		commandCount += count
@@ -37,19 +48,36 @@ func Workspace(root string) []Finding {
 			})
 		}
 	}
+	analysisFindings, err := validate.AnalyzeFiles(validFiles)
+	if err == nil {
+		findings = append(findings, analysisReviewFindings(analysisFindings)...)
+	}
 	if commandCount >= 3 {
 		findings = append(findings, Finding{
 			Severity: "warn",
 			Message:  fmt.Sprintf("workspace uses %d Command steps; prefer typed steps where possible", commandCount),
 		})
 	}
-	return findings
+	return dedupeFindings(findings)
 }
 
 func Candidate(files map[string]string) []Finding {
 	findings := make([]Finding, 0)
 	commandCount := 0
-	for path, content := range files {
+	paths := make([]string, 0, len(files))
+	for path := range files {
+		if isReviewablePath(path) {
+			paths = append(paths, path)
+		}
+	}
+	sort.Strings(paths)
+	for _, path := range paths {
+		content := files[path]
+		if !workspacepaths.IsComponentAuthoringPath(path) {
+			if err := validate.Bytes(path, []byte(content)); err != nil {
+				findings = append(findings, validationFindings(path, err)...)
+			}
+		}
 		count, hasTopLevelSteps := inspectWorkflow([]byte(content))
 		commandCount += count
 		if strings.HasSuffix(path, "/apply.yaml") && hasTopLevelSteps {
@@ -65,7 +93,164 @@ func Candidate(files map[string]string) []Finding {
 			Message:  fmt.Sprintf("candidate output uses %d Command steps; prefer typed steps where possible", commandCount),
 		})
 	}
-	return findings
+	return dedupeFindings(findings)
+}
+
+func reviewValidationErrors(path string, raw []byte) []error {
+	if workspacepaths.IsComponentWorkflowPath(path) {
+		return nil
+	}
+	errs := make([]error, 0, 2)
+	if err := validate.Bytes(path, raw); err != nil {
+		errs = append(errs, err)
+	}
+	if workspacepaths.IsScenarioWorkflowPath(path) {
+		if _, err := validate.Entrypoint(path); err != nil && !hasErrorMessage(errs, err) {
+			errs = append(errs, err)
+		}
+	}
+	return errs
+}
+
+func workspaceReviewPaths(root string) []string {
+	paths := make([]string, 0)
+	preparePath := workspacepaths.CanonicalPrepareWorkflowPath(root)
+	if fileExists(preparePath) {
+		paths = append(paths, preparePath)
+	}
+	paths = append(paths, yamlFilesUnder(workspacepaths.WorkflowScenariosPath(root))...)
+	paths = append(paths, yamlFilesUnder(workspacepaths.WorkflowComponentsPath(root))...)
+	return dedupeAndSort(paths)
+}
+
+func yamlFilesUnder(root string) []string {
+	paths := make([]string, 0)
+	if err := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			return nil
+		}
+		name := strings.ToLower(d.Name())
+		if strings.HasSuffix(name, ".yaml") || strings.HasSuffix(name, ".yml") {
+			paths = append(paths, path)
+		}
+		return nil
+	}); err != nil && !errors.Is(err, os.ErrNotExist) {
+		return nil
+	}
+	return paths
+}
+
+func fileExists(path string) bool {
+	info, err := os.Stat(path)
+	return err == nil && !info.IsDir()
+}
+
+func isReviewablePath(path string) bool {
+	clean := filepath.ToSlash(strings.TrimSpace(path))
+	return workspacepaths.IsCanonicalPrepareWorkflowPath(clean) || workspacepaths.IsScenarioAuthoringPath(clean) || workspacepaths.IsComponentAuthoringPath(clean)
+}
+
+func validationFindings(path string, err error) []Finding {
+	var issueErr interface{ ValidationIssues() []validate.Issue }
+	if errors.As(err, &issueErr) {
+		issues := issueErr.ValidationIssues()
+		findings := make([]Finding, 0, len(issues))
+		for _, issue := range issues {
+			findings = append(findings, validationIssueFinding(path, issue))
+		}
+		if len(findings) > 0 {
+			return findings
+		}
+	}
+	return []Finding{{Severity: "blocking", Message: fmt.Sprintf("%s validation failed: %s", filepath.ToSlash(path), err.Error())}}
+}
+
+func validationIssueFinding(path string, issue validate.Issue) Finding {
+	message := strings.TrimSpace(issue.Message)
+	if message == "" {
+		message = "validation failed"
+	}
+	if code := strings.TrimSpace(issue.Code); code != "" {
+		message = fmt.Sprintf("%s: %s", code, message)
+	}
+	if stepID := strings.TrimSpace(issue.StepID); stepID != "" {
+		message = fmt.Sprintf("%s (step %s)", message, stepID)
+	}
+	displayPath := strings.TrimSpace(issue.File)
+	if displayPath == "" {
+		displayPath = path
+	}
+	return Finding{Severity: normalizeSeverity(issue.Severity), Message: fmt.Sprintf("%s validation: %s", filepath.ToSlash(displayPath), message)}
+}
+
+func analysisReviewFindings(findings []validate.Finding) []Finding {
+	out := make([]Finding, 0, len(findings))
+	for _, finding := range findings {
+		message := strings.TrimSpace(finding.Message)
+		if message == "" {
+			continue
+		}
+		if finding.Path != "" {
+			message = fmt.Sprintf("%s: %s", filepath.ToSlash(finding.Path), message)
+		}
+		if finding.Hint != "" {
+			message = message + " " + strings.TrimSpace(finding.Hint)
+		}
+		out = append(out, Finding{Severity: normalizeSeverity(finding.Severity), Message: message})
+	}
+	return out
+}
+
+func normalizeSeverity(severity string) string {
+	switch strings.ToLower(strings.TrimSpace(severity)) {
+	case "blocking", "error", "fatal":
+		return "blocking"
+	case "warning", "warn", "advisory":
+		return "warn"
+	default:
+		return "warn"
+	}
+}
+
+func dedupeAndSort(values []string) []string {
+	seen := map[string]bool{}
+	out := make([]string, 0, len(values))
+	for _, value := range values {
+		if seen[value] {
+			continue
+		}
+		seen[value] = true
+		out = append(out, value)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func hasErrorMessage(errs []error, err error) bool {
+	message := strings.TrimSpace(err.Error())
+	for _, existing := range errs {
+		if strings.TrimSpace(existing.Error()) == message {
+			return true
+		}
+	}
+	return false
+}
+
+func dedupeFindings(findings []Finding) []Finding {
+	seen := map[string]bool{}
+	out := make([]Finding, 0, len(findings))
+	for _, finding := range findings {
+		key := finding.Severity + "\x00" + finding.Message
+		if seen[key] {
+			continue
+		}
+		seen[key] = true
+		out = append(out, finding)
+	}
+	return out
 }
 
 type workflowDoc struct {

--- a/internal/askreview/review_test.go
+++ b/internal/askreview/review_test.go
@@ -1,0 +1,130 @@
+package askreview
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/Airgap-Castaways/deck/internal/workspacepaths"
+)
+
+func TestWorkspaceReviewsScenarioFilesBeyondCanonicalApply(t *testing.T) {
+	root := t.TempDir()
+	writeReviewFile(t, root, filepath.Join(workspacepaths.CanonicalScenariosDir, "worker.yaml"), `version: v1alpha1
+steps:
+  - id: one
+    kind: Command
+    spec:
+      command: ["true"]
+  - id: two
+    kind: Command
+    spec:
+      command: ["true"]
+  - id: three
+    kind: Command
+    spec:
+      command: ["true"]
+`)
+
+	findings := Workspace(root)
+	if !hasFinding(findings, "workspace uses 3 Command steps") {
+		t.Fatalf("expected non-canonical scenario to contribute command finding, got %#v", findings)
+	}
+	if !hasFinding(findings, "Command step relies on opaque shell behavior") {
+		t.Fatalf("expected workflow analysis warning, got %#v", findings)
+	}
+}
+
+func TestWorkspaceReportsValidationFindingsFromScenarioImports(t *testing.T) {
+	root := t.TempDir()
+	writeReviewFile(t, root, filepath.Join(workspacepaths.CanonicalScenariosDir, "apply.yaml"), `version: v1alpha1
+phases:
+  - name: apply
+    imports:
+      - path: bad.yaml
+`)
+	writeReviewFile(t, root, filepath.Join(workspacepaths.CanonicalComponentsDir, "bad.yaml"), `steps:
+  - id: dup
+    kind: Command
+    spec:
+      command: ["true"]
+  - id: dup
+    kind: Command
+    spec:
+      command: ["true"]
+`)
+
+	findings := Workspace(root)
+	if !hasFindingWithSeverity(findings, "blocking", "duplicate_step_id") {
+		t.Fatalf("expected imported component validation finding, got %#v", findings)
+	}
+}
+
+func TestWorkspaceDoesNotValidateComponentsWithoutScenarioVars(t *testing.T) {
+	root := t.TempDir()
+	writeReviewFile(t, root, filepath.Join(workspacepaths.CanonicalComponentsDir, "templated.yaml"), `steps:
+  - id: install
+    kind: InstallPackage
+    spec:
+      packages: "{{ .vars.runtimePackages }}"
+`)
+
+	findings := Workspace(root)
+	if hasFindingWithSeverity(findings, "blocking", "Invalid type. Expected: array") {
+		t.Fatalf("expected component templates to avoid context-free validation blockers, got %#v", findings)
+	}
+}
+
+func TestCandidateReportsValidationFindingsForGeneratedWorkflows(t *testing.T) {
+	findings := Candidate(map[string]string{
+		workspacepaths.CanonicalApplyWorkflow: `version: v1alpha1
+steps:
+  - id: dup
+    kind: Command
+    spec:
+      command: ["true"]
+  - id: dup
+    kind: Command
+    spec:
+      command: ["true"]
+`,
+		workspacepaths.CanonicalVarsWorkflow: "not: a workflow\n",
+	})
+
+	if !hasFindingWithSeverity(findings, "blocking", "duplicate_step_id") {
+		t.Fatalf("expected candidate validation finding, got %#v", findings)
+	}
+	if hasFinding(findings, workspacepaths.CanonicalVarsWorkflow+" validation") {
+		t.Fatalf("expected vars file to be ignored by workflow review, got %#v", findings)
+	}
+}
+
+func writeReviewFile(t *testing.T, root string, rel string, content string) {
+	t.Helper()
+	path := filepath.Join(root, filepath.FromSlash(rel))
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+}
+
+func hasFinding(findings []Finding, needle string) bool {
+	for _, finding := range findings {
+		if strings.Contains(finding.Message, needle) {
+			return true
+		}
+	}
+	return false
+}
+
+func hasFindingWithSeverity(findings []Finding, severity string, needle string) bool {
+	for _, finding := range findings {
+		if finding.Severity == severity && strings.Contains(finding.Message, needle) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/askreview/review_test.go
+++ b/internal/askreview/review_test.go
@@ -61,6 +61,27 @@ phases:
 	}
 }
 
+func TestWorkspaceReportsValidationFindingsFromPrepareImports(t *testing.T) {
+	root := t.TempDir()
+	writeReviewFile(t, root, workspacepaths.CanonicalPrepareWorkflow, `version: v1alpha1
+phases:
+  - name: prepare
+    imports:
+      - path: bad-prepare.yaml
+`)
+	writeReviewFile(t, root, filepath.Join(workspacepaths.CanonicalComponentsDir, "bad-prepare.yaml"), `steps:
+  - id: install
+    kind: InstallPackage
+    spec:
+      packages: kubeadm
+`)
+
+	findings := Workspace(root)
+	if !hasFindingWithSeverity(findings, "blocking", "Invalid type. Expected: array") {
+		t.Fatalf("expected prepare import validation finding, got %#v", findings)
+	}
+}
+
 func TestWorkspaceDoesNotValidateComponentsWithoutScenarioVars(t *testing.T) {
 	root := t.TempDir()
 	writeReviewFile(t, root, filepath.Join(workspacepaths.CanonicalComponentsDir, "templated.yaml"), `steps:
@@ -73,6 +94,27 @@ func TestWorkspaceDoesNotValidateComponentsWithoutScenarioVars(t *testing.T) {
 	findings := Workspace(root)
 	if hasFindingWithSeverity(findings, "blocking", "Invalid type. Expected: array") {
 		t.Fatalf("expected component templates to avoid context-free validation blockers, got %#v", findings)
+	}
+}
+
+func TestYAMLFilesUnderReturnsPartialPathsAfterWalkError(t *testing.T) {
+	root := t.TempDir()
+	writeReviewFile(t, root, "ok.yaml", "version: v1alpha1\nsteps: []\n")
+	blocked := filepath.Join(root, "zz-blocked")
+	if err := os.Mkdir(blocked, 0o755); err != nil {
+		t.Fatalf("mkdir blocked: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(blocked, "hidden.yaml"), []byte("version: v1alpha1\nsteps: []\n"), 0o644); err != nil {
+		t.Fatalf("write hidden: %v", err)
+	}
+	if err := os.Chmod(blocked, 0); err != nil {
+		t.Fatalf("chmod blocked: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(blocked, 0o755) })
+
+	paths := yamlFilesUnder(root)
+	if len(paths) == 0 || !hasPath(paths, filepath.Join(root, "ok.yaml")) {
+		t.Fatalf("expected partial paths after walk error, got %#v", paths)
 	}
 }
 
@@ -114,6 +156,15 @@ func writeReviewFile(t *testing.T, root string, rel string, content string) {
 func hasFinding(findings []Finding, needle string) bool {
 	for _, finding := range findings {
 		if strings.Contains(finding.Message, needle) {
+			return true
+		}
+	}
+	return false
+}
+
+func hasPath(paths []string, target string) bool {
+	for _, path := range paths {
+		if path == target {
 			return true
 		}
 	}


### PR DESCRIPTION
## Summary
- Expand local ask review from canonical prepare/apply files to workspace scenario and component YAML files.
- Include validator and analysis findings in local review output, while avoiding context-free component/vars false positives.
- Feed local review findings into the LLM review prompt and preserve warning vs blocking severity.

## Verification
- make test
- make lint
- Real LLM smoke: `bin/deck ask --review` on `test/` returned `llm_used=true` with advisory findings only.
- Real LLM smoke: `bin/deck ask --review` on a flawed temp workspace returned `llm_used=true` and identified duplicate step ID plus `InstallPackage.packages` type blocker.

Closes #181