### PR TITLE
Add platform selection for staged artifacts

### DIFF
--- a/docs/reference/groups/artifact-staging.md
+++ b/docs/reference/groups/artifact-staging.md
@@ -166,6 +166,7 @@ spec:
 | `spec.distro` | `object` | no | `` | `` | Target distribution hint used to select resolver behavior. | `{family:rhel,release:rocky9}` |
 | `spec.outputDir` | `string` | no | `` | `` | Optional bundle-relative output directory for downloaded package artifacts. | `packages/kubernetes` |
 | `spec.packages` | `array<string>` | yes | `` | `` | Package names to download. | `[kubelet,kubeadm,kubectl]` |
+| `spec.platform` | `string` | no | `` | `` | Target container platform for package resolution in os/arch or os/arch/variant form. | `linux/amd64` |
 | `spec.repo` | `object` | no | `` | `` | Repository settings applied before download. | `{type:rpm,modules:[{name:container-tools,stream:4.0}]}` |
 
 ### Nested Objects
@@ -238,6 +239,7 @@ spec:
 | `spec.backend` | `object` | no | `` | `` | Backend-specific download settings. | `{engine:go-containerregistry}` |
 | `spec.images` | `array<string>` | yes | `` | `` | Fully qualified image references to download. | `[registry.k8s.io/pause:3.9]` |
 | `spec.outputDir` | `string` | no | `` | `` | Optional bundle-relative directory for per-image tar archives. | `images/control-plane` |
+| `spec.platforms` | `array<string>` | no | `` | `` | Optional target platforms in os/arch or os/arch/variant form. | `[linux/amd64,linux/arm64]` |
 
 ### Nested Objects
 
@@ -259,6 +261,7 @@ spec:
 
 - `outputDir` must stay under the prepared `images/` root.
 - Omit `outputDir` unless you need a dedicated image subdirectory under `images/`.
+- Use `spec.platforms` to pull target platforms explicitly; platform-specific archives include the platform in the filename.
 - `spec.auth` is optional and only applies to `DownloadImage`.
 
 ## Related

--- a/docs/reference/groups/runtime-services.md
+++ b/docs/reference/groups/runtime-services.md
@@ -216,12 +216,14 @@ spec:
 |---|---|---:|---|---|---|---|
 | `spec.command` | `array<string>` | no | `` | `` | Optional runtime command override. | `[ctr,-n,k8s.io,images,import,{archive}]` |
 | `spec.images` | `array<string>` | yes | `` | `` | Image references to load from the prepared archives. | `[registry.k8s.io/kube-apiserver:v1.30.1]` |
+| `spec.platforms` | `array<string>` | no | `` | `` | Optional target platforms matching DownloadImage archive suffixes. | `[linux/amd64]` |
 | `spec.runtime` | `string` | no | `` | `auto, ctr, docker, podman` | Runtime loader to use for imports. | `ctr` |
 | `spec.sourceDir` | `string` | no | `` | `` | Directory containing prepared image archives. | `images/control-plane` |
 
 ### Notes
 
 - `command` may include `{archive}` placeholders that deck substitutes per image archive.
+- When `spec.platforms` is set, deck loads archives with matching platform suffixes produced by `DownloadImage`.
 
 ## `VerifyImage`
 

--- a/internal/install/image_runtime_test.go
+++ b/internal/install/image_runtime_test.go
@@ -107,3 +107,39 @@ func TestRun_Image(t *testing.T) {
 		}
 	})
 }
+
+func TestRunLoadImageUsesPlatformArchiveSuffix(t *testing.T) {
+	dir := t.TempDir()
+	bundle := filepath.Join(dir, "bundle")
+	if err := os.MkdirAll(bundle, 0o755); err != nil {
+		t.Fatalf("mkdir bundle: %v", err)
+	}
+	logPath := filepath.Join(dir, "archives.txt")
+
+	err := runLoadImage(context.Background(), bundle, map[string]any{
+		"images":    []any{"registry.k8s.io/pause:3.9"},
+		"platforms": []any{"linux/amd64", "linux/arm64"},
+		"command": []any{
+			"sh",
+			"-c",
+			"printf '%s\n' \"$1\" >> \"$2\"",
+			"sh",
+			"{archive}",
+			logPath,
+		},
+	})
+	if err != nil {
+		t.Fatalf("runLoadImage failed: %v", err)
+	}
+	raw, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("read archive log: %v", err)
+	}
+	want := strings.Join([]string{
+		filepath.ToSlash(filepath.Join(bundle, "images", "registry.k8s.io_pause_3.9_linux_amd64.tar")),
+		filepath.ToSlash(filepath.Join(bundle, "images", "registry.k8s.io_pause_3.9_linux_arm64.tar")),
+	}, "\n") + "\n"
+	if string(raw) != want {
+		t.Fatalf("unexpected archive paths:\n%s\nwant:\n%s", string(raw), want)
+	}
+}

--- a/internal/install/steps_images_load.go
+++ b/internal/install/steps_images_load.go
@@ -26,14 +26,20 @@ func runLoadImage(ctx context.Context, bundleRoot string, spec map[string]any) e
 	if strings.TrimSpace(bundleRoot) != "" {
 		sourceDir = filepath.Join(bundleRoot, sourceDir)
 	}
