### PR TITLE
Select node-scoped vars by hostname

### DIFF
--- a/.github/e2e/hosted/fixtures/smoke/workflows/vars.yaml
+++ b/.github/e2e/hosted/fixtures/smoke/workflows/vars.yaml
@@ -1,3 +1,8 @@
-installPackages: "true"
-packageManager: apt
-packageName: jq
+all:
+  installPackages: "true"
+  packageManager: apt
+  packageName: jq
+
+hosts:
+  hosted-smoke-example:
+    role: smoke

--- a/cmd/deck/apply_cli_test.go
+++ b/cmd/deck/apply_cli_test.go
@@ -117,6 +117,103 @@ phases:
 	}
 }
 
+func TestPlanAndApplySelectNodeScopedVarsByHostname(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	hostname, err := os.Hostname()
+	if err != nil || strings.TrimSpace(hostname) == "" {
+		t.Skipf("hostname unavailable: %v", err)
+	}
+
+	root := t.TempDir()
+	workflowDir := filepath.Join(root, "workflows")
+	scenarioDir := filepath.Join(workflowDir, "scenarios")
+	if err := os.MkdirAll(scenarioDir, 0o755); err != nil {
+		t.Fatalf("mkdir scenarios: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(workflowDir, "vars.yaml"), []byte(fmt.Sprintf(`all:
+  site: lab-a
+hosts:
+  %q:
+    role: worker
+`, hostname)), 0o644); err != nil {
+		t.Fatalf("write vars.yaml: %v", err)
+	}
+	workflowPath := filepath.Join(scenarioDir, "apply.yaml")
+	writeWorkflowYAML(t, workflowPath, `version: v1alpha1
+phases:
+  - name: install
+    steps:
+      - id: host-match
+        kind: Command
+        when: vars.role == "worker" && vars.site == "lab-a"
+        spec:
+          command: ["true"]
+      - id: host-miss
+        kind: Command
+        when: vars.role == "control-plane"
+        spec:
+          command: ["true"]
+`)
+
+	planOut, err := runWithCapturedStdout([]string{"plan", "--workflow", workflowPath})
+	if err != nil {
+		t.Fatalf("plan failed: %v", err)
+	}
+	if !strings.Contains(planOut, "host-match Command RUN") || !strings.Contains(planOut, "host-miss Command SKIP") {
+		t.Fatalf("expected plan to select hostname-scoped vars, got %q", planOut)
+	}
+
+	applyOut, err := runWithCapturedStdout([]string{"apply", "--workflow", workflowPath, "--dry-run", root})
+	if err != nil {
+		t.Fatalf("apply dry-run failed: %v", err)
+	}
+	if !strings.Contains(applyOut, "host-match Command PLAN") || !strings.Contains(applyOut, "host-miss Command SKIP") {
+		t.Fatalf("expected apply dry-run to select hostname-scoped vars, got %q", applyOut)
+	}
+}
+
+func TestPlanAllowsUnmatchedNodeScopedHostname(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	hostname, err := os.Hostname()
+	if err != nil || strings.TrimSpace(hostname) == "" {
+		t.Skipf("hostname unavailable: %v", err)
+	}
+
+	root := t.TempDir()
+	workflowDir := filepath.Join(root, "workflows")
+	scenarioDir := filepath.Join(workflowDir, "scenarios")
+	if err := os.MkdirAll(scenarioDir, 0o755); err != nil {
+		t.Fatalf("mkdir scenarios: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(workflowDir, "vars.yaml"), []byte(fmt.Sprintf(`all:
+  site: lab-a
+hosts:
+  %q:
+    role: worker
+`, "not-"+hostname)), 0o644); err != nil {
+		t.Fatalf("write vars.yaml: %v", err)
+	}
+	workflowPath := filepath.Join(scenarioDir, "apply.yaml")
+	writeWorkflowYAML(t, workflowPath, `version: v1alpha1
+phases:
+  - name: install
+    steps:
+      - id: unmatched-host
+        kind: Command
+        when: vars.site == "lab-a"
+        spec:
+          command: ["true"]
+`)
+
+	planOut, err := runWithCapturedStdout([]string{"plan", "--workflow", workflowPath})
+	if err != nil {
+		t.Fatalf("plan failed: %v", err)
+	}
+	if !strings.Contains(planOut, "unmatched-host Command RUN") {
+		t.Fatalf("expected unmatched hostname to remain runnable, got %q", planOut)
+	}
+}
+
 func TestRunApplyPhaseSelectionAndSkip(t *testing.T) {
 	home := filepath.Join(t.TempDir(), "home")
 	if err := os.MkdirAll(home, 0o755); err != nil {

--- a/docs/guides/examples/offline-k8s-control-plane.yaml
+++ b/docs/guides/examples/offline-k8s-control-plane.yaml
@@ -60,6 +60,7 @@ phases:
           enabled: true
           state: started
       - id: kubeadm-init
+        when: vars.role == "control-plane"
         apiVersion: deck/v1alpha1
         kind: InitKubeadm
         spec:

--- a/docs/guides/examples/offline-k8s-worker.yaml
+++ b/docs/guides/examples/offline-k8s-worker.yaml
@@ -60,6 +60,7 @@ phases:
           enabled: true
           state: started
       - id: kubeadm-join
+        when: vars.role == "worker"
         apiVersion: deck/v1alpha1
         kind: JoinKubeadm
         spec:

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -167,6 +167,24 @@ deck plan --scenario apply --var role=worker
 deck apply --scenario apply --var role=control-plane --var nodeIP=10.0.0.10
 ```
 
+### Node-scoped workflow variables
+
+`deck lint`, `deck prepare`, `deck plan`, and `deck apply` automatically select node-scoped variables from `workflows/vars.yaml` when the file contains a `hosts:` map. There is no node-selection flag. Deck detects the local hostname, matches `hosts.<hostname>` or the short hostname before the first `.`, and merges that host entry into top-level `vars`.
+
+```yaml
+all:
+  kubernetesVersion: v1.35.5
+
+hosts:
+  k8s-cp1:
+    role: control-plane
+    ip: 192.168.81.211
+```
+
+If the hostname is not listed, these commands still run with ordinary `vars.yaml` values and `all:` values. Workflows that branch on host-specific fields should provide safe defaults in `all:`, such as `role: ""`, then use conditions such as `vars.role == "control-plane"`.
+
+CLI `--var` overrides remain highest precedence. For example, `--var kubernetesVersion=v1.35.6` overrides a value from `all:`.
+
 ### `server up` operational flags
 
 `deck server up` supports a few operational modes beyond the default `--root` and `--addr` pair:

--- a/docs/reference/workflow-model.md
+++ b/docs/reference/workflow-model.md
@@ -67,10 +67,40 @@ steps:
 
 Variables and runtime values come from distinct sources:
 
-Static `vars` flow from two sources, in order of precedence:
+Static `vars` flow from three sources, in order of precedence:
 
-1. `vars:` block in the scenario file (highest)
-2. `workflows/vars.yaml` (shared defaults)
+1. CLI `--var` overrides
+2. `vars:` block in the scenario file
+3. `workflows/vars.yaml` shared defaults
+
+`deck lint`, `deck prepare`, `deck plan`, and `deck apply` also support node-scoped shared variables in `workflows/vars.yaml`. When `hosts:` is present, deck detects the local hostname at execution time, applies optional `all:` values as shared defaults, and merges the matching host entry into top-level `vars`. If the hostname is not listed, execution continues with ordinary `vars.yaml` values and `all:` values.
+
+Node-scoped `vars.yaml` example:
+
+```yaml
+all:
+  kubernetesVersion: v1.35.5
+  podCIDR: 10.244.0.0/16
+
+hosts:
+  k8s-cp1:
+    ip: 192.168.81.211
+    role: control-plane
+
+  k8s-worker1:
+    ip: 192.168.81.221
+    role: worker
+```
+
+For `deck lint`, `deck prepare`, `deck plan`, and `deck apply`, the effective variable precedence is:
+
+1. ordinary `workflows/vars.yaml` values, excluding `all` and `hosts` when `hosts:` is present
+2. `workflows/vars.yaml` `all:` values
+3. selected host values from `hosts.<hostname>`
+4. selected workflow or scenario `vars:` values
+5. CLI `--var` overrides
+
+Hostname matching tries the detected hostname first, then the short hostname before the first `.`. Missing host entries are not fatal. Workflows that branch on host-specific fields should provide safe defaults in `all:`, such as `role: ""`, then use conditions such as `vars.role == "control-plane"`.
 
 Runtime values flow separately through `register` outputs and built-in runtime facts such as `runtime.host`.
 
@@ -107,6 +137,8 @@ vars:
     packages: [kubeadm, kubelet, kubectl]
   when: runtime.host.os.family == "rhel"
 ```
+
+Node-scoped vars are static inputs selected before planning and state hashing; `runtime.host` remains the runtime fact namespace for detected OS, architecture, and kernel data.
 
 `runtime.host` is a built-in reserved runtime namespace in both prepare and apply. Use it for detected host facts such as OS family, distro ID, version, architecture, and kernel release. Do not model detected local host facts as static `vars` values.
 

--- a/docs/reference/workspace-layout.md
+++ b/docs/reference/workspace-layout.md
@@ -80,6 +80,8 @@ steps:
 ### Variables (`workflows/vars.yaml`)
 A central YAML file for shared defaults. Values defined here are available to all workflows and components via the `{{ .vars.NAME }}` syntax.
 
+For node-specific runs, `vars.yaml` may contain `all:` defaults and `hosts:` overlays selected by local hostname. See [Workflow Model](workflow-model.md#variables) for precedence and hostname matching details.
+
 ## Prepared Outputs (`outputs/`)
 
 These directories hold the prepared source material that `apply` consumes.

--- a/internal/applycli/command.go
+++ b/internal/applycli/command.go
@@ -15,6 +15,8 @@ type PlanCommandOptions struct {
 	Output          string
 	Fresh           bool
 	VarOverrides    map[string]any
+	Hostname        string
+	DetectHostname  func() (string, error)
 	Verbosef        func(level int, format string, args ...any) error
 	StdoutPrintf    func(format string, args ...any) error
 	JSONEncoderFunc func() *json.Encoder
@@ -30,6 +32,8 @@ type ApplyCommandOptions struct {
 	Fresh          bool
 	DryRun         bool
 	VarOverrides   map[string]any
+	Hostname       string
+	DetectHostname func() (string, error)
 	Verbosef       func(level int, format string, args ...any) error
 	StdoutPrintf   func(format string, args ...any) error
 	StdoutPrintln  func(args ...any) error
@@ -52,6 +56,9 @@ func RunPlanCommand(ctx context.Context, opts PlanCommandOptions) error {
 		CommandName:                  "diff",
 		WorkflowPath:                 strings.TrimSpace(opts.WorkflowPath),
 		VarOverrides:                 opts.VarOverrides,
+		NodeScopedVars:               true,
+		Hostname:                     opts.Hostname,
+		DetectHostname:               opts.DetectHostname,
 		Fresh:                        opts.Fresh,
 		SelectedPhase:                strings.TrimSpace(opts.SelectedPhase),
 		DefaultPhase:                 "",
@@ -80,6 +87,9 @@ func RunApplyCommand(ctx context.Context, opts ApplyCommandOptions) error {
 		WorkflowPath:                 strings.TrimSpace(opts.WorkflowPath),
 		AllowRemoteWorkflow:          true,
 		VarOverrides:                 opts.VarOverrides,
+		NodeScopedVars:               true,
+		Hostname:                     opts.Hostname,
+		DetectHostname:               opts.DetectHostname,
 		Fresh:                        opts.Fresh,
 		SelectedPhase:                strings.TrimSpace(opts.SelectedPhase),
 		DefaultPhase:                 "",

--- a/internal/applycli/request.go
+++ b/internal/applycli/request.go
@@ -33,6 +33,9 @@ type ExecutionRequestOptions struct {
 	AllowRemoteWorkflow          bool
 	NormalizeLocalWorkflowPath   bool
 	VarOverrides                 map[string]any
+	NodeScopedVars               bool
+	Hostname                     string
+	DetectHostname               func() (string, error)
 	Fresh                        bool
 	SelectedPhase                string
 	DefaultPhase                 string
@@ -85,7 +88,12 @@ func ResolveExecutionRequest(ctx context.Context, opts ExecutionRequestOptions) 
 		}
 	}
 
-	wf, err := config.LoadWithOptions(ctx, workflowPath, config.LoadOptions{VarOverrides: opts.VarOverrides})
+	wf, err := config.LoadWithOptions(ctx, workflowPath, config.LoadOptions{
+		VarOverrides:   opts.VarOverrides,
+		NodeScopedVars: opts.NodeScopedVars,
+		Hostname:       opts.Hostname,
+		DetectHostname: opts.DetectHostname,
+	})
 	if err != nil {
 		return ExecutionRequest{}, err
 	}

--- a/internal/config/loader.go
+++ b/internal/config/loader.go
@@ -15,7 +15,10 @@ import (
 )
 
 type LoadOptions struct {
-	VarOverrides map[string]any
+	VarOverrides   map[string]any
+	NodeScopedVars bool
+	Hostname       string
+	DetectHostname func() (string, error)
 }
 
 func Load(ctx context.Context, source string) (*Workflow, error) {
@@ -44,12 +47,29 @@ func LoadWithOptions(ctx context.Context, source string, opts LoadOptions) (*Wor
 		return nil, fmt.Errorf("workflow cannot set both phases and steps")
 	}
 
-	effectiveVars := map[string]any{}
 	baseVars, err := loadBaseVars(ctx, origin)
 	if err != nil {
 		return nil, err
 	}
-	mergeVars(effectiveVars, baseVars)
+	baseVarsForMerge := baseVars
+	allVars := map[string]any(nil)
+	hostVars := map[string]any(nil)
+	if opts.NodeScopedVars {
+		var scoped bool
+		baseVarsForMerge, allVars, hostVars, scoped, err = resolveNodeScopedVars(baseVars, opts)
+		if err != nil {
+			return nil, err
+		}
+		if !scoped {
+			allVars = nil
+			hostVars = nil
+		}
+	}
+
+	effectiveVars := map[string]any{}
+	mergeVars(effectiveVars, baseVarsForMerge)
+	mergeVars(effectiveVars, allVars)
+	mergeVars(effectiveVars, hostVars)
 	mergeVars(effectiveVars, resolved.Vars)
 	mergeVars(effectiveVars, opts.VarOverrides)
 

--- a/internal/config/loader_test.go
+++ b/internal/config/loader_test.go
@@ -125,6 +125,174 @@ func TestVarsOverridesDeepMerge(t *testing.T) {
 	}
 }
 
+func TestNodeScopedVarsSelection(t *testing.T) {
+	dir := t.TempDir()
+	workflowPath := filepath.Join(dir, "apply.yaml")
+
+	if err := os.WriteFile(filepath.Join(dir, "vars.yaml"), []byte(`clusterName: base-cluster
+all:
+  kubernetesVersion: v1.35.5
+  packageManager: apt
+  region: shared
+hosts:
+  k8s-cp1:
+    ip: 192.168.81.211
+    packageManager: dnf
+    role: control-plane
+    region: host-region
+`), 0o644); err != nil {
+		t.Fatalf("write vars.yaml: %v", err)
+	}
+	if err := os.WriteFile(workflowPath, []byte(`version: v1alpha1
+vars:
+  region: workflow-region
+  role: scenario-role
+phases: []
+`), 0o644); err != nil {
+		t.Fatalf("write workflow: %v", err)
+	}
+
+	wf, err := LoadWithOptions(context.Background(), workflowPath, LoadOptions{NodeScopedVars: true, Hostname: "k8s-cp1"})
+	if err != nil {
+		t.Fatalf("LoadWithOptions failed: %v", err)
+	}
+	if _, ok := wf.Vars["all"]; ok {
+		t.Fatalf("expected scoped all key to be excluded from effective vars")
+	}
+	if _, ok := wf.Vars["hosts"]; ok {
+		t.Fatalf("expected scoped hosts key to be excluded from effective vars")
+	}
+	if got := wf.Vars["clusterName"]; got != "base-cluster" {
+		t.Fatalf("expected ordinary base var, got %#v", got)
+	}
+	if got := wf.Vars["kubernetesVersion"]; got != "v1.35.5" {
+		t.Fatalf("expected all overlay var, got %#v", got)
+	}
+	if got := wf.Vars["packageManager"]; got != "dnf" {
+		t.Fatalf("expected host overlay to override all overlay, got %#v", got)
+	}
+	if got := wf.Vars["region"]; got != "workflow-region" {
+		t.Fatalf("expected workflow vars to override host overlay, got %#v", got)
+	}
+	if got := wf.Vars["ip"]; got != "192.168.81.211" {
+		t.Fatalf("expected host overlay ip, got %#v", got)
+	}
+	if got := wf.Vars["role"]; got != "scenario-role" {
+		t.Fatalf("expected workflow role to override host overlay, got %#v", got)
+	}
+	if _, ok := wf.Vars["node"]; ok {
+		t.Fatalf("unexpected synthetic node var: %#v", wf.Vars["node"])
+	}
+}
+
+func TestNodeScopedVarsUnmatchedHostnameStillLoads(t *testing.T) {
+	dir := t.TempDir()
+	workflowPath := filepath.Join(dir, "apply.yaml")
+
+	if err := os.WriteFile(filepath.Join(dir, "vars.yaml"), []byte(`all:
+  site: lab-a
+hosts:
+  k8s-cp1:
+    role: control-plane
+`), 0o644); err != nil {
+		t.Fatalf("write vars.yaml: %v", err)
+	}
+	if err := os.WriteFile(workflowPath, []byte("version: v1alpha1\nphases: []\n"), 0o644); err != nil {
+		t.Fatalf("write workflow: %v", err)
+	}
+
+	wf, err := LoadWithOptions(context.Background(), workflowPath, LoadOptions{NodeScopedVars: true, Hostname: "unknown-host"})
+	if err != nil {
+		t.Fatalf("LoadWithOptions failed: %v", err)
+	}
+	if got := wf.Vars["site"]; got != "lab-a" {
+		t.Fatalf("expected all overlay for unmatched host, got %#v", got)
+	}
+	if _, ok := wf.Vars["role"]; ok {
+		t.Fatalf("unexpected host overlay role for unmatched host: %#v", wf.Vars)
+	}
+	if _, ok := wf.Vars["node"]; ok {
+		t.Fatalf("unexpected synthetic node var for unmatched host: %#v", wf.Vars["node"])
+	}
+}
+
+func TestNodeScopedVarsShortHostnameFallback(t *testing.T) {
+	dir := t.TempDir()
+	workflowPath := filepath.Join(dir, "apply.yaml")
+
+	if err := os.WriteFile(filepath.Join(dir, "vars.yaml"), []byte(`hosts:
+  k8s-cp1:
+    role: control-plane
+`), 0o644); err != nil {
+		t.Fatalf("write vars.yaml: %v", err)
+	}
+	if err := os.WriteFile(workflowPath, []byte("version: v1alpha1\nphases: []\n"), 0o644); err != nil {
+		t.Fatalf("write workflow: %v", err)
+	}
+
+	wf, err := LoadWithOptions(context.Background(), workflowPath, LoadOptions{NodeScopedVars: true, Hostname: "k8s-cp1.example.local"})
+	if err != nil {
+		t.Fatalf("LoadWithOptions failed: %v", err)
+	}
+	if got := wf.Vars["role"]; got != "control-plane" {
+		t.Fatalf("expected short hostname host overlay, got %#v", wf.Vars)
+	}
+}
+
+func TestNodeScopedVarsCanBeOverriddenByCLI(t *testing.T) {
+	dir := t.TempDir()
+	workflowPath := filepath.Join(dir, "apply.yaml")
+
+	if err := os.WriteFile(filepath.Join(dir, "vars.yaml"), []byte(`hosts:
+  k8s-cp1:
+    role: control-plane
+`), 0o644); err != nil {
+		t.Fatalf("write vars.yaml: %v", err)
+	}
+	if err := os.WriteFile(workflowPath, []byte("version: v1alpha1\nphases: []\n"), 0o644); err != nil {
+		t.Fatalf("write workflow: %v", err)
+	}
+
+	wf, err := LoadWithOptions(context.Background(), workflowPath, LoadOptions{NodeScopedVars: true, Hostname: "k8s-cp1", VarOverrides: map[string]any{"role": "worker"}})
+	if err != nil {
+		t.Fatalf("LoadWithOptions failed: %v", err)
+	}
+	if got := wf.Vars["role"]; got != "worker" {
+		t.Fatalf("expected CLI override to win, got %#v", got)
+	}
+}
+
+func TestNodeScopedVarsDisabledKeepsHostsAsOrdinaryVars(t *testing.T) {
+	dir := t.TempDir()
+	workflowPath := filepath.Join(dir, "apply.yaml")
+
+	if err := os.WriteFile(filepath.Join(dir, "vars.yaml"), []byte(`all:
+  site: lab-a
+hosts:
+  k8s-cp1:
+    role: control-plane
+`), 0o644); err != nil {
+		t.Fatalf("write vars.yaml: %v", err)
+	}
+	if err := os.WriteFile(workflowPath, []byte("version: v1alpha1\nphases: []\n"), 0o644); err != nil {
+		t.Fatalf("write workflow: %v", err)
+	}
+
+	wf, err := LoadWithOptions(context.Background(), workflowPath, LoadOptions{})
+	if err != nil {
+		t.Fatalf("LoadWithOptions failed: %v", err)
+	}
+	if _, ok := wf.Vars["hosts"]; !ok {
+		t.Fatalf("expected hosts to remain ordinary vars when node-scoped vars are disabled")
+	}
+	if _, ok := wf.Vars["all"]; !ok {
+		t.Fatalf("expected all to remain ordinary vars when node-scoped vars are disabled")
+	}
+	if _, ok := wf.Vars["node"]; ok {
+		t.Fatalf("unexpected node var when node-scoped vars are disabled")
+	}
+}
+
 func TestVarsURLFetch(t *testing.T) {
 	t.Run("loads vars yaml when present", func(t *testing.T) {
 		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -252,6 +420,31 @@ func TestStateKey(t *testing.T) {
 
 		if wf1.StateKey == wf2.StateKey {
 			t.Fatalf("expected state key to change when --var override changes")
+		}
+	})
+
+	t.Run("changes when selected host overlay changes", func(t *testing.T) {
+		dir := t.TempDir()
+		workflowPath := filepath.Join(dir, "apply.yaml")
+		workflowContent := []byte("version: v1alpha1\nphases: []\n")
+		if err := os.WriteFile(workflowPath, workflowContent, 0o644); err != nil {
+			t.Fatalf("write workflow: %v", err)
+		}
+		if err := os.WriteFile(filepath.Join(dir, "vars.yaml"), []byte("hosts:\n  node-a:\n    role: worker\n  node-b:\n    role: control-plane\n"), 0o644); err != nil {
+			t.Fatalf("write vars.yaml: %v", err)
+		}
+
+		wf1, err := LoadWithOptions(context.Background(), workflowPath, LoadOptions{NodeScopedVars: true, Hostname: "node-a"})
+		if err != nil {
+			t.Fatalf("LoadWithOptions(context.Background(), node-a) failed: %v", err)
+		}
+		wf2, err := LoadWithOptions(context.Background(), workflowPath, LoadOptions{NodeScopedVars: true, Hostname: "node-b"})
+		if err != nil {
+			t.Fatalf("LoadWithOptions(context.Background(), node-b) failed: %v", err)
+		}
+
+		if wf1.StateKey == wf2.StateKey {
+			t.Fatalf("expected state key to change when selected host overlay changes")
 		}
 	})
 }

--- a/internal/config/nodevars.go
+++ b/internal/config/nodevars.go
@@ -1,0 +1,109 @@
+package config
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/Airgap-Castaways/deck/internal/cloneutil"
+)
+
+const (
+	nodeScopedAllKey   = "all"
+	nodeScopedHostsKey = "hosts"
+)
+
+func resolveNodeScopedVars(baseVars map[string]any, opts LoadOptions) (map[string]any, map[string]any, map[string]any, bool, error) {
+	hostsRaw, hasHosts := baseVars[nodeScopedHostsKey]
+	if !hasHosts {
+		return cloneVars(baseVars), nil, nil, false, nil
+	}
+	hosts, ok := asStringAnyMap(hostsRaw)
+	if !ok {
+		return nil, nil, nil, false, fmt.Errorf("vars.%s must be a map when node-scoped vars are enabled", nodeScopedHostsKey)
+	}
+
+	ordinary := make(map[string]any, len(baseVars))
+	for key, value := range baseVars {
+		if key == nodeScopedAllKey || key == nodeScopedHostsKey {
+			continue
+		}
+		ordinary[key] = cloneutil.DeepValue(value)
+	}
+
+	allVars := map[string]any(nil)
+	if allRaw, ok := baseVars[nodeScopedAllKey]; ok {
+		allMap, ok := asStringAnyMap(allRaw)
+		if !ok {
+			return nil, nil, nil, false, fmt.Errorf("vars.%s must be a map when node-scoped vars are enabled", nodeScopedAllKey)
+		}
+		allVars = cloneVars(allMap)
+	}
+
+	hostname, err := resolveNodeScopedHostname(opts)
+	if err != nil {
+		return nil, nil, nil, false, err
+	}
+	hostOverlay := map[string]any(nil)
+	if hostKey, hostRaw, ok := selectHostOverlay(hosts, hostname); ok {
+		hostVars, ok := asStringAnyMap(hostRaw)
+		if !ok {
+			return nil, nil, nil, false, fmt.Errorf("vars.%s.%s must be a map", nodeScopedHostsKey, hostKey)
+		}
+		hostOverlay = cloneVars(hostVars)
+	}
+
+	return ordinary, allVars, hostOverlay, true, nil
+}
+
+func resolveNodeScopedHostname(opts LoadOptions) (string, error) {
+	if hostname := strings.TrimSpace(opts.Hostname); hostname != "" {
+		return hostname, nil
+	}
+	detect := opts.DetectHostname
+	if detect == nil {
+		detect = os.Hostname
+	}
+	hostname, err := detect()
+	if err != nil {
+		return "", fmt.Errorf("detect hostname for node-scoped vars: %w", err)
+	}
+	return strings.TrimSpace(hostname), nil
+}
+
+func selectHostOverlay(hosts map[string]any, hostname string) (string, any, bool) {
+	trimmed := strings.TrimSpace(hostname)
+	if trimmed == "" {
+		return "", nil, false
+	}
+	if value, ok := hosts[trimmed]; ok {
+		return trimmed, value, true
+	}
+	short := shortHostname(trimmed)
+	if short != trimmed {
+		if value, ok := hosts[short]; ok {
+			return short, value, true
+		}
+	}
+	return "", nil, false
+}
+
+func shortHostname(hostname string) string {
+	trimmed := strings.TrimSpace(hostname)
+	if idx := strings.Index(trimmed, "."); idx > 0 {
+		return trimmed[:idx]
+	}
+	return trimmed
+}
+
+func asStringAnyMap(value any) (map[string]any, bool) {
+	typed, ok := value.(map[string]any)
+	return typed, ok
+}
+
+func cloneVars(input map[string]any) map[string]any {
+	if len(input) == 0 {
+		return map[string]any{}
+	}
+	return cloneutil.DeepMap(input)
+}

--- a/internal/preparecli/service.go
+++ b/internal/preparecli/service.go
@@ -93,7 +93,7 @@ func Run(ctx context.Context, opts Options) error {
 	if err != nil {
 		return err
 	}
-	prepareWorkflow, err := config.LoadWithOptions(ctx, prepareWorkflowPath, config.LoadOptions{VarOverrides: opts.VarOverrides})
+	prepareWorkflow, err := config.LoadWithOptions(ctx, prepareWorkflowPath, config.LoadOptions{VarOverrides: opts.VarOverrides, NodeScopedVars: true})
 	if err != nil {
 		return err
 	}
@@ -249,7 +249,7 @@ func discoverPrepareWorkflow(ctx context.Context) (string, error) {
 	if statErr != nil || preferredInfo.IsDir() {
 		return "", fmt.Errorf("prepare workflow not found: %s", preferred)
 	}
-	if _, loadErr := config.Load(ctx, preferred); loadErr != nil {
+	if _, loadErr := config.LoadWithOptions(ctx, preferred, config.LoadOptions{NodeScopedVars: true}); loadErr != nil {
 		return "", loadErr
 	}
 	return preferred, nil

--- a/internal/validate/validate.go
+++ b/internal/validate/validate.go
@@ -243,7 +243,7 @@ func lintLocalEntrypoint(ctx context.Context, path string, inheritedVars map[str
 		return nil, withWorkflowName(absPath, fmt.Errorf("parse yaml: %w", err))
 	}
 
-	loadOpts := config.LoadOptions{VarOverrides: cloneAnyMap(inheritedVars)}
+	loadOpts := config.LoadOptions{VarOverrides: cloneAnyMap(inheritedVars), NodeScopedVars: true}
 	wf, err := config.LoadWithOptions(ctx, absPath, loadOpts)
 	if err != nil {
 		return nil, withWorkflowName(absPath, err)

--- a/test/workflow_integration_test.go
+++ b/test/workflow_integration_test.go
@@ -7,14 +7,62 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/Airgap-Castaways/deck/internal/applycli"
 	"github.com/Airgap-Castaways/deck/internal/config"
 )
+
+func TestHostedSmokeFixtureNodeScopedVars(t *testing.T) {
+	root := projectRoot(t)
+	workflowPath := filepath.Join(root, ".github", "e2e", "hosted", "fixtures", "smoke", "workflows", "scenarios", "apply.yaml")
+
+	req, err := applycli.ResolveExecutionRequest(context.Background(), applycli.ExecutionRequestOptions{
+		CommandName:                  "apply",
+		WorkflowPath:                 workflowPath,
+		NodeScopedVars:               true,
+		Hostname:                     "hosted-smoke-example",
+		BuildExecutionWorkflow:       true,
+		ResolveStatePath:             true,
+		StatePathFromExecutionTarget: false,
+	})
+	if err != nil {
+		t.Fatalf("resolve hosted smoke workflow: %v", err)
+	}
+
+	vars := req.Workflow.Vars
+	if got := vars["installPackages"]; got != "true" {
+		t.Fatalf("expected all.installPackages to merge into top-level vars, got %#v", got)
+	}
+	if got := vars["packageManager"]; got != "apt" {
+		t.Fatalf("expected all.packageManager to merge into top-level vars, got %#v", got)
+	}
+	if got := vars["packageName"]; got != "jq" {
+		t.Fatalf("expected all.packageName to merge into top-level vars, got %#v", got)
+	}
+	if got := vars["role"]; got != "smoke" {
+		t.Fatalf("expected selected host role to merge into top-level vars, got %#v", got)
+	}
+	if _, ok := vars["all"]; ok {
+		t.Fatalf("unexpected scoped all key in effective vars: %#v", vars["all"])
+	}
+	if _, ok := vars["hosts"]; ok {
+		t.Fatalf("unexpected scoped hosts key in effective vars: %#v", vars["hosts"])
+	}
+	if _, ok := vars["node"]; ok {
+		t.Fatalf("unexpected synthetic node var: %#v", vars["node"])
+	}
+	if req.StatePath == "" {
+		t.Fatalf("expected state path to be resolved")
+	}
+	if req.ExecutionWorkflow == nil || len(req.ExecutionWorkflow.Phases) == 0 {
+		t.Fatalf("expected execution workflow to be built")
+	}
+}
 
 func TestWorkflowIntegrationBootstrap(t *testing.T) {
 	root := projectRoot(t)
 	workflowPath := filepath.Join(root, "test", "workflows", "scenarios", "control-plane-bootstrap.yaml")
 
-	wf, err := config.LoadWithOptions(context.Background(), workflowPath, config.LoadOptions{VarOverrides: map[string]any{"clusterName": "bootstrap-cli"}})
+	wf, err := config.LoadWithOptions(context.Background(), workflowPath, config.LoadOptions{VarOverrides: map[string]any{"clusterName": "bootstrap-cli"}, NodeScopedVars: true})
 	if err != nil {
 		t.Fatalf("load bootstrap workflow: %v", err)
 	}
@@ -58,7 +106,7 @@ func TestWorkflowIntegrationWorkerJoin(t *testing.T) {
 	root := projectRoot(t)
 	workflowPath := filepath.Join(root, "test", "workflows", "scenarios", "worker-join.yaml")
 
-	wf, err := config.LoadWithOptions(context.Background(), workflowPath, config.LoadOptions{VarOverrides: map[string]any{"joinFile": "/tmp/join-cli.txt"}})
+	wf, err := config.LoadWithOptions(context.Background(), workflowPath, config.LoadOptions{VarOverrides: map[string]any{"joinFile": "/tmp/join-cli.txt"}, NodeScopedVars: true})
 	if err != nil {
 		t.Fatalf("load worker join workflow: %v", err)
 	}
@@ -85,7 +133,7 @@ func TestWorkflowIntegrationNodeReset(t *testing.T) {
 	root := projectRoot(t)
 	workflowPath := filepath.Join(root, "test", "workflows", "scenarios", "node-reset.yaml")
 
-	wf, err := config.Load(context.Background(), workflowPath)
+	wf, err := config.LoadWithOptions(context.Background(), workflowPath, config.LoadOptions{NodeScopedVars: true})
 	if err != nil {
 		t.Fatalf("load node-reset workflow: %v", err)
 	}
@@ -112,7 +160,7 @@ func TestWorkflowIntegrationUpgrade(t *testing.T) {
 	wf, err := config.LoadWithOptions(context.Background(), workflowPath, config.LoadOptions{VarOverrides: map[string]any{
 		"kubernetesVersion":        "v1.30.1",
 		"upgradeKubernetesVersion": "v1.31.0",
-	}})
+	}, NodeScopedVars: true})
 	if err != nil {
 		t.Fatalf("load upgrade workflow: %v", err)
 	}

--- a/test/workflows/vars.yaml
+++ b/test/workflows/vars.yaml
@@ -1,167 +1,179 @@
-kubernetesVersion: v1.30.1
-upgradeKubernetesVersion: ""
-upgradePauseImage: registry.k8s.io/pause:3.10
-upgradeEtcdImage: registry.k8s.io/etcd:3.5.15-0
-upgradeCoreDNSImage: registry.k8s.io/coredns/coredns:v1.11.1
-arch: amd64
-backendRuntime: auto
-serverURL: 192.168.57.10:18080
-registryHost: 192.168.57.10:18080
-release: ubuntu2204
-sharedFlavor: k8s-shared
-enableJoin: "true"
-allowDestructive: "false"
-controlPlaneImages:
-  - registry.k8s.io/kube-apiserver:{{ .vars.kubernetesVersion }}
-  - registry.k8s.io/kube-controller-manager:{{ .vars.kubernetesVersion }}
-  - registry.k8s.io/kube-scheduler:{{ .vars.kubernetesVersion }}
-  - registry.k8s.io/kube-proxy:{{ .vars.kubernetesVersion }}
-  - registry.k8s.io/pause:3.9
-  - registry.k8s.io/etcd:3.5.12-0
-  - registry.k8s.io/coredns/coredns:v1.11.1
-upgradeControlPlaneImages:
-  - registry.k8s.io/kube-apiserver:{{ .vars.upgradeKubernetesVersion }}
-  - registry.k8s.io/kube-controller-manager:{{ .vars.upgradeKubernetesVersion }}
-  - registry.k8s.io/kube-scheduler:{{ .vars.upgradeKubernetesVersion }}
-  - registry.k8s.io/kube-proxy:{{ .vars.upgradeKubernetesVersion }}
-  - "{{ .vars.upgradePauseImage }}"
-  - "{{ .vars.upgradeEtcdImage }}"
-  - "{{ .vars.upgradeCoreDNSImage }}"
-binaryDownloads:
-  - source:
-      url: https://dl.k8s.io/release/{{ .vars.kubernetesVersion }}/bin/linux/amd64/kubelet
-    outputPath: files/bin/linux/amd64/kubelet
-    mode: "0755"
-  - source:
-      url: https://dl.k8s.io/release/{{ .vars.kubernetesVersion }}/bin/linux/arm64/kubelet
-    outputPath: files/bin/linux/arm64/kubelet
-    mode: "0755"
-  - source:
-      url: https://dl.k8s.io/release/{{ .vars.kubernetesVersion }}/bin/linux/amd64/kubeadm
-    outputPath: files/bin/linux/amd64/kubeadm
-    mode: "0755"
-  - source:
-      url: https://dl.k8s.io/release/{{ .vars.kubernetesVersion }}/bin/linux/arm64/kubeadm
-    outputPath: files/bin/linux/arm64/kubeadm
-    mode: "0755"
-  - source:
-      url: https://dl.k8s.io/release/{{ .vars.kubernetesVersion }}/bin/linux/amd64/kubectl
-    outputPath: files/bin/linux/amd64/kubectl
-    mode: "0755"
-  - source:
-      url: https://dl.k8s.io/release/{{ .vars.kubernetesVersion }}/bin/linux/arm64/kubectl
-    outputPath: files/bin/linux/arm64/kubectl
-    mode: "0755"
-  - source:
-      url: https://github.com/kubernetes-sigs/cri-tools/releases/download/v1.30.0/crictl-v1.30.0-linux-amd64.tar.gz
-    outputPath: files/bin/linux/amd64/crictl.tar.gz
-  - source:
-      url: https://github.com/kubernetes-sigs/cri-tools/releases/download/v1.30.0/crictl-v1.30.0-linux-arm64.tar.gz
-    outputPath: files/bin/linux/arm64/crictl.tar.gz
-  - source:
-      url: https://github.com/containerd/containerd/releases/download/v1.7.18/containerd-1.7.18-linux-amd64.tar.gz
-    outputPath: files/bin/linux/amd64/containerd.tar.gz
-  - source:
-      url: https://github.com/containerd/containerd/releases/download/v1.7.18/containerd-1.7.18-linux-arm64.tar.gz
-    outputPath: files/bin/linux/arm64/containerd.tar.gz
-  - source:
-      url: https://github.com/opencontainers/runc/releases/download/v1.1.13/runc.amd64
-    outputPath: files/bin/linux/amd64/runc
-    mode: "0755"
-  - source:
-      url: https://github.com/opencontainers/runc/releases/download/v1.1.13/runc.arm64
-    outputPath: files/bin/linux/arm64/runc
-    mode: "0755"
-  - source:
-      url: https://github.com/containernetworking/plugins/releases/download/v1.5.1/cni-plugins-linux-amd64-v1.5.1.tgz
-    outputPath: files/bin/linux/amd64/cni-plugins.tgz
-  - source:
-      url: https://github.com/containernetworking/plugins/releases/download/v1.5.1/cni-plugins-linux-arm64-v1.5.1.tgz
-    outputPath: files/bin/linux/arm64/cni-plugins.tgz
-upgradeBinaryDownloads:
-  - source:
-      url: https://dl.k8s.io/release/{{ .vars.upgradeKubernetesVersion }}/bin/linux/amd64/kubelet
-    outputPath: files/bin/linux/amd64/upgrade/{{ .vars.upgradeKubernetesVersion }}/kubelet
-    mode: "0755"
-  - source:
-      url: https://dl.k8s.io/release/{{ .vars.upgradeKubernetesVersion }}/bin/linux/arm64/kubelet
-    outputPath: files/bin/linux/arm64/upgrade/{{ .vars.upgradeKubernetesVersion }}/kubelet
-    mode: "0755"
-  - source:
-      url: https://dl.k8s.io/release/{{ .vars.upgradeKubernetesVersion }}/bin/linux/amd64/kubeadm
-    outputPath: files/bin/linux/amd64/upgrade/{{ .vars.upgradeKubernetesVersion }}/kubeadm
-    mode: "0755"
-  - source:
-      url: https://dl.k8s.io/release/{{ .vars.upgradeKubernetesVersion }}/bin/linux/arm64/kubeadm
-    outputPath: files/bin/linux/arm64/upgrade/{{ .vars.upgradeKubernetesVersion }}/kubeadm
-    mode: "0755"
-  - source:
-      url: https://dl.k8s.io/release/{{ .vars.upgradeKubernetesVersion }}/bin/linux/amd64/kubectl
-    outputPath: files/bin/linux/amd64/upgrade/{{ .vars.upgradeKubernetesVersion }}/kubectl
-    mode: "0755"
-  - source:
-      url: https://dl.k8s.io/release/{{ .vars.upgradeKubernetesVersion }}/bin/linux/arm64/kubectl
-    outputPath: files/bin/linux/arm64/upgrade/{{ .vars.upgradeKubernetesVersion }}/kubectl
-    mode: "0755"
-runtimeDepPackages:
-  debian:
-    - conntrack
-    - socat
-    - iptables
-  rhel:
-    - conntrack-tools
-    - socat
-    - iptables
-install:
-  k8sBinaries:
-    kubelet:
-      source:
-        url: http://{{ .vars.serverURL }}/files/bin/linux/{{ .runtime.host.arch }}/kubelet
-      path: /usr/bin/kubelet
+all:
+  kubernetesVersion: v1.30.1
+  upgradeKubernetesVersion: ""
+  upgradePauseImage: registry.k8s.io/pause:3.10
+  upgradeEtcdImage: registry.k8s.io/etcd:3.5.15-0
+  upgradeCoreDNSImage: registry.k8s.io/coredns/coredns:v1.11.1
+  arch: amd64
+  backendRuntime: auto
+  serverURL: 192.168.57.10:18080
+  registryHost: 192.168.57.10:18080
+  release: ubuntu2204
+  sharedFlavor: k8s-shared
+  enableJoin: "true"
+  allowDestructive: "false"
+  controlPlaneImages:
+    - registry.k8s.io/kube-apiserver:{{ .vars.kubernetesVersion }}
+    - registry.k8s.io/kube-controller-manager:{{ .vars.kubernetesVersion }}
+    - registry.k8s.io/kube-scheduler:{{ .vars.kubernetesVersion }}
+    - registry.k8s.io/kube-proxy:{{ .vars.kubernetesVersion }}
+    - registry.k8s.io/pause:3.9
+    - registry.k8s.io/etcd:3.5.12-0
+    - registry.k8s.io/coredns/coredns:v1.11.1
+  upgradeControlPlaneImages:
+    - registry.k8s.io/kube-apiserver:{{ .vars.upgradeKubernetesVersion }}
+    - registry.k8s.io/kube-controller-manager:{{ .vars.upgradeKubernetesVersion }}
+    - registry.k8s.io/kube-scheduler:{{ .vars.upgradeKubernetesVersion }}
+    - registry.k8s.io/kube-proxy:{{ .vars.upgradeKubernetesVersion }}
+    - "{{ .vars.upgradePauseImage }}"
+    - "{{ .vars.upgradeEtcdImage }}"
+    - "{{ .vars.upgradeCoreDNSImage }}"
+  binaryDownloads:
+    - source:
+        url: https://dl.k8s.io/release/{{ .vars.kubernetesVersion }}/bin/linux/amd64/kubelet
+      outputPath: files/bin/linux/amd64/kubelet
       mode: "0755"
-    kubeadm:
-      source:
-        url: http://{{ .vars.serverURL }}/files/bin/linux/{{ .runtime.host.arch }}/kubeadm
-      path: /usr/bin/kubeadm
+    - source:
+        url: https://dl.k8s.io/release/{{ .vars.kubernetesVersion }}/bin/linux/arm64/kubelet
+      outputPath: files/bin/linux/arm64/kubelet
       mode: "0755"
-    kubectl:
-      source:
-        url: http://{{ .vars.serverURL }}/files/bin/linux/{{ .runtime.host.arch }}/kubectl
-      path: /usr/bin/kubectl
+    - source:
+        url: https://dl.k8s.io/release/{{ .vars.kubernetesVersion }}/bin/linux/amd64/kubeadm
+      outputPath: files/bin/linux/amd64/kubeadm
       mode: "0755"
-    crictl:
-      source:
-        url: http://{{ .vars.serverURL }}/files/bin/linux/{{ .runtime.host.arch }}/crictl.tar.gz
-      path: /usr/bin
-      include:
-        - crictl
+    - source:
+        url: https://dl.k8s.io/release/{{ .vars.kubernetesVersion }}/bin/linux/arm64/kubeadm
+      outputPath: files/bin/linux/arm64/kubeadm
       mode: "0755"
-  runtimeDeps:
+    - source:
+        url: https://dl.k8s.io/release/{{ .vars.kubernetesVersion }}/bin/linux/amd64/kubectl
+      outputPath: files/bin/linux/amd64/kubectl
+      mode: "0755"
+    - source:
+        url: https://dl.k8s.io/release/{{ .vars.kubernetesVersion }}/bin/linux/arm64/kubectl
+      outputPath: files/bin/linux/arm64/kubectl
+      mode: "0755"
+    - source:
+        url: https://github.com/kubernetes-sigs/cri-tools/releases/download/v1.30.0/crictl-v1.30.0-linux-amd64.tar.gz
+      outputPath: files/bin/linux/amd64/crictl.tar.gz
+    - source:
+        url: https://github.com/kubernetes-sigs/cri-tools/releases/download/v1.30.0/crictl-v1.30.0-linux-arm64.tar.gz
+      outputPath: files/bin/linux/arm64/crictl.tar.gz
+    - source:
+        url: https://github.com/containerd/containerd/releases/download/v1.7.18/containerd-1.7.18-linux-amd64.tar.gz
+      outputPath: files/bin/linux/amd64/containerd.tar.gz
+    - source:
+        url: https://github.com/containerd/containerd/releases/download/v1.7.18/containerd-1.7.18-linux-arm64.tar.gz
+      outputPath: files/bin/linux/arm64/containerd.tar.gz
+    - source:
+        url: https://github.com/opencontainers/runc/releases/download/v1.1.13/runc.amd64
+      outputPath: files/bin/linux/amd64/runc
+      mode: "0755"
+    - source:
+        url: https://github.com/opencontainers/runc/releases/download/v1.1.13/runc.arm64
+      outputPath: files/bin/linux/arm64/runc
+      mode: "0755"
+    - source:
+        url: https://github.com/containernetworking/plugins/releases/download/v1.5.1/cni-plugins-linux-amd64-v1.5.1.tgz
+      outputPath: files/bin/linux/amd64/cni-plugins.tgz
+    - source:
+        url: https://github.com/containernetworking/plugins/releases/download/v1.5.1/cni-plugins-linux-arm64-v1.5.1.tgz
+      outputPath: files/bin/linux/arm64/cni-plugins.tgz
+  upgradeBinaryDownloads:
+    - source:
+        url: https://dl.k8s.io/release/{{ .vars.upgradeKubernetesVersion }}/bin/linux/amd64/kubelet
+      outputPath: files/bin/linux/amd64/upgrade/{{ .vars.upgradeKubernetesVersion }}/kubelet
+      mode: "0755"
+    - source:
+        url: https://dl.k8s.io/release/{{ .vars.upgradeKubernetesVersion }}/bin/linux/arm64/kubelet
+      outputPath: files/bin/linux/arm64/upgrade/{{ .vars.upgradeKubernetesVersion }}/kubelet
+      mode: "0755"
+    - source:
+        url: https://dl.k8s.io/release/{{ .vars.upgradeKubernetesVersion }}/bin/linux/amd64/kubeadm
+      outputPath: files/bin/linux/amd64/upgrade/{{ .vars.upgradeKubernetesVersion }}/kubeadm
+      mode: "0755"
+    - source:
+        url: https://dl.k8s.io/release/{{ .vars.upgradeKubernetesVersion }}/bin/linux/arm64/kubeadm
+      outputPath: files/bin/linux/arm64/upgrade/{{ .vars.upgradeKubernetesVersion }}/kubeadm
+      mode: "0755"
+    - source:
+        url: https://dl.k8s.io/release/{{ .vars.upgradeKubernetesVersion }}/bin/linux/amd64/kubectl
+      outputPath: files/bin/linux/amd64/upgrade/{{ .vars.upgradeKubernetesVersion }}/kubectl
+      mode: "0755"
+    - source:
+        url: https://dl.k8s.io/release/{{ .vars.upgradeKubernetesVersion }}/bin/linux/arm64/kubectl
+      outputPath: files/bin/linux/arm64/upgrade/{{ .vars.upgradeKubernetesVersion }}/kubectl
+      mode: "0755"
+  runtimeDepPackages:
     debian:
-      extractContainerd:
-        source:
-          url: http://{{ .vars.serverURL }}/files/bin/linux/{{ .runtime.host.arch }}/containerd.tar.gz
-        path: /usr/local
-      installRunc:
-        source:
-          url: http://{{ .vars.serverURL }}/files/bin/linux/{{ .runtime.host.arch }}/runc
-        path: /usr/local/sbin/runc
-        mode: "0755"
-      extractCNIPlugins:
-        source:
-          url: http://{{ .vars.serverURL }}/files/bin/linux/{{ .runtime.host.arch }}/cni-plugins.tgz
-        path: /opt/cni/bin
+      - conntrack
+      - socat
+      - iptables
     rhel:
-      extractContainerd:
+      - conntrack-tools
+      - socat
+      - iptables
+  install:
+    k8sBinaries:
+      kubelet:
         source:
-          url: http://{{ .vars.serverURL }}/files/bin/linux/{{ .runtime.host.arch }}/containerd.tar.gz
-        path: /usr/local
-      installRunc:
-        source:
-          url: http://{{ .vars.serverURL }}/files/bin/linux/{{ .runtime.host.arch }}/runc
-        path: /usr/local/sbin/runc
+          url: http://{{ .vars.serverURL }}/files/bin/linux/{{ .runtime.host.arch }}/kubelet
+        path: /usr/bin/kubelet
         mode: "0755"
-      extractCNIPlugins:
+      kubeadm:
         source:
-          url: http://{{ .vars.serverURL }}/files/bin/linux/{{ .runtime.host.arch }}/cni-plugins.tgz
-        path: /opt/cni/bin
+          url: http://{{ .vars.serverURL }}/files/bin/linux/{{ .runtime.host.arch }}/kubeadm
+        path: /usr/bin/kubeadm
+        mode: "0755"
+      kubectl:
+        source:
+          url: http://{{ .vars.serverURL }}/files/bin/linux/{{ .runtime.host.arch }}/kubectl
+        path: /usr/bin/kubectl
+        mode: "0755"
+      crictl:
+        source:
+          url: http://{{ .vars.serverURL }}/files/bin/linux/{{ .runtime.host.arch }}/crictl.tar.gz
+        path: /usr/bin
+        include:
+          - crictl
+        mode: "0755"
+    runtimeDeps:
+      debian:
+        extractContainerd:
+          source:
+            url: http://{{ .vars.serverURL }}/files/bin/linux/{{ .runtime.host.arch }}/containerd.tar.gz
+          path: /usr/local
+        installRunc:
+          source:
+            url: http://{{ .vars.serverURL }}/files/bin/linux/{{ .runtime.host.arch }}/runc
+          path: /usr/local/sbin/runc
+          mode: "0755"
+        extractCNIPlugins:
+          source:
+            url: http://{{ .vars.serverURL }}/files/bin/linux/{{ .runtime.host.arch }}/cni-plugins.tgz
+          path: /opt/cni/bin
+      rhel:
+        extractContainerd:
+          source:
+            url: http://{{ .vars.serverURL }}/files/bin/linux/{{ .runtime.host.arch }}/containerd.tar.gz
+          path: /usr/local
+        installRunc:
+          source:
+            url: http://{{ .vars.serverURL }}/files/bin/linux/{{ .runtime.host.arch }}/runc
+          path: /usr/local/sbin/runc
+          mode: "0755"
+        extractCNIPlugins:
+          source:
+            url: http://{{ .vars.serverURL }}/files/bin/linux/{{ .runtime.host.arch }}/cni-plugins.tgz
+          path: /opt/cni/bin
+
+hosts:
+  control-plane:
+    role: control-plane
+    ip: 192.168.57.10
+  worker:
+    role: worker
+    ip: 192.168.57.11
+  worker-2:
+    role: worker
+    ip: 192.168.57.12


### PR DESCRIPTION
## Summary
- Select `workflows/vars.yaml` `hosts.<hostname>` overlays automatically for lint, prepare, plan, and apply without adding a node-selection flag.
- Merge node-scoped values into top-level vars with precedence `ordinary vars.yaml -> all -> host overlay -> workflow vars -> CLI --var`.
- Update hosted/test workflow fixtures, examples, docs, and coverage for unmatched hosts and hosted smoke vars.

## Verification
- `go test ./internal/config ./internal/preparecli ./internal/validate ./internal/lintcli ./cmd/deck ./test`
- `make test`
- `make lint`
- `make build`
- `./bin/deck lint --root test`
- `./bin/deck lint --file docs/guides/examples/offline-k8s-control-plane.yaml`
- `./bin/deck lint --file docs/guides/examples/offline-k8s-worker.yaml`
- `./bin/deck lint --file .github/e2e/hosted/fixtures/smoke/workflows/scenarios/apply.yaml`

Closes #188.