### PR TITLE
Hide image aliases from server browse

### DIFF
--- a/internal/server/http_browse.go
+++ b/internal/server/http_browse.go
@@ -243,7 +243,7 @@ func (h *serverHandler) renderImageBrowse(rel string) (string, error) {
 		items = append([]browseEntry{{Name: "..", Href: "/", Kind: "dir"}}, items...)
 		return renderBrowsePage("/browse/images/", items)
 	}
-	if repoExists(canonicalRegistryEntries(entries), rel) {
+	if repoExists(entries, rel, true) {
 		repo := rel
 		tags := map[string]bool{}
 		for _, entry := range entries {
@@ -258,7 +258,7 @@ func (h *serverHandler) renderImageBrowse(rel string) (string, error) {
 		sort.Slice(items[1:], func(i, j int) bool { return items[1+i].Name < items[1+j].Name })
 		return renderBrowsePage("/browse/images/"+repo+"/", items)
 	}
-	repo, tag := splitRepoTag(canonicalRegistryEntries(entries), rel)
+	repo, tag := splitRepoTag(entries, rel, true)
 	if repo == "" || tag == "" {
 		items := []browseEntry{{Name: "..", Href: "/browse/images/", Kind: "dir"}}
 		return renderBrowsePage("/browse/images/"+rel+"/", items)
@@ -291,21 +291,11 @@ func (h *serverHandler) renderImageBrowse(rel string) (string, error) {
 	return renderBrowsePage("/browse/images/"+repo+"/"+tag+"/", items)
 }
 
-func canonicalRegistryEntries(entries []registryCatalogEntry) []registryCatalogEntry {
-	out := make([]registryCatalogEntry, 0, len(entries))
-	for _, entry := range entries {
-		if entry.isCanonical() {
-			out = append(out, entry)
-		}
-	}
-	return out
-}
-
 func registryAliasesForResolved(entries []registryCatalogEntry, resolved *registryResolvedImage) []string {
 	if resolved == nil {
 		return nil
 	}
-	aliases := make([]string, 0)
+	var aliases []string
 	seen := map[string]bool{}
 	for _, entry := range entries {
 		if entry.isCanonical() || entry.canonicalRepo != resolved.repo || entry.tag != resolved.tag || entry.tarPath != resolved.tarPath {
@@ -321,8 +311,11 @@ func registryAliasesForResolved(entries []registryCatalogEntry, resolved *regist
 	return aliases
 }
 
-func repoExists(entries []registryCatalogEntry, repo string) bool {
+func repoExists(entries []registryCatalogEntry, repo string, canonicalOnly bool) bool {
 	for _, entry := range entries {
+		if canonicalOnly && !entry.isCanonical() {
+			continue
+		}
 		if entry.repo == repo {
 			return true
 		}
@@ -330,10 +323,13 @@ func repoExists(entries []registryCatalogEntry, repo string) bool {
 	return false
 }
 
-func splitRepoTag(entries []registryCatalogEntry, rel string) (string, string) {
+func splitRepoTag(entries []registryCatalogEntry, rel string, canonicalOnly bool) (string, string) {
 	bestRepo := ""
 	bestTag := ""
 	for _, entry := range entries {
+		if canonicalOnly && !entry.isCanonical() {
+			continue
+		}
 		prefix := entry.repo + "/"
 		if !strings.HasPrefix(rel, prefix) {
 			continue

--- a/internal/server/http_browse.go
+++ b/internal/server/http_browse.go
@@ -230,6 +230,9 @@ func (h *serverHandler) renderImageBrowse(rel string) (string, error) {
 	if rel == "" {
 		repos := map[string]bool{}
 		for _, entry := range entries {
+			if !entry.isCanonical() {
+				continue
+			}
 			repos[entry.repo] = true
 		}
 		items := make([]browseEntry, 0, len(repos))
@@ -240,11 +243,11 @@ func (h *serverHandler) renderImageBrowse(rel string) (string, error) {
 		items = append([]browseEntry{{Name: "..", Href: "/", Kind: "dir"}}, items...)
 		return renderBrowsePage("/browse/images/", items)
 	}
-	if repoExists(entries, rel) {
+	if repoExists(canonicalRegistryEntries(entries), rel) {
 		repo := rel
 		tags := map[string]bool{}
 		for _, entry := range entries {
-			if entry.repo == repo {
+			if entry.repo == repo && entry.isCanonical() {
 				tags[entry.tag] = true
 			}
 		}
@@ -255,7 +258,7 @@ func (h *serverHandler) renderImageBrowse(rel string) (string, error) {
 		sort.Slice(items[1:], func(i, j int) bool { return items[1+i].Name < items[1+j].Name })
 		return renderBrowsePage("/browse/images/"+repo+"/", items)
 	}
-	repo, tag := splitRepoTag(entries, rel)
+	repo, tag := splitRepoTag(canonicalRegistryEntries(entries), rel)
 	if repo == "" || tag == "" {
 		items := []browseEntry{{Name: "..", Href: "/browse/images/", Kind: "dir"}}
 		return renderBrowsePage("/browse/images/"+rel+"/", items)
@@ -276,6 +279,9 @@ func (h *serverHandler) renderImageBrowse(rel string) (string, error) {
 		browseEntry{Name: "archive", Kind: "meta", Meta: resolved.tarPath, Size: archiveSize},
 		browseEntry{Name: "registry manifest", Href: "/v2/" + repo + "/manifests/" + tag, Kind: "link", Meta: "open raw manifest", Size: int64(len(resolved.rawManifest))},
 	)
+	if aliases := registryAliasesForResolved(entries, resolved); len(aliases) > 0 {
+		items = append(items, browseEntry{Name: "aliases", Kind: "meta", Meta: strings.Join(aliases, ", ")})
+	}
 	if resolved.manifest != nil {
 		items = append(items, browseEntry{Name: "config", Kind: "meta", Meta: resolved.manifest.Config.Digest.String(), Size: resolved.manifest.Config.Size})
 		for _, layer := range resolved.manifest.Layers {
@@ -283,6 +289,36 @@ func (h *serverHandler) renderImageBrowse(rel string) (string, error) {
 		}
 	}
 	return renderBrowsePage("/browse/images/"+repo+"/"+tag+"/", items)
+}
+
+func canonicalRegistryEntries(entries []registryCatalogEntry) []registryCatalogEntry {
+	out := make([]registryCatalogEntry, 0, len(entries))
+	for _, entry := range entries {
+		if entry.isCanonical() {
+			out = append(out, entry)
+		}
+	}
+	return out
+}
+
+func registryAliasesForResolved(entries []registryCatalogEntry, resolved *registryResolvedImage) []string {
+	if resolved == nil {
+		return nil
+	}
+	aliases := make([]string, 0)
+	seen := map[string]bool{}
+	for _, entry := range entries {
+		if entry.isCanonical() || entry.canonicalRepo != resolved.repo || entry.tag != resolved.tag || entry.tarPath != resolved.tarPath {
+			continue
+		}
+		if seen[entry.repo] {
+			continue
+		}
+		seen[entry.repo] = true
+		aliases = append(aliases, entry.repo)
+	}
+	sort.Strings(aliases)
+	return aliases
 }
 
 func repoExists(entries []registryCatalogEntry, repo string) bool {

--- a/internal/server/http_registry.go
+++ b/internal/server/http_registry.go
@@ -30,7 +30,7 @@ type registryCatalogEntry struct {
 }
 
 func (e registryCatalogEntry) isCanonical() bool {
-	return strings.TrimSpace(e.canonicalRepo) == "" || e.repo == e.canonicalRepo
+	return e.canonicalRepo == "" || e.repo == e.canonicalRepo
 }
 
 type registryResolvedImage struct {

--- a/internal/server/http_registry.go
+++ b/internal/server/http_registry.go
@@ -22,10 +22,15 @@ import (
 )
 
 type registryCatalogEntry struct {
-	repoTag string
-	repo    string
-	tag     string
-	tarPath string
+	repoTag       string
+	repo          string
+	canonicalRepo string
+	tag           string
+	tarPath       string
+}
+
+func (e registryCatalogEntry) isCanonical() bool {
+	return strings.TrimSpace(e.canonicalRepo) == "" || e.repo == e.canonicalRepo
 }
 
 type registryResolvedImage struct {
@@ -322,13 +327,15 @@ func (h *serverHandler) scanRegistryCatalog() ([]registryCatalogEntry, error) {
 					if err != nil {
 						continue
 					}
-					aliases := registryRepositoryAliases(tag.Repository.Name())
+					canonicalRepo := tag.Repository.Name()
+					aliases := registryRepositoryAliases(canonicalRepo)
 					for _, alias := range aliases {
 						entries = append(entries, registryCatalogEntry{
-							repoTag: repoTag,
-							repo:    alias,
-							tag:     tag.TagStr(),
-							tarPath: path,
+							repoTag:       repoTag,
+							repo:          alias,
+							canonicalRepo: canonicalRepo,
+							tag:           tag.TagStr(),
+							tarPath:       path,
 						})
 					}
 				}

--- a/internal/server/http_test.go
+++ b/internal/server/http_test.go
@@ -115,6 +115,18 @@ func TestServe_StaticReadOnly(t *testing.T) {
 	if err := tarball.WriteToFile(nestedTarPath, nestedTag, nestedImage); err != nil {
 		t.Fatalf("tarball.WriteToFile nested: %v", err)
 	}
+	quayTag, err := name.NewTag("quay.io/calico/node-driver-registrar:v3.28.0", name.WeakValidation)
+	if err != nil {
+		t.Fatalf("name.NewTag quay: %v", err)
+	}
+	quayImage, err := random.Image(256, 1)
+	if err != nil {
+		t.Fatalf("random.Image quay: %v", err)
+	}
+	quayTarPath := filepath.Join(root, "outputs", "images", "quay.io_calico_node-driver-registrar_v3.28.0.tar")
+	if err := tarball.WriteToFile(quayTarPath, quayTag, quayImage); err != nil {
+		t.Fatalf("tarball.WriteToFile quay: %v", err)
+	}
 
 	h, err := NewHandler(root, HandlerOptions{})
 	if err != nil {
@@ -150,11 +162,12 @@ func TestServe_StaticReadOnly(t *testing.T) {
 			{path: "/browse/bin/", want: "linux"},
 			{path: "/browse/workflows/", want: "scenarios"},
 			{path: "/browse/images/", want: "kube-apiserver"},
-			{path: "/browse/images/coredns/coredns/", want: "v1.11.1"},
-			{path: "/browse/images/kube-apiserver/v1.30.1/", want: fmt.Sprintf("%d bytes", registryTarInfo.Size())},
-			{path: "/browse/images/kube-apiserver/v1.30.1/", want: fmt.Sprintf("%d bytes", len(rawManifest))},
-			{path: "/browse/images/kube-apiserver/v1.30.1/", want: fmt.Sprintf("%d bytes", manifest.Config.Size)},
-			{path: "/browse/images/kube-apiserver/v1.30.1/", want: fmt.Sprintf("%d bytes", manifest.Layers[0].Size)},
+			{path: "/browse/images/registry.k8s.io/coredns/coredns/", want: "v1.11.1"},
+			{path: "/browse/images/registry.k8s.io/kube-apiserver/v1.30.1/", want: fmt.Sprintf("%d bytes", registryTarInfo.Size())},
+			{path: "/browse/images/registry.k8s.io/kube-apiserver/v1.30.1/", want: fmt.Sprintf("%d bytes", len(rawManifest))},
+			{path: "/browse/images/registry.k8s.io/kube-apiserver/v1.30.1/", want: fmt.Sprintf("%d bytes", manifest.Config.Size)},
+			{path: "/browse/images/registry.k8s.io/kube-apiserver/v1.30.1/", want: fmt.Sprintf("%d bytes", manifest.Layers[0].Size)},
+			{path: "/browse/images/quay.io/calico/node-driver-registrar/v3.28.0/", want: "calico/node-driver-registrar"},
 		} {
 			req := httptest.NewRequest(http.MethodGet, tc.path, nil)
 			rr := httptest.NewRecorder()
@@ -165,6 +178,20 @@ func TestServe_StaticReadOnly(t *testing.T) {
 			if !strings.Contains(rr.Body.String(), tc.want) {
 				t.Fatalf("expected %s body to contain %q, got %q", tc.path, tc.want, rr.Body.String())
 			}
+		}
+
+		rootReq := httptest.NewRequest(http.MethodGet, "/browse/images/", nil)
+		rootRR := httptest.NewRecorder()
+		h.ServeHTTP(rootRR, rootReq)
+		if rootRR.Code != http.StatusOK {
+			t.Fatalf("expected /browse/images/ 200, got %d", rootRR.Code)
+		}
+		rootBody := rootRR.Body.String()
+		if !strings.Contains(rootBody, `href="/browse/images/quay.io/calico/node-driver-registrar/"`) {
+			t.Fatalf("expected canonical quay repo link, got %q", rootBody)
+		}
+		if strings.Contains(rootBody, `href="/browse/images/calico/node-driver-registrar/"`) {
+			t.Fatalf("expected alias repo to be hidden from browse root, got %q", rootBody)
 		}
 	})
 
@@ -257,6 +284,13 @@ func TestServe_StaticReadOnly(t *testing.T) {
 		}
 		if !strings.Contains(nestedTagsRR.Body.String(), `"name":"coredns/coredns"`) || !strings.Contains(nestedTagsRR.Body.String(), `"v1.11.1"`) {
 			t.Fatalf("expected nested tags list body, got %q", nestedTagsRR.Body.String())
+		}
+
+		quayAliasReq := httptest.NewRequest(http.MethodGet, "/v2/calico/node-driver-registrar/manifests/v3.28.0", nil)
+		quayAliasRR := httptest.NewRecorder()
+		h.ServeHTTP(quayAliasRR, quayAliasReq)
+		if quayAliasRR.Code != http.StatusOK {
+			t.Fatalf("expected alias manifest GET 200, got %d", quayAliasRR.Code)
 		}
 	})
 


### PR DESCRIPTION
## Summary
- Keep registry alias resolution available for `/v2/...` pull compatibility.
- Hide stripped alias repositories from the server image browse root and canonical repo navigation.
- Show aliases only on the canonical image detail page metadata.

## Verification
- `go test ./internal/server`
- `make test`
- `make lint`

Related: #193