+	platforms, err := loadImagePlatforms(decoded.Platforms)
+	if err != nil {
+		return err
+	}
 	for _, image := range decoded.Images {
-		archivePath := filepath.ToSlash(filepath.Join(sourceDir, sanitizeImageArchiveName(image)+".tar"))
-		args, err := loadImageCommandArgs(decoded, archivePath)
-		if err != nil {
-			return err
-		}
-		if err := runTimedCommandWithContext(ctx, args[0], args[1:], commandTimeoutWithDefault(spec, 10*time.Minute)); err != nil {
-			return fmt.Errorf("load image %s: %w", image, err)
+		for _, platform := range platforms {
+			archivePath := filepath.ToSlash(filepath.Join(sourceDir, imageArchiveName(image, platform)+".tar"))
+			args, err := loadImageCommandArgs(decoded, archivePath)
+			if err != nil {
+				return err
+			}
+			if err := runTimedCommandWithContext(ctx, args[0], args[1:], commandTimeoutWithDefault(spec, 10*time.Minute)); err != nil {
+				return fmt.Errorf("load image %s%s: %w", image, imagePlatformErrorSuffix(platform), err)
+			}
 		}
 	}
 	return nil
@@ -62,4 +68,54 @@ func loadImageCommandArgs(spec stepspec.LoadImage, archivePath string) ([]string
 func sanitizeImageArchiveName(v string) string {
 	replacer := strings.NewReplacer("/", "_", ":", "_", "@", "_")
 	return replacer.Replace(v)
+}
+
+func loadImagePlatforms(raw []stepspec.ImagePlatform) ([]string, error) {
+	if len(raw) == 0 {
+		return []string{""}, nil
+	}
+	platforms := make([]string, 0, len(raw))
+	seen := map[string]bool{}
+	for _, item := range raw {
+		platform, err := normalizeImagePlatform(string(item))
+		if err != nil {
+			return nil, err
+		}
+		if seen[platform] {
+			return nil, fmt.Errorf("LoadImage platforms contains duplicate entry: %s", platform)
+		}
+		seen[platform] = true
+		platforms = append(platforms, platform)
+	}
+	return platforms, nil
+}
+
+func normalizeImagePlatform(raw string) (string, error) {
+	trimmed := strings.ToLower(strings.TrimSpace(raw))
+	parts := strings.Split(trimmed, "/")
+	if len(parts) != 2 && len(parts) != 3 {
+		return "", fmt.Errorf("image platform %q must use os/arch or os/arch/variant", raw)
+	}
+	for i, part := range parts {
+		parts[i] = strings.TrimSpace(part)
+		if parts[i] == "" {
+			return "", fmt.Errorf("image platform %q must not contain empty components", raw)
+		}
+	}
+	return strings.Join(parts, "/"), nil
+}
+
+func imageArchiveName(image, platform string) string {
+	name := sanitizeImageArchiveName(image)
+	if strings.TrimSpace(platform) != "" {
+		name += "_" + strings.NewReplacer("/", "_").Replace(platform)
+	}
+	return name
+}
+
+func imagePlatformErrorSuffix(platform string) string {
+	if strings.TrimSpace(platform) == "" {
+		return ""
+	}
+	return " for platform " + platform
 }

--- a/internal/install/steps_images_load.go
+++ b/internal/install/steps_images_load.go
@@ -77,7 +77,7 @@ func loadImagePlatforms(raw []stepspec.ImagePlatform) ([]string, error) {
 	platforms := make([]string, 0, len(raw))
 	seen := map[string]bool{}
 	for _, item := range raw {
-		platform, err := normalizeImagePlatform(string(item))
+		platform, err := stepspec.NormalizePlatform(string(item))
 		if err != nil {
 			return nil, err
 		}
@@ -88,21 +88,6 @@ func loadImagePlatforms(raw []stepspec.ImagePlatform) ([]string, error) {
 		platforms = append(platforms, platform)
 	}
 	return platforms, nil
-}
-
-func normalizeImagePlatform(raw string) (string, error) {
-	trimmed := strings.ToLower(strings.TrimSpace(raw))
-	parts := strings.Split(trimmed, "/")
-	if len(parts) != 2 && len(parts) != 3 {
-		return "", fmt.Errorf("image platform %q must use os/arch or os/arch/variant", raw)
-	}
-	for i, part := range parts {
-		parts[i] = strings.TrimSpace(part)
-		if parts[i] == "" {
-			return "", fmt.Errorf("image platform %q must not contain empty components", raw)
-		}
-	}
-	return strings.Join(parts, "/"), nil
 }
 
 func imageArchiveName(image, platform string) string {

--- a/internal/prepare/artifact_backend_test.go
+++ b/internal/prepare/artifact_backend_test.go
@@ -2,6 +2,7 @@ package prepare
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -172,6 +173,83 @@ func TestRun_PackagesContainerBackend(t *testing.T) {
 
 	if _, err := os.Stat(filepath.Join(bundle, "packages", "mock-package.deb")); err != nil {
 		t.Fatalf("expected mock package artifact: %v", err)
+	}
+}
+
+func TestRun_DownloadPackagePassesPlatformToContainer(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	bundle := t.TempDir()
+	r := &fakeRunner{}
+
+	wf := &config.Workflow{
+		Version: "v1",
+		Phases: []config.Phase{{
+			Name: "prepare",
+			Steps: []config.Step{{
+				ID:   "k8s-pkgs",
+				Kind: "DownloadPackage",
+				Spec: map[string]any{
+					"packages": []any{"kubelet", "kubeadm"},
+					"platform": " linux/AMD64 ",
+					"backend": map[string]any{
+						"mode":    "container",
+						"runtime": "docker",
+						"image":   "ubuntu:22.04",
+					},
+				},
+			}},
+		}},
+	}
+
+	if err := Run(context.Background(), wf, RunOptions{BundleRoot: bundle, CommandRunner: r}); err != nil {
+		t.Fatalf("Run failed: %v", err)
+	}
+
+	r.mu.Lock()
+	if len(r.createArgs) == 0 {
+		r.mu.Unlock()
+		t.Fatalf("expected container create call")
+	}
+	createArgs := append([]string(nil), r.createArgs[0]...)
+	r.mu.Unlock()
+	if len(createArgs) < 4 || createArgs[0] != "create" || createArgs[1] != "--platform" || createArgs[2] != "linux/amd64" || createArgs[3] != "--name" {
+		t.Fatalf("expected docker create --platform linux/amd64, got %#v", createArgs)
+	}
+
+	raw, err := os.ReadFile(packageMetaFileAbs(bundle, "packages"))
+	if err != nil {
+		t.Fatalf("read package metadata: %v", err)
+	}
+	var meta packageCacheMeta
+	if err := json.Unmarshal(raw, &meta); err != nil {
+		t.Fatalf("decode package metadata: %v", err)
+	}
+	if meta.Platform != "linux/amd64" {
+		t.Fatalf("expected platform metadata, got %q", meta.Platform)
+	}
+}
+
+func TestRun_DownloadPackageRejectsInvalidPlatform(t *testing.T) {
+	bundle := t.TempDir()
+	wf := &config.Workflow{
+		Version: "v1",
+		Phases: []config.Phase{{
+			Name: "prepare",
+			Steps: []config.Step{{
+				ID:   "k8s-pkgs",
+				Kind: "DownloadPackage",
+				Spec: map[string]any{
+					"packages": []any{"kubelet"},
+					"platform": "linux",
+					"backend":  map[string]any{"mode": "container", "runtime": "docker", "image": "ubuntu:22.04"},
+				},
+			}},
+		}},
+	}
+
+	err := Run(context.Background(), wf, RunOptions{BundleRoot: bundle, CommandRunner: &fakeRunner{}})
+	if err == nil || !strings.Contains(err.Error(), "os/arch") {
+		t.Fatalf("expected invalid platform error, got %v", err)
 	}
 }
 
@@ -436,7 +514,7 @@ func TestRun_DownloadImageCorruptedArchiveTriggersRefetch(t *testing.T) {
 		parseReference: func(v string) (name.Reference, error) {
 			return name.ParseReference(v, name.WeakValidation)
 		},
-		fetchImage: func(_ name.Reference, _ ...remote.Option) (v1.Image, error) {
+		fetchImage: func(_ name.Reference, _ *v1.Platform, _ ...remote.Option) (v1.Image, error) {
 			fetches++
 			return empty.Image, nil
 		},

--- a/internal/prepare/download_images.go
+++ b/internal/prepare/download_images.go
@@ -23,6 +23,7 @@ import (
 
 type imageArtifactMeta struct {
 	Images        []string          `json:"images"`
+	Platforms     []string          `json:"platforms,omitempty"`
 	Files         []string          `json:"files"`
 	Checksums     map[string]string `json:"checksums,omitempty"`
 	SourceDigests map[string]string `json:"sourceDigests,omitempty"`
@@ -30,16 +31,23 @@ type imageArtifactMeta struct {
 
 type imageDownloadOps struct {
 	parseReference func(string) (name.Reference, error)
-	fetchImage     func(name.Reference, ...remote.Option) (v1.Image, error)
+	fetchImage     func(name.Reference, *v1.Platform, ...remote.Option) (v1.Image, error)
 	writeArchive   func(string, name.Reference, v1.Image, ...tarball.WriteOption) error
 }
 
 func defaultDownloadImageOps() imageDownloadOps {
 	return imageDownloadOps{
 		parseReference: parseWeakImageReference,
-		fetchImage:     remote.Image,
+		fetchImage:     fetchRemoteImage,
 		writeArchive:   tarball.WriteToFile,
 	}
+}
+
+func fetchRemoteImage(ref name.Reference, platform *v1.Platform, opts ...remote.Option) (v1.Image, error) {
+	if platform != nil {
+		opts = append(opts, remote.WithPlatform(*platform))
+	}
+	return remote.Image(ref, opts...)
 }
 
 func parseWeakImageReference(v string) (name.Reference, error) {
@@ -88,65 +96,119 @@ func runDownloadImage(ctx context.Context, runner CommandRunner, bundleRoot stri
 		return nil, err
 	}
 
-	return runGoContainerRegistryDownloads(ctx, bundleRoot, dir, images, auth, opts)
+	platforms, err := parseImagePlatforms(decoded.Platforms)
+	if err != nil {
+		return nil, err
+	}
+
+	return runGoContainerRegistryDownloads(ctx, bundleRoot, dir, images, platforms, auth, opts)
 }
 
-func runGoContainerRegistryDownloads(ctx context.Context, bundleRoot, dir string, images []string, auth imageRegistryAuthMap, opts RunOptions) ([]string, error) {
+type imagePlatformSelection struct {
+	Raw      string
+	Platform v1.Platform
+}
+
+func runGoContainerRegistryDownloads(ctx context.Context, bundleRoot, dir string, images []string, platforms []imagePlatformSelection, auth imageRegistryAuthMap, opts RunOptions) ([]string, error) {
 	deps := resolveDownloadImageOps(opts)
-	if files, reused, err := tryReuseImageArtifact(bundleRoot, dir, images, opts); err != nil {
+	platformKeys := imagePlatformKeys(platforms)
+	if files, reused, err := tryReuseImageArtifact(bundleRoot, dir, images, platformKeys, opts); err != nil {
 		return nil, err
 	} else if reused {
 		return files, nil
 	}
-	files := make([]string, 0, len(images))
+	fetchTargets := imageFetchTargets(platforms)
+	files := make([]string, 0, len(images)*len(fetchTargets))
 	sourceDigests := map[string]string{}
 	for _, img := range images {
-		rel := filepath.ToSlash(filepath.Join(dir, sanitizeImageName(img)+".tar"))
-		target := filepath.Join(bundleRoot, filepath.FromSlash(rel))
-		if err := filemode.EnsureParentDir(target, filemode.PublishedArtifact); err != nil {
-			return nil, err
-		}
-		if err := os.Remove(target); err != nil && !os.IsNotExist(err) {
-			return nil, err
-		}
-
 		ref, err := deps.parseReference(img)
 		if err != nil {
 			return nil, fmt.Errorf("parse image reference %s: %w", img, err)
 		}
 		registry := ref.Context().RegistryStr()
 
-		imageObj, err := deps.fetchImage(
-			ref,
-			remote.WithAuthFromKeychain(auth.keychain()),
-			remote.WithContext(ctx),
-		)
-		if err != nil {
-			if auth.hasRegistry(registry) {
-				return nil, fmt.Errorf("pull image %s from registry %s with configured auth: %w", img, registry, err)
+		for _, fetchTarget := range fetchTargets {
+			rel := imageArchiveRel(dir, img, fetchTarget.raw)
+			target := filepath.Join(bundleRoot, filepath.FromSlash(rel))
+			if err := filemode.EnsureParentDir(target, filemode.PublishedArtifact); err != nil {
+				return nil, err
 			}
-			return nil, fmt.Errorf("pull image %s: %w", img, err)
-		}
+			if err := os.Remove(target); err != nil && !os.IsNotExist(err) {
+				return nil, err
+			}
 
-		if err := deps.writeArchive(target, ref, imageObj); err != nil {
-			return nil, fmt.Errorf("write image archive %s: %w", img, err)
-		}
-		if digest, digestErr := imageObj.Digest(); digestErr == nil {
-			sourceDigests[img] = digest.String()
-		}
+			imageObj, err := deps.fetchImage(
+				ref,
+				fetchTarget.platform,
+				remote.WithAuthFromKeychain(auth.keychain()),
+				remote.WithContext(ctx),
+			)
+			if err != nil {
+				if auth.hasRegistry(registry) {
+					return nil, fmt.Errorf("pull image %s%s from registry %s with configured auth: %w", img, imagePlatformErrorSuffix(fetchTarget.raw), registry, err)
+				}
+				return nil, fmt.Errorf("pull image %s%s: %w", img, imagePlatformErrorSuffix(fetchTarget.raw), err)
+			}
 
-		if info, err := os.Stat(target); err != nil {
-			return nil, err
-		} else if info.Size() == 0 {
-			return nil, fmt.Errorf("write image archive %s: empty archive", img)
-		}
+			if err := deps.writeArchive(target, ref, imageObj); err != nil {
+				return nil, fmt.Errorf("write image archive %s%s: %w", img, imagePlatformErrorSuffix(fetchTarget.raw), err)
+			}
+			if digest, digestErr := imageObj.Digest(); digestErr == nil {
+				sourceDigests[imageDigestKey(img, fetchTarget.raw)] = digest.String()
+			}
 
-		files = append(files, rel)
+			if info, err := os.Stat(target); err != nil {
+				return nil, err
+			} else if info.Size() == 0 {
+				return nil, fmt.Errorf("write image archive %s%s: empty archive", img, imagePlatformErrorSuffix(fetchTarget.raw))
+			}
+
+			files = append(files, rel)
+		}
 	}
-	if err := writeImageArtifactMeta(bundleRoot, dir, images, files, sourceDigests); err != nil {
+	if err := writeImageArtifactMeta(bundleRoot, dir, images, platformKeys, files, sourceDigests); err != nil {
 		return nil, err
 	}
 	return files, nil
+}
+
+type imageFetchTarget struct {
+	raw      string
+	platform *v1.Platform
+}
+
+func imageFetchTargets(platforms []imagePlatformSelection) []imageFetchTarget {
+	if len(platforms) == 0 {
+		return []imageFetchTarget{{}}
+	}
+	targets := make([]imageFetchTarget, 0, len(platforms))
+	for _, platform := range platforms {
+		p := platform.Platform
+		targets = append(targets, imageFetchTarget{raw: platform.Raw, platform: &p})
+	}
+	return targets
+}
+
+func imagePlatformErrorSuffix(platform string) string {
+	if strings.TrimSpace(platform) == "" {
+		return ""
+	}
+	return " for platform " + platform
+}
+
+func imageDigestKey(img, platform string) string {
+	if strings.TrimSpace(platform) == "" {
+		return img
+	}
+	return img + "@" + platform
+}
+
+func imageArchiveRel(dir, img, platform string) string {
+	name := sanitizeImageName(img)
+	if strings.TrimSpace(platform) != "" {
+		name += "_" + sanitizeImagePlatformName(platform)
+	}
+	return filepath.ToSlash(filepath.Join(dir, name+".tar"))
 }
 
 func imageMetaFileAbs(bundleRoot, dir string) string {
@@ -168,6 +230,7 @@ func parseImageArtifactMeta(raw []byte) (imageArtifactMeta, bool) {
 		return imageArtifactMeta{}, false
 	}
 	meta.Images = normalizeStrings(meta.Images)
+	meta.Platforms = normalizeStrings(meta.Platforms)
 	meta.Files = normalizeStrings(meta.Files)
 	meta.Checksums = normalizeChecksumMap(meta.Checksums)
 	meta.SourceDigests = normalizeChecksumMap(meta.SourceDigests)
@@ -189,13 +252,14 @@ func loadImageArtifactMeta(bundleRoot, dir string) (imageArtifactMeta, bool, err
 	return meta, true, nil
 }
 
-func writeImageArtifactMeta(bundleRoot, dir string, images, files []string, sourceDigests map[string]string) error {
+func writeImageArtifactMeta(bundleRoot, dir string, images, platforms, files []string, sourceDigests map[string]string) error {
 	checksums, err := computeArtifactChecksums(bundleRoot, files)
 	if err != nil {
 		return err
 	}
 	meta := imageArtifactMeta{
 		Images:        normalizeStrings(images),
+		Platforms:     normalizeStrings(platforms),
 		Files:         normalizeStrings(files),
 		Checksums:     checksums,
 		SourceDigests: normalizeChecksumMap(sourceDigests),
@@ -211,7 +275,7 @@ func writeImageArtifactMeta(bundleRoot, dir string, images, files []string, sour
 	return filemode.WriteArtifactFile(path, raw)
 }
 
-func tryReuseImageArtifact(bundleRoot, dir string, images []string, opts RunOptions) ([]string, bool, error) {
+func tryReuseImageArtifact(bundleRoot, dir string, images, platforms []string, opts RunOptions) ([]string, bool, error) {
 	if opts.ForceRedownload {
 		return nil, false, nil
 	}
@@ -223,6 +287,9 @@ func tryReuseImageArtifact(bundleRoot, dir string, images []string, opts RunOpti
 		return nil, false, nil
 	}
 	if !equalStrings(normalizeStrings(images), meta.Images) {
+		return nil, false, nil
+	}
+	if !equalStrings(normalizeStrings(platforms), meta.Platforms) {
 		return nil, false, nil
 	}
 	checksumsOK, err := verifyArtifactChecksums(bundleRoot, meta.Files, meta.Checksums)
@@ -303,6 +370,70 @@ func parseImageRegistryAuth(spec stepspec.DownloadImage) (imageRegistryAuthMap, 
 	return entries, nil
 }
 
+func parseImagePlatforms(raw []stepspec.ImagePlatform) ([]imagePlatformSelection, error) {
+	if len(raw) == 0 {
+		return nil, nil
+	}
+	platforms := make([]imagePlatformSelection, 0, len(raw))
+	seen := map[string]bool{}
+	duplicates := make([]string, 0)
+	for _, item := range raw {
+		platform, err := parseImagePlatform(string(item))
+		if err != nil {
+			return nil, err
+		}
+		if seen[platform.Raw] {
+			duplicates = append(duplicates, platform.Raw)
+			continue
+		}
+		seen[platform.Raw] = true
+		platforms = append(platforms, platform)
+	}
+	if len(duplicates) > 0 {
+		sort.Strings(duplicates)
+		return nil, fmt.Errorf("image platforms contains duplicate entries: %s", strings.Join(duplicates, ", "))
+	}
+	return platforms, nil
+}
+
+func parseImagePlatform(raw string) (imagePlatformSelection, error) {
+	trimmed := strings.ToLower(strings.TrimSpace(raw))
+	parts := strings.Split(trimmed, "/")
+	if len(parts) != 2 && len(parts) != 3 {
+		return imagePlatformSelection{}, fmt.Errorf("image platform %q must use os/arch or os/arch/variant", raw)
+	}
+	for i, part := range parts {
+		parts[i] = strings.TrimSpace(part)
+		if parts[i] == "" {
+			return imagePlatformSelection{}, fmt.Errorf("image platform %q must not contain empty components", raw)
+		}
+	}
+	platform := v1.Platform{OS: parts[0], Architecture: parts[1]}
+	if len(parts) == 3 {
+		platform.Variant = parts[2]
+	}
+	return imagePlatformSelection{Raw: imagePlatformKey(platform), Platform: platform}, nil
+}
+
+func imagePlatformKeys(platforms []imagePlatformSelection) []string {
+	if len(platforms) == 0 {
+		return nil
+	}
+	keys := make([]string, 0, len(platforms))
+	for _, platform := range platforms {
+		keys = append(keys, platform.Raw)
+	}
+	return keys
+}
+
+func imagePlatformKey(platform v1.Platform) string {
+	key := strings.ToLower(strings.TrimSpace(platform.OS)) + "/" + strings.ToLower(strings.TrimSpace(platform.Architecture))
+	if variant := strings.ToLower(strings.TrimSpace(platform.Variant)); variant != "" {
+		key += "/" + variant
+	}
+	return key
+}
+
 func sanitizeImageName(v string) string {
 	replacer := strings.NewReplacer(
 		"/", "_",
@@ -310,4 +441,8 @@ func sanitizeImageName(v string) string {
 		"@", "_",
 	)
 	return replacer.Replace(v)
+}
+
+func sanitizeImagePlatformName(v string) string {
+	return strings.NewReplacer("/", "_").Replace(strings.ToLower(strings.TrimSpace(v)))
 }

--- a/internal/prepare/download_images.go
+++ b/internal/prepare/download_images.go
@@ -397,17 +397,11 @@ func parseImagePlatforms(raw []stepspec.ImagePlatform) ([]imagePlatformSelection
 }
 
 func parseImagePlatform(raw string) (imagePlatformSelection, error) {
-	trimmed := strings.ToLower(strings.TrimSpace(raw))
-	parts := strings.Split(trimmed, "/")
-	if len(parts) != 2 && len(parts) != 3 {
-		return imagePlatformSelection{}, fmt.Errorf("image platform %q must use os/arch or os/arch/variant", raw)
+	normalized, err := stepspec.NormalizePlatform(raw)
+	if err != nil {
+		return imagePlatformSelection{}, err
 	}
-	for i, part := range parts {
-		parts[i] = strings.TrimSpace(part)
-		if parts[i] == "" {
-			return imagePlatformSelection{}, fmt.Errorf("image platform %q must not contain empty components", raw)
-		}
-	}
+	parts := strings.Split(normalized, "/")
 	platform := v1.Platform{OS: parts[0], Architecture: parts[1]}
 	if len(parts) == 3 {
 		platform.Variant = parts[2]

--- a/internal/prepare/download_images_test.go
+++ b/internal/prepare/download_images_test.go
@@ -1,12 +1,17 @@
 package prepare
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/google/go-containerregistry/pkg/name"
+	"github.com/google/go-containerregistry/pkg/v1"
+	"github.com/google/go-containerregistry/pkg/v1/empty"
+	"github.com/google/go-containerregistry/pkg/v1/remote"
+	"github.com/google/go-containerregistry/pkg/v1/tarball"
 
 	"github.com/Airgap-Castaways/deck/internal/stepspec"
 )
@@ -87,6 +92,62 @@ func TestImageAuthKeychainFallsBackWhenRegistryNotConfigured(t *testing.T) {
 	}
 	if config.Username == "robot" {
 		t.Fatalf("expected fallback auth, got explicit credentials: %+v", config)
+	}
+}
+
+func TestRunDownloadImageUsesExplicitPlatforms(t *testing.T) {
+	bundle := t.TempDir()
+	platforms := make([]string, 0)
+	imageOps := imageDownloadOps{
+		parseReference: func(v string) (name.Reference, error) {
+			return name.ParseReference(v, name.WeakValidation)
+		},
+		fetchImage: func(_ name.Reference, platform *v1.Platform, _ ...remote.Option) (v1.Image, error) {
+			if platform == nil {
+				platforms = append(platforms, "")
+			} else {
+				platforms = append(platforms, imagePlatformKey(*platform))
+			}
+			return empty.Image, nil
+		},
+		writeArchive: func(path string, _ name.Reference, _ v1.Image, _ ...tarball.WriteOption) error {
+			return os.WriteFile(path, []byte(filepath.Base(path)), 0o644)
+		},
+	}
+
+	files, err := runDownloadImage(context.Background(), nil, bundle, map[string]any{
+		"images":    []any{"registry.k8s.io/pause:3.9"},
+		"platforms": []any{"linux/amd64", "linux/arm64"},
+	}, RunOptions{imageDownloadOps: imageOps})
+	if err != nil {
+		t.Fatalf("runDownloadImage failed: %v", err)
+	}
+
+	wantFiles := []string{
+		"images/registry.k8s.io_pause_3.9_linux_amd64.tar",
+		"images/registry.k8s.io_pause_3.9_linux_arm64.tar",
+	}
+	if strings.Join(files, "\n") != strings.Join(wantFiles, "\n") {
+		t.Fatalf("unexpected files: got %#v want %#v", files, wantFiles)
+	}
+	if strings.Join(platforms, ",") != "linux/amd64,linux/arm64" {
+		t.Fatalf("unexpected platforms: %#v", platforms)
+	}
+	meta, ok, err := loadImageArtifactMeta(bundle, "images")
+	if err != nil || !ok {
+		t.Fatalf("load image meta: ok=%v err=%v", ok, err)
+	}
+	if strings.Join(meta.Platforms, ",") != "linux/amd64,linux/arm64" {
+		t.Fatalf("expected platforms in metadata, got %#v", meta.Platforms)
+	}
+}
+
+func TestParseImagePlatformsRejectsInvalidValues(t *testing.T) {
+	if _, err := parseImagePlatforms([]stepspec.ImagePlatform{"linux"}); err == nil || !strings.Contains(err.Error(), "os/arch") {
+		t.Fatalf("expected invalid platform error, got %v", err)
+	}
+	if _, err := parseImagePlatforms([]stepspec.ImagePlatform{"linux/amd64", "linux/amd64"}); err == nil || !strings.Contains(err.Error(), "duplicate") {
+		t.Fatalf("expected duplicate platform error, got %v", err)
 	}
 }
 

--- a/internal/prepare/download_packages.go
+++ b/internal/prepare/download_packages.go
@@ -304,32 +304,21 @@ func parseRPMModules(repo stepspec.DownloadPackageRepo) ([]rpmModuleSpec, error)
 }
 
 func parsePackagePlatform(raw stepspec.PackagePlatform) (string, error) {
-	platform := normalizePackagePlatformKey(string(raw))
-	if platform == "" {
+	if strings.TrimSpace(string(raw)) == "" {
 		return "", nil
 	}
-	parts := strings.Split(platform, "/")
-	if len(parts) != 2 && len(parts) != 3 {
-		return "", fmt.Errorf("package platform %q must use os/arch or os/arch/variant", string(raw))
-	}
-	for _, part := range parts {
-		if part == "" {
-			return "", fmt.Errorf("package platform %q must not contain empty components", string(raw))
-		}
-	}
-	return platform, nil
+	return stepspec.NormalizePlatform(string(raw))
 }
 
 func normalizePackagePlatformKey(raw string) string {
-	trimmed := strings.ToLower(strings.TrimSpace(raw))
-	if trimmed == "" {
+	if strings.TrimSpace(raw) == "" {
 		return ""
 	}
-	parts := strings.Split(trimmed, "/")
-	for i, part := range parts {
-		parts[i] = strings.TrimSpace(part)
+	platform, err := stepspec.NormalizePlatform(raw)
+	if err != nil {
+		return strings.ToLower(strings.TrimSpace(raw))
 	}
-	return strings.Join(parts, "/")
+	return platform
 }
 
 func buildRPMModuleEnableCommand(modules []rpmModuleSpec) (string, error) {

--- a/internal/prepare/download_packages.go
+++ b/internal/prepare/download_packages.go
@@ -19,6 +19,7 @@ import (
 
 type packageCacheMeta struct {
 	Packages  []string          `json:"packages"`
+	Platform  string            `json:"platform,omitempty"`
 	Files     []string          `json:"files"`
 	Checksums map[string]string `json:"checksums,omitempty"`
 }
@@ -48,6 +49,10 @@ func runDownloadPackage(ctx context.Context, runner CommandRunner, bundleRoot st
 	packages := decoded.Packages
 	if len(packages) == 0 {
 		return nil, fmt.Errorf("packages action download requires packages")
+	}
+	platform, err := parsePackagePlatform(decoded.Platform)
+	if err != nil {
+		return nil, err
 	}
 
 	if decoded.Backend.Mode == "container" && decoded.Backend.Image != "" {
@@ -79,32 +84,32 @@ func runDownloadPackage(ctx context.Context, runner CommandRunner, bundleRoot st
 				return nil, fmt.Errorf("packages action download repo.type must be deb-flat or rpm")
 			}
 
-			if files, reused, err := tryReusePackageArtifact(bundleRoot, repoRoot, packages, opts); err != nil {
+			if files, reused, err := tryReusePackageArtifact(bundleRoot, repoRoot, packages, platform, opts); err != nil {
 				return nil, err
 			} else if reused {
 				return files, nil
 			}
-			files, err := runContainerPackageRepoBuild(ctx, runner, bundleRoot, repoRoot, family, repoType, generate, pkgsDir, step, decoded, inputVars, packages, opts)
+			files, err := runContainerPackageRepoBuild(ctx, runner, bundleRoot, repoRoot, family, repoType, generate, pkgsDir, step, decoded, inputVars, packages, platform, opts)
 			if err != nil {
 				return nil, err
 			}
-			if err := writePackageArtifactMeta(bundleRoot, repoRoot, packages, files); err != nil {
+			if err := writePackageArtifactMeta(bundleRoot, repoRoot, packages, platform, files); err != nil {
 				return nil, err
 			}
 			return files, nil
 		}
 
-		if files, reused, err := tryReusePackageArtifact(bundleRoot, dir, packages, opts); err != nil {
+		if files, reused, err := tryReusePackageArtifact(bundleRoot, dir, packages, platform, opts); err != nil {
 			return nil, err
 		} else if reused {
 			return files, nil
 		}
 
-		files, err := runContainerDownloadPackageAll(ctx, runner, bundleRoot, dir, step, decoded, inputVars, packages, opts)
+		files, err := runContainerDownloadPackageAll(ctx, runner, bundleRoot, dir, step, decoded, inputVars, packages, platform, opts)
 		if err != nil {
 			return nil, err
 		}
-		if err := writePackageArtifactMeta(bundleRoot, dir, packages, files); err != nil {
+		if err := writePackageArtifactMeta(bundleRoot, dir, packages, platform, files); err != nil {
 			return nil, err
 		}
 		return files, nil
@@ -126,6 +131,7 @@ func runContainerPackageRepoBuild(
 	spec stepspec.DownloadPackage,
 	inputVars map[string]string,
 	packages []string,
+	platform string,
 	opts RunOptions,
 ) ([]string, error) {
 	runtimeSel, err := detectRuntime(runner, spec.Backend.Runtime)
@@ -145,10 +151,10 @@ func runContainerPackageRepoBuild(
 	if err != nil {
 		return nil, err
 	}
-	return runContainerDownloadPackageToCache(ctx, runner, runtimeSel, image, bundleRoot, repoRoot, step, inputVars, packages, cmdScript, opts)
+	return runContainerDownloadPackageToCache(ctx, runner, runtimeSel, image, platform, bundleRoot, repoRoot, step, inputVars, packages, cmdScript, opts)
 }
 
-func runContainerDownloadPackageAll(ctx context.Context, runner CommandRunner, bundleRoot, dir string, step config.Step, decoded stepspec.DownloadPackage, inputVars map[string]string, packages []string, opts RunOptions) ([]string, error) {
+func runContainerDownloadPackageAll(ctx context.Context, runner CommandRunner, bundleRoot, dir string, step config.Step, decoded stepspec.DownloadPackage, inputVars map[string]string, packages []string, platform string, opts RunOptions) ([]string, error) {
 	runtimeSel, err := detectRuntime(runner, decoded.Backend.Runtime)
 	if err != nil {
 		return nil, err
@@ -172,7 +178,7 @@ func runContainerDownloadPackageAll(ctx context.Context, runner CommandRunner, b
 	if err != nil {
 		return nil, err
 	}
-	return runContainerDownloadPackageToCache(ctx, runner, runtimeSel, image, bundleRoot, dir, step, inputVars, packages, cmdScript, opts)
+	return runContainerDownloadPackageToCache(ctx, runner, runtimeSel, image, platform, bundleRoot, dir, step, inputVars, packages, cmdScript, opts)
 }
 
 func buildDownloadPackageAllScript(family string, packages []string, modules []rpmModuleSpec) (string, error) {
@@ -297,6 +303,35 @@ func parseRPMModules(repo stepspec.DownloadPackageRepo) ([]rpmModuleSpec, error)
 	return modules, nil
 }
 
+func parsePackagePlatform(raw stepspec.PackagePlatform) (string, error) {
+	platform := normalizePackagePlatformKey(string(raw))
+	if platform == "" {
+		return "", nil
+	}
+	parts := strings.Split(platform, "/")
+	if len(parts) != 2 && len(parts) != 3 {
+		return "", fmt.Errorf("package platform %q must use os/arch or os/arch/variant", string(raw))
+	}
+	for _, part := range parts {
+		if part == "" {
+			return "", fmt.Errorf("package platform %q must not contain empty components", string(raw))
+		}
+	}
+	return platform, nil
+}
+
+func normalizePackagePlatformKey(raw string) string {
+	trimmed := strings.ToLower(strings.TrimSpace(raw))
+	if trimmed == "" {
+		return ""
+	}
+	parts := strings.Split(trimmed, "/")
+	for i, part := range parts {
+		parts[i] = strings.TrimSpace(part)
+	}
+	return strings.Join(parts, "/")
+}
+
 func buildRPMModuleEnableCommand(modules []rpmModuleSpec) (string, error) {
 	if len(modules) == 0 {
 		return "", nil
@@ -308,21 +343,21 @@ func buildRPMModuleEnableCommand(modules []rpmModuleSpec) (string, error) {
 	return "dnf -y module enable " + strings.Join(parts, " ") + " >/dev/null 2>&1", nil
 }
 
-func runContainerDownloadPackageToCache(ctx context.Context, runner CommandRunner, runtimeSel, image, bundleRoot, rootRel string, step config.Step, inputVars map[string]string, packages []string, script string, opts RunOptions) ([]string, error) {
+func runContainerDownloadPackageToCache(ctx context.Context, runner CommandRunner, runtimeSel, image, platform, bundleRoot, rootRel string, step config.Step, inputVars map[string]string, packages []string, script string, opts RunOptions) ([]string, error) {
 	cacheKey := computeStepCacheKey(step)
 	cachePath, err := exportedPackageCachePath(cacheKey, inputVars)
 	if err != nil {
 		return nil, err
 	}
-	if files, reused, err := tryReuseExportedPackageArtifact(bundleRoot, rootRel, cachePath, packages, opts); err != nil {
+	if files, reused, err := tryReuseExportedPackageArtifact(bundleRoot, rootRel, cachePath, packages, platform, opts); err != nil {
 		return nil, err
 	} else if reused {
-		if err := writePackageArtifactMeta(bundleRoot, rootRel, packages, files); err != nil {
+		if err := writePackageArtifactMeta(bundleRoot, rootRel, packages, platform, files); err != nil {
 			return nil, err
 		}
 		return files, nil
 	}
-	exported, err := runPackageContainerWithExport(ctx, runner, runtimeSel, image, script)
+	exported, err := runPackageContainerWithExport(ctx, runner, runtimeSel, image, platform, script)
 	if err != nil {
 		return nil, err
 	}
@@ -336,7 +371,7 @@ func runContainerDownloadPackageToCache(ctx context.Context, runner CommandRunne
 		_ = os.RemoveAll(cacheStage)
 		return nil, errcode.Newf(errCodePrepareArtifactEmpty, "no package artifacts generated in %s", rootRel)
 	}
-	meta := exportedPackageCacheMeta{RootRel: rootRel, Packages: packages, Files: relFiles}
+	meta := exportedPackageCacheMeta{RootRel: rootRel, Packages: packages, Platform: platform, Files: relFiles}
 	if err := saveExportedPackageCacheMeta(cacheStage, meta); err != nil {
 		_ = os.RemoveAll(cacheStage)
 		return nil, err
@@ -349,7 +384,7 @@ func runContainerDownloadPackageToCache(ctx context.Context, runner CommandRunne
 		return nil, err
 	}
 	files := packageFilesFromDirListing(rootRel, relFiles)
-	if err := writePackageArtifactMeta(bundleRoot, rootRel, packages, files); err != nil {
+	if err := writePackageArtifactMeta(bundleRoot, rootRel, packages, platform, files); err != nil {
 		return nil, err
 	}
 	return files, nil
@@ -409,7 +444,7 @@ func packageMetaFileAbs(bundleRoot, rootRel string) string {
 	return filepath.Join(bundleRoot, filepath.FromSlash(rootRel), packageCacheMetaFile)
 }
 
-func tryReusePackageArtifact(bundleRoot, rootRel string, packages []string, opts RunOptions) ([]string, bool, error) {
+func tryReusePackageArtifact(bundleRoot, rootRel string, packages []string, platform string, opts RunOptions) ([]string, bool, error) {
 	if opts.ForceRedownload {
 		return nil, false, nil
 	}
@@ -430,6 +465,9 @@ func tryReusePackageArtifact(bundleRoot, rootRel string, packages []string, opts
 	if !equalStrings(want, got) {
 		return nil, false, nil
 	}
+	if normalizePackagePlatformKey(meta.Platform) != normalizePackagePlatformKey(platform) {
+		return nil, false, nil
+	}
 	files := normalizeStrings(meta.Files)
 	if len(files) == 0 {
 		return nil, false, nil
@@ -447,13 +485,14 @@ func tryReusePackageArtifact(bundleRoot, rootRel string, packages []string, opts
 	return files, true, nil
 }
 
-func writePackageArtifactMeta(bundleRoot, rootRel string, packages, files []string) error {
+func writePackageArtifactMeta(bundleRoot, rootRel string, packages []string, platform string, files []string) error {
 	checksums, err := computeArtifactChecksums(bundleRoot, files)
 	if err != nil {
 		return err
 	}
 	meta := packageCacheMeta{
 		Packages:  normalizeStrings(packages),
+		Platform:  normalizePackagePlatformKey(platform),
 		Files:     normalizeStrings(files),
 		Checksums: checksums,
 	}

--- a/internal/prepare/package_artifact_cache.go
+++ b/internal/prepare/package_artifact_cache.go
@@ -26,6 +26,7 @@ var packageArtifactStageCounter uint64
 type exportedPackageCacheMeta struct {
 	RootRel   string            `json:"root_rel"`
 	Packages  []string          `json:"packages"`
+	Platform  string            `json:"platform,omitempty"`
 	Files     []string          `json:"files"`
 	Checksums map[string]string `json:"checksums,omitempty"`
 }
@@ -83,6 +84,7 @@ func loadExportedPackageCache(path string) (exportedPackageCacheMeta, bool, erro
 	}
 	meta.Files = normalizeStrings(meta.Files)
 	meta.Packages = normalizeStrings(meta.Packages)
+	meta.Platform = normalizePackagePlatformKey(meta.Platform)
 	meta.Checksums = normalizeChecksumMap(meta.Checksums)
 	return meta, true, nil
 }
@@ -90,6 +92,7 @@ func loadExportedPackageCache(path string) (exportedPackageCacheMeta, bool, erro
 func saveExportedPackageCacheMeta(path string, meta exportedPackageCacheMeta) error {
 	meta.Files = normalizeStrings(meta.Files)
 	meta.Packages = normalizeStrings(meta.Packages)
+	meta.Platform = normalizePackagePlatformKey(meta.Platform)
 	checksums, err := computeArtifactChecksums(exportedPackageCachePayloadPath(path), meta.Files)
 	if err != nil {
 		return err
@@ -114,7 +117,7 @@ func buildPublishedArtifactStage(path string) string {
 	return fmt.Sprintf("%s.stage-%d", path, atomic.AddUint64(&packageArtifactStageCounter, 1))
 }
 
-func tryReuseExportedPackageArtifact(bundleRoot, rootRel, cachePath string, packages []string, opts RunOptions) ([]string, bool, error) {
+func tryReuseExportedPackageArtifact(bundleRoot, rootRel, cachePath string, packages []string, platform string, opts RunOptions) ([]string, bool, error) {
 	if opts.ForceRedownload {
 		return nil, false, nil
 	}
@@ -129,6 +132,9 @@ func tryReuseExportedPackageArtifact(bundleRoot, rootRel, cachePath string, pack
 		return nil, false, nil
 	}
 	if !equalStrings(normalizeStrings(packages), meta.Packages) {
+		return nil, false, nil
+	}
+	if normalizePackagePlatformKey(meta.Platform) != normalizePackagePlatformKey(platform) {
 		return nil, false, nil
 	}
 	if len(meta.Files) == 0 {

--- a/internal/prepare/package_container_export.go
+++ b/internal/prepare/package_container_export.go
@@ -12,11 +12,15 @@ import (
 
 var packageContainerCounter uint64
 
-func runPackageContainerWithExport(ctx context.Context, runner CommandRunner, runtimeSel, image, script string) ([]byte, error) {
+func runPackageContainerWithExport(ctx context.Context, runner CommandRunner, runtimeSel, image, platform, script string) ([]byte, error) {
 	containerName := fmt.Sprintf("deck-prepare-%d", atomic.AddUint64(&packageContainerCounter, 1))
 	createStdout := &bytes.Buffer{}
 	createStderr := &bytes.Buffer{}
-	createArgs := []string{"create", "--name", containerName, image, "bash", "-lc", script}
+	createArgs := []string{"create"}
+	if strings.TrimSpace(platform) != "" {
+		createArgs = append(createArgs, "--platform", platform)
+	}
+	createArgs = append(createArgs, "--name", containerName, image, "bash", "-lc", script)
 	if err := runner.RunWithIO(ctx, createStdout, createStderr, runtimeSel, createArgs...); err != nil {
 		return nil, formatContainerCommandError("create package download container", err, createStderr.String())
 	}

--- a/internal/prepare/test_helpers_test.go
+++ b/internal/prepare/test_helpers_test.go
@@ -35,7 +35,7 @@ func stubDownloadImageOps() imageDownloadOps {
 		parseReference: func(v string) (name.Reference, error) {
 			return name.ParseReference(v, name.WeakValidation)
 		},
-		fetchImage: func(_ name.Reference, _ ...remote.Option) (v1.Image, error) {
+		fetchImage: func(_ name.Reference, _ *v1.Platform, _ ...remote.Option) (v1.Image, error) {
 			return empty.Image, nil
 		},
 		writeArchive: func(path string, _ name.Reference, _ v1.Image, _ ...tarball.WriteOption) error {
@@ -47,6 +47,7 @@ func stubDownloadImageOps() imageDownloadOps {
 type fakeRunner struct {
 	mu                sync.Mutex
 	containerPayloads map[string]map[string][]byte
+	createArgs        [][]string
 	failExport        bool
 }
 
@@ -181,6 +182,7 @@ func (f *fakeRunner) RunWithIO(_ context.Context, stdout io.Writer, _ io.Writer,
 	switch args[0] {
 	case "create":
 		f.mu.Lock()
+		f.createArgs = append(f.createArgs, append([]string(nil), args...))
 		containerID := fmt.Sprintf("container-%d", len(f.containerPayloads)+1)
 		f.containerPayloads[containerID] = fakePackageContainerPayload(args)
 		f.mu.Unlock()

--- a/internal/stepspec/image.go
+++ b/internal/stepspec/image.go
@@ -24,10 +24,13 @@ type ImageBackend struct {
 	Engine string `json:"engine"`
 }
 
+type ImagePlatform string
+
 // Download container images into prepared bundle storage.
 // @deck.when Use this during prepare to collect required images for offline use.
 // @deck.note Omit `outputDir` unless you need a dedicated image subdirectory; deck writes to `images/` by default.
 // @deck.note `spec.auth` is optional and only applies to `DownloadImage`.
+// @deck.note Use `spec.platforms` to pull target platforms explicitly instead of relying on the download engine default.
 // @deck.example
 // kind: DownloadImage
 // spec:
@@ -44,6 +47,9 @@ type DownloadImage struct {
 	// Fully qualified image references to download.
 	// @deck.example [registry.k8s.io/pause:3.9]
 	Images []string `json:"images"`
+	// Optional target platforms in os/arch or os/arch/variant form.
+	// @deck.example [linux/amd64,linux/arm64]
+	Platforms []ImagePlatform `json:"platforms"`
 	// Optional registry authentication entries used during download.
 	// @deck.example [{registry:registry.example.com,basic:{username:robot,password:${REGISTRY_PASSWORD}}}]
 	Auth []ImageAuth `json:"auth"`
@@ -73,6 +79,9 @@ type LoadImage struct {
 	// Image references to load from the prepared archives.
 	// @deck.example [registry.k8s.io/kube-apiserver:v1.30.1]
 	Images []string `json:"images"`
+	// Optional target platforms matching DownloadImage archive suffixes.
+	// @deck.example [linux/amd64]
+	Platforms []ImagePlatform `json:"platforms"`
 	// Directory containing prepared image archives.
 	// @deck.example images/control-plane
 	SourceDir string `json:"sourceDir"`

--- a/internal/stepspec/image_meta.go
+++ b/internal/stepspec/image_meta.go
@@ -22,6 +22,7 @@ var _ = stepmeta.MustRegister[DownloadImage](stepmeta.Definition{
 	Notes: []string{
 		"`outputDir` must stay under the prepared `images/` root.",
 		"Omit `outputDir` unless you need a dedicated image subdirectory under `images/`.",
+		"Use `spec.platforms` to pull target platforms explicitly; platform-specific archives include the platform in the filename.",
 		"`spec.auth` is optional and only applies to `DownloadImage`.",
 	},
 	Ask: stepmeta.AskMetadata{
@@ -41,7 +42,7 @@ var _ = stepmeta.MustRegister[DownloadImage](stepmeta.Definition{
 			},
 		}},
 		MatchSignals:             []string{"air-gapped", "image", "images", "registry", "mirror", "offline", "prepare"},
-		KeyFields:                []string{"spec.images", "spec.auth", "spec.backend", "spec.outputDir"},
+		KeyFields:                []string{"spec.images", "spec.platforms", "spec.auth", "spec.backend", "spec.outputDir"},
 		ValidationHints:          []stepmeta.ValidationHint{{ErrorContains: "spec.backend.engine must be one of", Fix: "Keep spec.backend.engine as the literal value `go-containerregistry`; do not replace it with a vars template."}, {ErrorContains: "is not supported for role prepare", Fix: "For prepare-time image collection, use DownloadImage instead of Command so the step matches the prepare role."}},
 		ConstrainedLiteralFields: []stepmeta.ConstrainedLiteralField{{Path: "spec.backend.engine", AllowedValues: []string{"go-containerregistry"}, Guidance: "Keep spec.backend.engine as a literal enum, not a vars template."}},
 	},
@@ -59,6 +60,10 @@ var _ = stepmeta.MustRegister[LoadImage](stepmeta.Definition{
 	Roles:       []string{"apply"},
 	SchemaFile:  "image.load.schema.json",
 	SchemaPatch: stepmeta.PatchImageLoadToolSchema,
+	Notes: []string{
+		"`command` may include `{archive}` placeholders that deck substitutes per image archive.",
+		"When `spec.platforms` is set, deck loads archives with matching platform suffixes produced by `DownloadImage`.",
+	},
 	Ask: stepmeta.AskMetadata{
 		Capabilities:  []string{"image-staging", "apply-artifact-consumer", "kubeadm-bootstrap"},
 		ContractHints: stepmeta.ContractHints{ConsumesArtifacts: []string{"image"}},
@@ -76,7 +81,7 @@ var _ = stepmeta.MustRegister[LoadImage](stepmeta.Definition{
 			},
 		}},
 		MatchSignals:             []string{"air-gapped", "image", "images", "archive", "containerd", "docker", "offline"},
-		KeyFields:                []string{"spec.images", "spec.sourceDir", "spec.runtime", "spec.command"},
+		KeyFields:                []string{"spec.images", "spec.platforms", "spec.sourceDir", "spec.runtime", "spec.command"},
 		ConstrainedLiteralFields: []stepmeta.ConstrainedLiteralField{{Path: "spec.runtime", AllowedValues: []string{"auto", "ctr", "docker", "podman"}, Guidance: "Keep spec.runtime as a literal enum, not a vars template."}},
 	},
 })

--- a/internal/stepspec/platform.go
+++ b/internal/stepspec/platform.go
@@ -1,0 +1,21 @@
+package stepspec
+
+import (
+	"fmt"
+	"strings"
+)
+
+func NormalizePlatform(raw string) (string, error) {
+	trimmed := strings.ToLower(strings.TrimSpace(raw))
+	parts := strings.Split(trimmed, "/")
+	if len(parts) != 2 && len(parts) != 3 {
+		return "", fmt.Errorf("platform %q must use os/arch or os/arch/variant", raw)
+	}
+	for i, part := range parts {
+		parts[i] = strings.TrimSpace(part)
+		if parts[i] == "" {
+			return "", fmt.Errorf("platform %q must not contain empty components", raw)
+		}
+	}
+	return strings.Join(parts, "/"), nil
+}

--- a/internal/stepspec/system_package.go
+++ b/internal/stepspec/system_package.go
@@ -388,6 +388,8 @@ type DownloadPackageBackend struct {
 	Image string `json:"image"`
 }
 
+type PackagePlatform string
+
 // Download packages into prepared bundle storage.
 // @deck.when Use this during prepare to collect package-manager content for offline installation.
 // @deck.note Omit `outputDir` unless you need a custom package location.
@@ -413,6 +415,9 @@ type DownloadPackage struct {
 	// Package names to download.
 	// @deck.example [kubelet,kubeadm,kubectl]
 	Packages []string `json:"packages"`
+	// Target container platform for package resolution in os/arch or os/arch/variant form.
+	// @deck.example linux/amd64
+	Platform PackagePlatform `json:"platform"`
 	// Target distribution hint used to select resolver behavior.
 	// @deck.example {family:rhel,release:rocky9}
 	Distro DownloadPackageDistro `json:"distro"`

--- a/schemas/tools/image.download.schema.json
+++ b/schemas/tools/image.download.schema.json
@@ -116,6 +116,16 @@
           ],
           "minLength": 1,
           "type": "string"
+        },
+        "platforms": {
+          "description": "Optional target platforms in os/arch or os/arch/variant form.",
+          "examples": [
+            "[linux/amd64,linux/arm64]"
+          ],
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
         }
       },
       "required": [

--- a/schemas/tools/image.load.schema.json
+++ b/schemas/tools/image.load.schema.json
@@ -62,6 +62,16 @@
           "minItems": 1,
           "type": "array"
         },
+        "platforms": {
+          "description": "Optional target platforms matching DownloadImage archive suffixes.",
+          "examples": [
+            "[linux/amd64]"
+          ],
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
         "runtime": {
           "description": "Runtime loader to use for imports.",
           "enum": [

--- a/schemas/tools/package.download.schema.json
+++ b/schemas/tools/package.download.schema.json
@@ -129,6 +129,13 @@
           "minItems": 1,
           "type": "array"
         },
+        "platform": {
+          "description": "Target container platform for package resolution in os/arch or os/arch/variant form.",
+          "examples": [
+            "linux/amd64"
+          ],
+          "type": "string"
+        },
         "repo": {
           "additionalProperties": false,
           "description": "Repository settings applied before download.",


### PR DESCRIPTION
## Summary
- Add explicit `DownloadImage.spec.platforms` and matching `LoadImage.spec.platforms` archive suffix handling.
- Add `DownloadPackage.spec.platform` and pass it to Docker/Podman resolver containers.
- Include selected platforms in image/package cache metadata to avoid stale artifact reuse.

## Verification
- `make test`
- `make lint`
- `make verify-generated`
- `make build`
- `./bin/deck lint --file docs/guides/examples/offline-k8s-control-plane.yaml`
- `./bin/deck lint --file docs/guides/examples/offline-k8s-worker.yaml`
- `./bin/deck lint --root test`

Closes #190