### PR TITLE
Exercise platform selection in workflow fixtures

### DIFF
--- a/.github/workflows/ci-reusable.yml
+++ b/.github/workflows/ci-reusable.yml
@@ -66,6 +66,7 @@ jobs:
       - name: Run test set
         run: |
           make test
+          ./bin/deck lint --root test
           ./bin/deck lint --file docs/guides/examples/vagrant-smoke-install.yaml
           ./bin/deck lint --file test/workflows/scenarios/control-plane-bootstrap.yaml
           ./bin/deck lint --file test/workflows/scenarios/worker-join.yaml

--- a/docs/guides/examples/offline-pull-control-plane.yaml
+++ b/docs/guides/examples/offline-pull-control-plane.yaml
@@ -4,6 +4,7 @@ vars:
   release: ubuntu2204
   registryHost: 192.168.56.1:5000
   kubernetesVersion: v1.30.1
+  imagePlatforms: [linux/amd64]
 phases:
   - name: install
     steps:
@@ -108,6 +109,7 @@ phases:
         kind: LoadImage
         spec:
           sourceDir: images/control-plane
+          platforms: "{{ .vars.imagePlatforms }}"
           images:
             - registry.k8s.io/kube-apiserver:{{ .vars.kubernetesVersion }}
             - registry.k8s.io/kube-controller-manager:{{ .vars.kubernetesVersion }}

--- a/test/workflows/components/prepare/images.yaml
+++ b/test/workflows/components/prepare/images.yaml
@@ -3,10 +3,12 @@ steps:
     kind: DownloadImage
     spec:
       images: "{{ .vars.controlPlaneImages }}"
+      platforms: "{{ .vars.imagePlatforms }}"
       outputDir: images/control-plane
   - id: download-upgrade-control-plane-images
     kind: DownloadImage
     when: vars.upgradeKubernetesVersion != ""
     spec:
       images: "{{ .vars.upgradeControlPlaneImages }}"
+      platforms: "{{ .vars.imagePlatforms }}"
       outputDir: images/control-plane

--- a/test/workflows/components/prepare/packages.yaml
+++ b/test/workflows/components/prepare/packages.yaml
@@ -4,6 +4,7 @@ steps:
     parallelGroup: distro-package-downloads
     spec:
       packages: "{{ .vars.runtimeDepPackages.debian }}"
+      platform: "{{ .vars.packagePlatform }}"
       distro:
         family: debian
         release: ubuntu2204
@@ -20,6 +21,7 @@ steps:
     parallelGroup: distro-package-downloads
     spec:
       packages: "{{ .vars.runtimeDepPackages.debian }}"
+      platform: "{{ .vars.packagePlatform }}"
       distro:
         family: debian
         release: ubuntu2404
@@ -36,6 +38,7 @@ steps:
     parallelGroup: distro-package-downloads
     spec:
       packages: "{{ .vars.runtimeDepPackages.rhel }}"
+      platform: "{{ .vars.packagePlatform }}"
       distro:
         family: rhel
         release: rocky9

--- a/test/workflows/vars.yaml
+++ b/test/workflows/vars.yaml
@@ -5,6 +5,9 @@ all:
   upgradeEtcdImage: registry.k8s.io/etcd:3.5.15-0
   upgradeCoreDNSImage: registry.k8s.io/coredns/coredns:v1.11.1
   arch: amd64
+  packagePlatform: linux/amd64
+  imagePlatforms:
+    - linux/amd64
   backendRuntime: auto
   serverURL: 192.168.57.10:18080
   registryHost: 192.168.57.10:18080


### PR DESCRIPTION
## Summary
- Add explicit package and image platform vars to the test workflow fixtures.
- Wire `DownloadPackage.spec.platform` and `DownloadImage.spec.platforms` through prepare components.
- Add workspace-level test workflow linting to reusable CI and show `LoadImage.spec.platforms` in the pull-control-plane example.

## Verification
- `make test`
- `make lint`
- `make build`
- `./bin/deck lint --root test`
- `./bin/deck lint --file docs/guides/examples/offline-pull-control-plane.yaml`