### PR TITLE
Expose workflow execution context

### DIFF
--- a/cmd/deck/apply_cli_test.go
+++ b/cmd/deck/apply_cli_test.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -14,7 +13,6 @@ import (
 
 	"github.com/Airgap-Castaways/deck/internal/applycli"
 	"github.com/Airgap-Castaways/deck/internal/config"
-	"github.com/Airgap-Castaways/deck/internal/install"
 )
 
 func TestResolveInstallStatePathUsesHomeAndStateKey(t *testing.T) {
@@ -34,6 +32,21 @@ func TestResolveInstallStatePathUsesHomeAndStateKey(t *testing.T) {
 	if statePath != expected {
 		t.Fatalf("state path mismatch: got %q want %q", statePath, expected)
 	}
+}
+
+func statePathFromVerboseApply(t *testing.T, args []string) string {
+	t.Helper()
+	res := execute(append(args, "--v=1"))
+	if res.err != nil {
+		t.Fatalf("apply for state path: %v", res.err)
+	}
+	for _, field := range strings.Fields(res.stderr) {
+		if strings.HasPrefix(field, "state=") {
+			return strings.TrimPrefix(field, "state=")
+		}
+	}
+	t.Fatalf("expected state in stderr, got %q", res.stderr)
+	return ""
 }
 
 func TestApplyWritesRunRecordUnderXDGStateHome(t *testing.T) {
@@ -169,6 +182,41 @@ phases:
 	}
 	if !strings.Contains(applyOut, "host-match Command PLAN") || !strings.Contains(applyOut, "host-miss Command SKIP") {
 		t.Fatalf("expected apply dry-run to select hostname-scoped vars, got %q", applyOut)
+	}
+}
+
+func TestApplyContextFieldsFromInferredBundleRoot(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	root := t.TempDir()
+	createValidBundleManifest(t, root)
+	workflowDir := filepath.Join(root, "workflows", "scenarios")
+	if err := os.MkdirAll(workflowDir, 0o755); err != nil {
+		t.Fatalf("mkdir workflow dir: %v", err)
+	}
+	outPath := filepath.Join(t.TempDir(), "context.txt")
+	wfPath := filepath.Join(workflowDir, "apply.yaml")
+	writeWorkflowYAML(t, wfPath, fmt.Sprintf(`version: v1alpha1
+phases:
+  - name: install
+    steps:
+      - id: context-write
+        kind: Command
+        when: context.command == "apply" && context.workflow.source == "filesystem" && context.workflow.isServer == false && context.paths.bundleRoot == %q
+        spec:
+          command: ["sh", "-c", "printf 'source={{ .context.workflow.source }} server={{ .context.workflow.isServer }} bundle={{ .context.paths.bundleRoot }} legacy={{ .context.bundleRoot }}' > %s"]
+`, root, outPath))
+
+	if _, err := runWithCapturedStdout([]string{"apply", "--workflow", wfPath}); err != nil {
+		t.Fatalf("apply failed: %v", err)
+	}
+	raw, err := os.ReadFile(outPath)
+	if err != nil {
+		t.Fatalf("read context output: %v", err)
+	}
+	for _, want := range []string{"source=filesystem", "server=false", "bundle=" + root, "legacy=" + root} {
+		if !strings.Contains(string(raw), want) {
+			t.Fatalf("expected %q in context output, got %q", want, string(raw))
+		}
 	}
 }
 
@@ -326,18 +374,7 @@ phases:
 		defer ts.Close()
 
 		workflowURL := ts.URL + "/workflows/scenarios/apply.yaml"
-		if _, err := runWithCapturedStdout([]string{"apply", "--workflow", workflowURL}); err != nil {
-			t.Fatalf("remote apply(1) failed: %v", err)
-		}
-
-		wf1, err := config.Load(context.Background(), workflowURL)
-		if err != nil {
-			t.Fatalf("load remote workflow(1): %v", err)
-		}
-		statePath1, err := applycli.ResolveInstallStatePath(wf1)
-		if err != nil {
-			t.Fatalf("resolve state path(1): %v", err)
-		}
+		statePath1 := statePathFromVerboseApply(t, []string{"apply", "--workflow", workflowURL})
 		if _, err := os.Stat(statePath1); err != nil {
 			t.Fatalf("expected first state file: %v", err)
 		}
@@ -346,18 +383,7 @@ phases:
 		varsBody = "mode: beta\n"
 		mu.Unlock()
 
-		if _, err := runWithCapturedStdout([]string{"apply", "--workflow", workflowURL}); err != nil {
-			t.Fatalf("remote apply(2) failed: %v", err)
-		}
-
-		wf2, err := config.Load(context.Background(), workflowURL)
-		if err != nil {
-			t.Fatalf("load remote workflow(2): %v", err)
-		}
-		statePath2, err := applycli.ResolveInstallStatePath(wf2)
-		if err != nil {
-			t.Fatalf("resolve state path(2): %v", err)
-		}
+		statePath2 := statePathFromVerboseApply(t, []string{"apply", "--workflow", workflowURL})
 		if statePath1 == statePath2 {
 			t.Fatalf("expected state path to change when vars.yaml changes")
 		}
@@ -456,16 +482,8 @@ func TestPlan(t *testing.T) {
 		t.Fatalf("expected RUN in plan output, got %q", before)
 	}
 
-	wf, err := config.Load(context.Background(), wfPath)
-	if err != nil {
-		t.Fatalf("load workflow: %v", err)
-	}
-	execWf, err := applycli.BuildExecutionWorkflow(wf, "install")
-	if err != nil {
-		t.Fatalf("build execution workflow: %v", err)
-	}
-	if err := install.Run(context.Background(), execWf, install.RunOptions{BundleRoot: ""}); err != nil {
-		t.Fatalf("install run: %v", err)
+	if _, err := runWithCapturedStdout([]string{"apply", "--workflow", wfPath, "--phase", "install"}); err != nil {
+		t.Fatalf("apply run: %v", err)
 	}
 
 	after, err := runWithCapturedStdout([]string{"plan", "--workflow", wfPath})
@@ -719,18 +737,15 @@ func TestResolveApplyBundleRootPrecedence(t *testing.T) {
 		t.Fatalf("expected positional bundle, got %s", resolved)
 	}
 
-	resolved, err = applycli.ResolveBundleRoot("")
+	resolved, err = applycli.ResolveBundleRoot(archivePath)
 	if err != nil {
-		t.Fatalf("resolve default bundle candidate: %v", err)
+		t.Fatalf("resolve explicit bundle archive: %v", err)
 	}
 	resolvedSlash := filepath.ToSlash(resolved)
 	if !strings.Contains(resolvedSlash, "/.cache/deck/extract/") || !strings.HasSuffix(resolvedSlash, "/bundle") {
 		t.Fatalf("expected extracted bundle root, got %s", resolved)
 	}
 
-	if err := os.Remove(archivePath); err != nil {
-		t.Fatalf("remove bundle.tar: %v", err)
-	}
 	resolved, err = applycli.ResolveBundleRoot("")
 	if err != nil {
 		t.Fatalf("resolve cwd candidate: %v", err)

--- a/cmd/deck/cmd_apply.go
+++ b/cmd/deck/cmd_apply.go
@@ -82,12 +82,13 @@ func runDiffWithOptions(env *cliEnv, ctx context.Context, opts diffOptions) erro
 		return err
 	}
 	selectedPhase := strings.TrimSpace(opts.selectedPhase)
-	return executeDiff(env, ctx, workflowPath, selectedPhase, opts.output, opts.fresh, varsAsAnyMap(opts.varOverrides))
+	return executeDiff(env, ctx, workflowPath, strings.TrimSpace(opts.scenario), selectedPhase, opts.output, opts.fresh, varsAsAnyMap(opts.varOverrides))
 }
 
-func executeDiff(env *cliEnv, ctx context.Context, workflowPath, selectedPhase, output string, fresh bool, varOverrides map[string]any) error {
+func executeDiff(env *cliEnv, ctx context.Context, workflowPath, scenario, selectedPhase, output string, fresh bool, varOverrides map[string]any) error {
 	return applycli.RunPlanCommand(ctx, applycli.PlanCommandOptions{
 		WorkflowPath:    workflowPath,
+		Scenario:        scenario,
 		SelectedPhase:   selectedPhase,
 		Output:          output,
 		Fresh:           fresh,

--- a/cmd/schema-gen/doc_blocks.go
+++ b/cmd/schema-gen/doc_blocks.go
@@ -9,6 +9,8 @@ import (
 const (
 	workflowSchemaBlockBegin    = "<!-- BEGIN GENERATED:WORKFLOW_SCHEMA_CONTRACT -->"
 	workflowSchemaBlockEnd      = "<!-- END GENERATED:WORKFLOW_SCHEMA_CONTRACT -->"
+	systemVariablesBlockBegin   = "<!-- BEGIN GENERATED:SYSTEM_VARIABLES -->"
+	systemVariablesBlockEnd     = "<!-- END GENERATED:SYSTEM_VARIABLES -->"
 	componentFragmentBlockBegin = "<!-- BEGIN GENERATED:COMPONENT_FRAGMENT_CONTRACT -->"
 	componentFragmentBlockEnd   = "<!-- END GENERATED:COMPONENT_FRAGMENT_CONTRACT -->"
 	toolDefinitionBlockBegin    = "<!-- BEGIN GENERATED:TOOL_DEFINITION_SCHEMA -->"

--- a/cmd/schema-gen/main.go
+++ b/cmd/schema-gen/main.go
@@ -117,6 +117,9 @@ func writeGeneratedSchemaDocs(root string, workflowSchema, componentFragmentSche
 	if err := syncGeneratedBlock(filepath.Join(root, "docs", "reference", "workflow-model.md"), workflowSchemaBlockBegin, workflowSchemaBlockEnd, schemadoc.RenderWorkflowSchemaPartial("../../schemas/deck-workflow.schema.json", workflowSchema, schemadoc.WorkflowMeta())); err != nil {
 		return err
 	}
+	if err := syncGeneratedBlock(filepath.Join(root, "docs", "reference", "workflow-model.md"), systemVariablesBlockBegin, systemVariablesBlockEnd, schemadoc.RenderSystemVariablesPartial()); err != nil {
+		return err
+	}
 	if err := syncGeneratedBlock(filepath.Join(root, "docs", "reference", "workspace-layout.md"), componentFragmentBlockBegin, componentFragmentBlockEnd, schemadoc.RenderComponentFragmentSchemaPartial("../../schemas/deck-component-fragment.schema.json", componentFragmentSchema, schemadoc.ComponentFragmentMeta())); err != nil {
 		return err
 	}

--- a/docs/guides/offline-kubernetes.md
+++ b/docs/guides/offline-kubernetes.md
@@ -61,14 +61,16 @@ The bundle includes the canonical workspace inputs: `outputs/packages/`, `output
 
 ## 5. Move the bundle into the offline site
 
-Transfer `bundle.tar` through the approved path for your environment - removable media, controlled gateway, or another site-approved handoff. `deck` does not require a remote control service for this step.
+Transfer `bundle.tar` through the approved path for your environment - removable media, controlled gateway, or another site-approved handoff. Unpack it on the target side before running apply. `deck` does not require a remote control service for this step.
 
 ## 6. Run workflows locally on the target nodes
 
 At the offline site, execute on the target machine itself:
 
 ```bash
-deck apply
+tar -xf bundle.tar
+cd bundle
+./deck apply
 ```
 
 Use the control-plane and worker workflows in your workspace as starting points for kubeadm-based bootstrap and follow-on maintenance.

--- a/docs/guides/quick-start.md
+++ b/docs/guides/quick-start.md
@@ -73,7 +73,7 @@ deck bundle build --out ./bundle.tar
 deck apply
 ```
 
-`apply` executes the workflow locally on the machine that needs the change. No SSH, no controller, no external reach-back required.
+`apply` executes the workflow locally on the machine that needs the change. Run it from a workspace or unpacked bundle root that contains `workflows/`. No SSH, no controller, no external reach-back required.
 
 ## 6. Optional: add site assistance
 

--- a/docs/reference/workflow-model.md
+++ b/docs/reference/workflow-model.md
@@ -65,7 +65,7 @@ steps:
 
 ## Variables
 
-Variables and runtime values come from distinct sources:
+Variables, runtime values, and execution context come from distinct sources:
 
 Static `vars` flow from three sources, in order of precedence:
 
@@ -102,7 +102,7 @@ For `deck lint`, `deck prepare`, `deck plan`, and `deck apply`, the effective va
 
 Hostname matching tries the detected hostname first, then the short hostname before the first `.`. Missing host entries are not fatal. Workflows that branch on host-specific fields should provide safe defaults in `all:`, such as `role: ""`, then use conditions such as `vars.role == "control-plane"`.
 
-Runtime values flow separately through `register` outputs and built-in runtime facts such as `runtime.host`.
+Runtime values flow separately through `register` outputs and built-in runtime facts such as `runtime.host`. Execution context values under `context.*` are deck-supplied metadata resolved at command runtime, such as the command name, workflow source, workflow path, bundle root, output root, and state file.
 
 **`workflows/vars.yaml`** — define shared defaults once:
 
@@ -128,7 +128,7 @@ vars:
     content: "{{ .vars.clusterName }}\n"
 ```
 
-**CEL expressions** — use `vars.NAME` and `runtime.NAME` (no braces) in `when:` conditions:
+**CEL expressions** — use `vars.NAME`, `runtime.NAME`, and `context.NAME` (no braces) in `when:` conditions:
 
 ```yaml
 - id: install-rhel-packages
@@ -140,7 +140,42 @@ vars:
 
 Node-scoped vars are static inputs selected before planning and state hashing; `runtime.host` remains the runtime fact namespace for detected OS, architecture, and kernel data.
 
+<!-- BEGIN GENERATED:SYSTEM_VARIABLES -->
+### Built-In Runtime Fields
+
 `runtime.host` is a built-in reserved runtime namespace in both prepare and apply. Use it for detected host facts such as OS family, distro ID, version, architecture, and kernel release. Do not model detected local host facts as static `vars` values.
+
+| Field | Type | Description |
+|---|---|---|
+| `runtime.host.os.name` | `string` | Operating system name reported by the Go runtime. |
+| `runtime.host.os.id` | `string` | Distribution ID from `/etc/os-release` `ID`, lowercased. |
+| `runtime.host.os.family` | `string` | Inferred distribution family such as `debian` or `rhel`, or empty when unknown. |
+| `runtime.host.os.version` | `string` | Distribution version from `/etc/os-release` `VERSION`. |
+| `runtime.host.os.versionId` | `string` | Distribution version ID from `/etc/os-release` `VERSION_ID`. |
+| `runtime.host.os.release` | `string` | Alias of `runtime.host.os.versionId` retained for existing workflows. |
+| `runtime.host.os.idLike` | `string` | Distribution compatibility IDs from `/etc/os-release` `ID_LIKE`, lowercased. |
+| `runtime.host.arch` | `string` | Normalized host architecture such as `amd64` or `arm64`. |
+| `runtime.host.kernel.release` | `string` | Kernel release from `/proc/sys/kernel/osrelease`. |
+
+### Execution Context Fields
+
+`context` is available in both `when` expressions and templates. Canonical fields are:
+
+| Field | Type | Prepare | Apply | Description |
+|---|---|---:|---:|---|
+| `context.command` | `string` | yes | yes | Current command, `prepare` or `apply`. |
+| `context.workflow.source` | `string` | yes | yes | Workflow source, `filesystem` or `server`. |
+| `context.workflow.isServer` | `boolean` | yes | yes | Boolean convenience value derived from `context.workflow.source == "server"`. |
+| `context.workflow.path` | `string` | yes | yes | Resolved workflow file path or URL. |
+| `context.workflow.scenario` | `string` | no | yes | Scenario name when apply resolved a scenario. |
+| `context.paths.bundleRoot` | `string` | yes | yes | Prepared output root during prepare; selected bundle root during apply. |
+| `context.paths.outputRoot` | `string` | yes | no | Prepared output root. |
+| `context.paths.stateFile` | `string` | no | yes | Apply state file path. |
+
+Legacy aliases remain available for existing templates: `context.bundleRoot` maps to `context.paths.bundleRoot`, and `context.stateFile` maps to `context.paths.stateFile`.
+
+When apply state keys are computed, deck includes a fingerprint of the execution context except fields derived from other context values, such as `context.workflow.isServer`, and `context.paths.stateFile`, which is derived from the state key itself.
+<!-- END GENERATED:SYSTEM_VARIABLES -->
 
 ## Minimal workflow
 
@@ -201,7 +236,7 @@ Shared envelope rules:
 
 ### `when` — conditional execution
 
-`when` takes a CEL expression. Use `vars.` to reference input variables defined in `vars:` or `vars.yaml`, and `runtime.` to reference step outputs registered earlier in the run plus built-in host facts under `runtime.host`.
+`when` takes a CEL expression. Use `vars.` to reference input variables defined in `vars:` or `vars.yaml`, `runtime.` to reference step outputs registered earlier in the run plus built-in host facts under `runtime.host`, and `context.` to reference deck-supplied execution metadata.
 
 ```yaml
 steps:

--- a/internal/applycli/command.go
+++ b/internal/applycli/command.go
@@ -4,13 +4,18 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"path/filepath"
 	"strings"
 
+	"github.com/Airgap-Castaways/deck/internal/config"
 	"github.com/Airgap-Castaways/deck/internal/install"
+	"github.com/Airgap-Castaways/deck/internal/workflowcontext"
+	"github.com/Airgap-Castaways/deck/internal/workspacepaths"
 )
 
 type PlanCommandOptions struct {
 	WorkflowPath    string
+	Scenario        string
 	SelectedPhase   string
 	Output          string
 	Fresh           bool
@@ -69,8 +74,17 @@ func RunPlanCommand(ctx context.Context, opts PlanCommandOptions) error {
 	if err != nil {
 		return err
 	}
+	execContext, err := buildPlanExecutionContext(&resolvedRequest, strings.TrimSpace(opts.Scenario))
+	if err != nil {
+		return err
+	}
+	if err := applyContextStateKey(&resolvedRequest, execContext); err != nil {
+		return err
+	}
+	execContext.Paths.StateFile = resolvedRequest.StatePath
 	return ExecutePlan(ctx, PlanOptions{
 		Request:         resolvedRequest,
+		Context:         execContext.RenderMap(),
 		Output:          resolvedOutput,
 		Verbosef:        opts.Verbosef,
 		StdoutPrintf:    opts.StdoutPrintf,
@@ -100,9 +114,18 @@ func RunApplyCommand(ctx context.Context, opts ApplyCommandOptions) error {
 	if err != nil {
 		return err
 	}
+	execContext, bundleRoot, err := buildApplyExecutionContext(resolvedRequest, opts)
+	if err != nil {
+		return err
+	}
+	if err := applyContextStateKey(&resolvedRequest, execContext); err != nil {
+		return err
+	}
+	execContext.Paths.StateFile = resolvedRequest.StatePath
 	return Execute(ctx, ExecuteOptions{
 		Request:        resolvedRequest,
-		BundleRoot:     opts.BundleRoot,
+		BundleRoot:     bundleRoot,
+		Context:        execContext,
 		WorkflowSource: strings.TrimSpace(opts.WorkflowSource),
 		Scenario:       strings.TrimSpace(opts.Scenario),
 		DryRun:         opts.DryRun,
@@ -112,4 +135,88 @@ func RunApplyCommand(ctx context.Context, opts ApplyCommandOptions) error {
 		AdditionalSink: opts.AdditionalSink,
 		NewRunLogger:   opts.NewRunLogger,
 	})
+}
+
+func buildPlanExecutionContext(request *ExecutionRequest, scenario string) (workflowcontext.Context, error) {
+	if request == nil {
+		return workflowcontext.Context{}, fmt.Errorf("execution request is nil")
+	}
+	bundleRoot := ""
+	if !IsHTTPWorkflowPath(request.WorkflowPath) {
+		inferred, err := inferBundleRootFromWorkflowPath(request.WorkflowPath)
+		if err != nil {
+			return workflowcontext.Context{}, err
+		}
+		bundleRoot = inferred
+	}
+	return workflowcontext.Context{
+		Command: workflowcontext.CommandApply,
+		Workflow: workflowcontext.Workflow{
+			Source:   workflowcontext.SourceForWorkflowPath(request.WorkflowPath),
+			Path:     request.WorkflowPath,
+			Scenario: strings.TrimSpace(scenario),
+		},
+		Paths: workflowcontext.Paths{BundleRoot: bundleRoot},
+	}, nil
+}
+
+func buildApplyExecutionContext(request ExecutionRequest, opts ApplyCommandOptions) (workflowcontext.Context, string, error) {
+	bundleRoot := strings.TrimSpace(opts.BundleRoot)
+	if bundleRoot == "" && !IsHTTPWorkflowPath(request.WorkflowPath) {
+		inferred, err := inferBundleRootFromWorkflowPath(request.WorkflowPath)
+		if err != nil {
+			return workflowcontext.Context{}, "", err
+		}
+		bundleRoot = inferred
+	}
+	workflowSource := workflowcontext.SourceForWorkflowPath(request.WorkflowPath)
+	if strings.TrimSpace(opts.WorkflowSource) == "server" {
+		workflowSource = workflowcontext.SourceServer
+	}
+	return workflowcontext.Context{
+		Command: workflowcontext.CommandApply,
+		Workflow: workflowcontext.Workflow{
+			Source:   workflowSource,
+			Path:     request.WorkflowPath,
+			Scenario: strings.TrimSpace(opts.Scenario),
+		},
+		Paths: workflowcontext.Paths{BundleRoot: bundleRoot},
+	}, bundleRoot, nil
+}
+
+func applyContextStateKey(request *ExecutionRequest, execContext workflowcontext.Context) error {
+	if request == nil || request.Workflow == nil {
+		return fmt.Errorf("workflow is nil")
+	}
+	stateKey := config.StateKeyWithContext(request.Workflow.StateKey, execContext.StateFingerprint())
+	if stateKey == "" {
+		return fmt.Errorf("workflow state key is empty")
+	}
+	request.Workflow.StateKey = stateKey
+	if request.ExecutionWorkflow != nil {
+		request.ExecutionWorkflow.StateKey = stateKey
+	}
+	statePath, err := ResolveInstallStatePath(request.Workflow)
+	if err != nil {
+		return err
+	}
+	request.StatePath = statePath
+	return nil
+}
+
+func inferBundleRootFromWorkflowPath(workflowPath string) (string, error) {
+	trimmed := strings.TrimSpace(workflowPath)
+	if trimmed == "" || IsHTTPWorkflowPath(trimmed) {
+		return "", nil
+	}
+	abs, err := filepath.Abs(trimmed)
+	if err != nil {
+		return "", fmt.Errorf("resolve workflow path: %w", err)
+	}
+	workflowDir := string(filepath.Separator) + workspacepaths.WorkflowRootDir + string(filepath.Separator)
+	idx := strings.LastIndex(abs, workflowDir)
+	if idx < 0 {
+		return "", nil
+	}
+	return abs[:idx], nil
 }

--- a/internal/applycli/plan.go
+++ b/internal/applycli/plan.go
@@ -13,6 +13,7 @@ import (
 
 type PlanOptions struct {
 	Request         ExecutionRequest
+	Context         map[string]any
 	Output          string
 	Verbosef        func(level int, format string, args ...any) error
 	StdoutPrintf    func(format string, args ...any) error
@@ -44,12 +45,13 @@ type PlanSummary struct {
 }
 
 type PlanReport struct {
-	WorkflowPath   string      `json:"workflowPath"`
-	SelectedPhase  string      `json:"selectedPhase,omitempty"`
-	StatePath      string      `json:"statePath"`
-	RuntimeVarKeys []string    `json:"runtimeVarKeys,omitempty"`
-	Summary        PlanSummary `json:"summary"`
-	Steps          []PlanStep  `json:"steps"`
+	WorkflowPath   string         `json:"workflowPath"`
+	SelectedPhase  string         `json:"selectedPhase,omitempty"`
+	StatePath      string         `json:"statePath"`
+	RuntimeVarKeys []string       `json:"runtimeVarKeys,omitempty"`
+	Context        map[string]any `json:"context,omitempty"`
+	Summary        PlanSummary    `json:"summary"`
+	Steps          []PlanStep     `json:"steps"`
 }
 
 func ExecutePlan(ctx context.Context, opts PlanOptions) error {
@@ -59,7 +61,7 @@ func ExecutePlan(ctx context.Context, opts PlanOptions) error {
 	if opts.StdoutPrintf == nil {
 		return fmt.Errorf("stdout printf is nil")
 	}
-	report, err := BuildPlanReport(opts.Request)
+	report, err := BuildPlanReportWithContext(opts.Request, opts.Context)
 	if err != nil {
 		return err
 	}
@@ -89,6 +91,10 @@ func ExecutePlan(ctx context.Context, opts PlanOptions) error {
 }
 
 func BuildPlanReport(request ExecutionRequest) (PlanReport, error) {
+	return BuildPlanReportWithContext(request, nil)
+}
+
+func BuildPlanReportWithContext(request ExecutionRequest, context map[string]any) (PlanReport, error) {
 	if request.ExecutionWorkflow == nil {
 		return PlanReport{}, fmt.Errorf("execution workflow is nil")
 	}
@@ -126,7 +132,7 @@ func BuildPlanReport(request ExecutionRequest) (PlanReport, error) {
 				steps = append(steps, entry)
 				continue
 			}
-			ok, evalErr := install.EvaluateWhen(step.When, request.ExecutionWorkflow.Vars, runtimeVars)
+			ok, evalErr := install.EvaluateWhenWithContext(step.When, request.ExecutionWorkflow.Vars, runtimeVars, context)
 			if evalErr != nil {
 				return PlanReport{}, fmt.Errorf("WHEN_EVAL_ERROR: step %s (%s): %w", step.ID, step.Kind, evalErr)
 			}
@@ -149,7 +155,7 @@ func BuildPlanReport(request ExecutionRequest) (PlanReport, error) {
 		runtimeVarKeys = append(runtimeVarKeys, key)
 	}
 	slices.Sort(runtimeVarKeys)
-	return PlanReport{WorkflowPath: request.WorkflowPath, SelectedPhase: request.SelectedPhase, StatePath: request.StatePath, RuntimeVarKeys: runtimeVarKeys, Summary: summary, Steps: steps}, nil
+	return PlanReport{WorkflowPath: request.WorkflowPath, SelectedPhase: request.SelectedPhase, StatePath: request.StatePath, RuntimeVarKeys: runtimeVarKeys, Context: context, Summary: summary, Steps: steps}, nil
 }
 
 func writePlanText(stdoutPrintf func(format string, args ...any) error, report PlanReport) error {

--- a/internal/applycli/request.go
+++ b/internal/applycli/request.go
@@ -182,7 +182,7 @@ func ResolveBundleRoot(positionalBundle string) (string, error) {
 	if strings.TrimSpace(positionalBundle) != "" {
 		return resolveBundleCandidate(positionalBundle, true)
 	}
-	for _, candidate := range []string{"./bundle.tar", "."} {
+	for _, candidate := range []string{"."} {
 		resolved, err := resolveBundleCandidate(candidate, false)
 		if err != nil {
 			return "", err
@@ -191,7 +191,7 @@ func ResolveBundleRoot(positionalBundle string) (string, error) {
 			return resolved, nil
 		}
 	}
-	return "", fmt.Errorf("bundle not found: expected positional bundle path, ./bundle.tar, ./bundle, or current directory with workflows/")
+	return "", fmt.Errorf("bundle not found: expected positional bundle path or current directory with workflows/")
 }
 
 func BundleSHA256Hex(path string) (string, error) {

--- a/internal/applycli/service.go
+++ b/internal/applycli/service.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/Airgap-Castaways/deck/internal/install"
 	"github.com/Airgap-Castaways/deck/internal/logs"
+	"github.com/Airgap-Castaways/deck/internal/workflowcontext"
 )
 
 type RunLogger interface {
@@ -19,6 +20,7 @@ type RunLogger interface {
 type ExecuteOptions struct {
 	Request        ExecutionRequest
 	BundleRoot     string
+	Context        workflowcontext.Context
 	WorkflowSource string
 	Scenario       string
 	DryRun         bool
@@ -44,7 +46,7 @@ func Execute(ctx context.Context, opts ExecuteOptions) (err error) {
 		return err
 	}
 	if opts.DryRun {
-		return writeApplyDryRun(opts.StdoutPrintf, request)
+		return writeApplyDryRun(opts.StdoutPrintf, request, opts.Context.RenderMap())
 	}
 	if opts.NewRunLogger == nil {
 		return fmt.Errorf("run logger factory is nil")
@@ -68,7 +70,7 @@ func Execute(ctx context.Context, opts ExecuteOptions) (err error) {
 		}
 	}()
 
-	if err := install.Run(ctx, request.ExecutionWorkflow, install.RunOptions{BundleRoot: opts.BundleRoot, StatePath: request.StatePath, EventSink: eventSink, Fresh: request.Fresh}); err != nil {
+	if err := install.Run(ctx, request.ExecutionWorkflow, install.RunOptions{BundleRoot: opts.BundleRoot, StatePath: request.StatePath, Context: opts.Context, EventSink: eventSink, Fresh: request.Fresh}); err != nil {
 		return err
 	}
 	if opts.StdoutPrintln == nil {
@@ -77,7 +79,7 @@ func Execute(ctx context.Context, opts ExecuteOptions) (err error) {
 	return opts.StdoutPrintln("apply: ok")
 }
 
-func writeApplyDryRun(stdoutPrintf func(format string, args ...any) error, request ExecutionRequest) error {
+func writeApplyDryRun(stdoutPrintf func(format string, args ...any) error, request ExecutionRequest, context map[string]any) error {
 	if stdoutPrintf == nil {
 		return fmt.Errorf("stdout printf is nil")
 	}
@@ -117,7 +119,7 @@ func writeApplyDryRun(stdoutPrintf func(format string, args ...any) error, reque
 			continue
 		}
 		for _, step := range phase.Steps {
-			ok, evalErr := install.EvaluateWhen(step.When, wf.Vars, runtimeVars)
+			ok, evalErr := install.EvaluateWhenWithContext(step.When, wf.Vars, runtimeVars, context)
 			if evalErr != nil {
 				return fmt.Errorf("WHEN_EVAL_ERROR: step %s (%s): %w", step.ID, step.Kind, evalErr)
 			}

--- a/internal/config/hash.go
+++ b/internal/config/hash.go
@@ -20,6 +20,19 @@ func computeStateKey(workflowBytes []byte, effectiveVars map[string]any) string 
 	return hex.EncodeToString(h.Sum(nil))
 }
 
+func StateKeyWithContext(baseStateKey string, contextFingerprint string) string {
+	base := strings.TrimSpace(baseStateKey)
+	fingerprint := strings.TrimSpace(contextFingerprint)
+	if base == "" || fingerprint == "" {
+		return base
+	}
+	h := sha256.New()
+	_, _ = h.Write([]byte(base))
+	_, _ = h.Write([]byte("\n--context--\n"))
+	_, _ = h.Write([]byte(fingerprint))
+	return hex.EncodeToString(h.Sum(nil))
+}
+
 func normalizeWorkflowBytes(workflowBytes []byte) []byte {
 	if len(workflowBytes) == 0 {
 		return nil

--- a/internal/install/conditions.go
+++ b/internal/install/conditions.go
@@ -3,9 +3,17 @@ package install
 import "github.com/Airgap-Castaways/deck/internal/workflowexec"
 
 func evaluateWhen(expr string, vars map[string]any, runtime map[string]any) (bool, error) {
-	return workflowexec.EvaluateWhen(expr, vars, runtime, errCodeConditionEval)
+	return evaluateWhenWithContext(expr, vars, runtime, nil)
+}
+
+func evaluateWhenWithContext(expr string, vars map[string]any, runtime map[string]any, context map[string]any) (bool, error) {
+	return workflowexec.EvaluateWhenWithContext(expr, vars, runtime, context, errCodeConditionEval)
 }
 
 func EvaluateWhen(expr string, vars map[string]any, runtime map[string]any) (bool, error) {
 	return evaluateWhen(expr, vars, runtime)
+}
+
+func EvaluateWhenWithContext(expr string, vars map[string]any, runtime map[string]any, context map[string]any) (bool, error) {
+	return evaluateWhenWithContext(expr, vars, runtime, context)
 }

--- a/internal/install/execution_context.go
+++ b/internal/install/execution_context.go
@@ -1,14 +1,22 @@
 package install
 
-import "strings"
+import (
+	"strings"
+
+	"github.com/Airgap-Castaways/deck/internal/workflowcontext"
+)
 
 type ExecutionContext struct {
 	BundleRoot string
 	StatePath  string
+	Context    workflowcontext.Context
 	kubeadm    kubeadmExecutor
 }
 
 func (c ExecutionContext) RenderContext() map[string]any {
+	if strings.TrimSpace(c.Context.Command) != "" {
+		return c.Context.RenderMap()
+	}
 	return map[string]any{
 		"bundleRoot": strings.TrimSpace(c.BundleRoot),
 		"stateFile":  strings.TrimSpace(c.StatePath),

--- a/internal/install/execution_runtime_test.go
+++ b/internal/install/execution_runtime_test.go
@@ -295,19 +295,19 @@ func TestWhen_NamespaceEnforced(t *testing.T) {
 		t.Fatalf("expected bare identifier guidance, got %v", err)
 	}
 
-	_, err = EvaluateWhen("context.nodeRole == \"worker\"", vars, runtimeVars)
-	if err == nil {
-		t.Fatalf("expected context namespace to fail")
+	ok, err = EvaluateWhenWithContext("context.nodeRole == \"worker\"", vars, runtimeVars, map[string]any{"nodeRole": "worker"})
+	if err != nil {
+		t.Fatalf("expected context namespace expression to pass, got %v", err)
 	}
-	if !strings.Contains(err.Error(), "unknown identifier \"context.nodeRole\"; supported prefixes are vars. and runtime") {
-		t.Fatalf("expected namespace restriction message, got %v", err)
+	if !ok {
+		t.Fatalf("expected context namespace expression to be true")
 	}
 
 	_, err = EvaluateWhen("other.nodeRole == \"worker\"", vars, runtimeVars)
 	if err == nil {
 		t.Fatalf("expected unknown dotted namespace to fail")
 	}
-	if !strings.Contains(err.Error(), "unknown identifier \"other.nodeRole\"; supported prefixes are vars. and runtime") {
+	if !strings.Contains(err.Error(), "unknown identifier \"other.nodeRole\"; supported prefixes are context., vars., and runtime") {
 		t.Fatalf("expected namespace restriction message, got %v", err)
 	}
 }

--- a/internal/install/runner.go
+++ b/internal/install/runner.go
@@ -10,12 +10,14 @@ import (
 	"github.com/Airgap-Castaways/deck/internal/batchrun"
 	"github.com/Airgap-Castaways/deck/internal/bundle"
 	"github.com/Airgap-Castaways/deck/internal/config"
+	"github.com/Airgap-Castaways/deck/internal/workflowcontext"
 	"github.com/Airgap-Castaways/deck/internal/workflowexec"
 )
 
 type RunOptions struct {
 	BundleRoot string
 	StatePath  string
+	Context    workflowcontext.Context
 	EventSink  StepEventSink
 	Fresh      bool
 	kubeadm    kubeadmExecutor
@@ -135,7 +137,7 @@ func Run(ctx context.Context, wf *config.Workflow, opts RunOptions) error {
 		runtimeVars[k] = v
 	}
 	runtimeVars["host"] = detectHostFacts()
-	execCtx := ExecutionContext{BundleRoot: bundleRoot, StatePath: statePath, kubeadm: withKubeadmExecutor(opts.kubeadm)}
+	execCtx := ExecutionContext{BundleRoot: bundleRoot, StatePath: statePath, Context: opts.Context, kubeadm: withKubeadmExecutor(opts.kubeadm)}
 	ctxData := execCtx.RenderContext()
 	for _, phase := range phases {
 		st.Phase = phase.Name
@@ -214,7 +216,7 @@ func executeInstallBatch(ctx context.Context, wf *config.Workflow, runtimeVars m
 }
 
 func executeInstallStep(ctx context.Context, wf *config.Workflow, runtimeSnapshot map[string]any, ctxData map[string]any, execCtx ExecutionContext, phaseName string, batchCtx batchEventContext, step config.Step, sink StepEventSink) (installBatchResult, error) {
-	ok, err := evaluateWhen(step.When, wf.Vars, runtimeSnapshot)
+	ok, err := evaluateWhenWithContext(step.When, wf.Vars, runtimeSnapshot, ctxData)
 	if err != nil {
 		return installBatchResult{}, fmt.Errorf("step %s (%s): %w", step.ID, step.Kind, err)
 	}

--- a/internal/maputil/dotted.go
+++ b/internal/maputil/dotted.go
@@ -1,0 +1,25 @@
+package maputil
+
+import "strings"
+
+func SetDottedPath(root map[string]any, path string, value any) {
+	parts := strings.Split(strings.TrimSpace(path), ".")
+	if len(parts) == 0 {
+		return
+	}
+	current := root
+	for _, part := range parts[:len(parts)-1] {
+		if part == "" {
+			return
+		}
+		next, _ := current[part].(map[string]any)
+		if next == nil {
+			next = map[string]any{}
+			current[part] = next
+		}
+		current = next
+	}
+	if last := parts[len(parts)-1]; last != "" {
+		current[last] = value
+	}
+}

--- a/internal/prepare/execution_runtime_test.go
+++ b/internal/prepare/execution_runtime_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/Airgap-Castaways/deck/internal/config"
+	"github.com/Airgap-Castaways/deck/internal/workflowcontext"
 )
 
 func TestRun_WhenAndRegisterSemantics(t *testing.T) {
@@ -76,6 +77,40 @@ func TestRun_WhenAndRegisterSemantics(t *testing.T) {
 	}
 	if _, err := os.Stat(filepath.Join(bundle, "files", "skip.bin")); err == nil {
 		t.Fatalf("expected skipped artifact to not exist")
+	}
+}
+
+func TestRun_ContextFieldsInWhenAndTemplates(t *testing.T) {
+	bundle := t.TempDir()
+	localCache := t.TempDir()
+	sourceRel := filepath.ToSlash(filepath.Join("files", "payload.txt"))
+	sourceAbs := filepath.Join(localCache, filepath.FromSlash(sourceRel))
+	if err := os.MkdirAll(filepath.Dir(sourceAbs), 0o755); err != nil {
+		t.Fatalf("mkdir source dir: %v", err)
+	}
+	if err := os.WriteFile(sourceAbs, []byte("hello"), 0o644); err != nil {
+		t.Fatalf("write source: %v", err)
+	}
+	wf := &config.Workflow{Version: "v1", Phases: []config.Phase{{Name: "prepare", Steps: []config.Step{{
+		ID:   "context-download",
+		Kind: "DownloadFile",
+		When: "context.command == \"prepare\" && context.workflow.source == \"filesystem\" && context.workflow.isServer == false && context.paths.outputRoot == \"" + bundle + "\"",
+		Spec: map[string]any{
+			"source":     map[string]any{"path": sourceRel},
+			"fetch":      map[string]any{"sources": []any{map[string]any{"type": "local", "path": localCache}}},
+			"outputPath": "files/{{ .context.command }}-{{ .context.workflow.source }}.txt",
+		},
+	}}}}}
+	execContext := workflowcontext.Context{
+		Command:  workflowcontext.CommandPrepare,
+		Workflow: workflowcontext.Workflow{Source: workflowcontext.SourceFilesystem, Path: filepath.Join(t.TempDir(), "workflows", "prepare.yaml")},
+		Paths:    workflowcontext.Paths{BundleRoot: bundle, OutputRoot: bundle},
+	}
+	if err := Run(context.Background(), wf, RunOptions{BundleRoot: bundle, Context: execContext}); err != nil {
+		t.Fatalf("Run failed: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(bundle, "files", "prepare-filesystem.txt")); err != nil {
+		t.Fatalf("expected context-rendered artifact: %v", err)
 	}
 }
 
@@ -263,19 +298,19 @@ func TestWhen_NamespaceEnforced(t *testing.T) {
 		t.Fatalf("expected bare identifier guidance, got %v", err)
 	}
 
-	_, err = EvaluateWhen("context.nodeRole == \"worker\"", vars, runtimeVars)
-	if err == nil {
-		t.Fatalf("expected context namespace to fail")
+	ok, err = EvaluateWhenWithContext("context.nodeRole == \"worker\"", vars, runtimeVars, map[string]any{"nodeRole": "worker"})
+	if err != nil {
+		t.Fatalf("expected context namespace expression to pass, got %v", err)
 	}
-	if !strings.Contains(err.Error(), "unknown identifier \"context.nodeRole\"; supported prefixes are vars. and runtime") {
-		t.Fatalf("expected namespace restriction message, got %v", err)
+	if !ok {
+		t.Fatalf("expected context namespace expression to be true")
 	}
 
 	_, err = EvaluateWhen("other.nodeRole == \"worker\"", vars, runtimeVars)
 	if err == nil {
 		t.Fatalf("expected unknown dotted namespace to fail")
 	}
-	if !strings.Contains(err.Error(), "unknown identifier \"other.nodeRole\"; supported prefixes are vars. and runtime") {
+	if !strings.Contains(err.Error(), "unknown identifier \"other.nodeRole\"; supported prefixes are context., vars., and runtime") {
 		t.Fatalf("expected namespace restriction message, got %v", err)
 	}
 }

--- a/internal/prepare/runner.go
+++ b/internal/prepare/runner.go
@@ -20,12 +20,14 @@ import (
 	"github.com/Airgap-Castaways/deck/internal/fsutil"
 	ctrllogs "github.com/Airgap-Castaways/deck/internal/logs"
 	"github.com/Airgap-Castaways/deck/internal/stepmeta"
+	"github.com/Airgap-Castaways/deck/internal/workflowcontext"
 	"github.com/Airgap-Castaways/deck/internal/workflowexec"
 	"github.com/Airgap-Castaways/deck/internal/workspacepaths"
 )
 
 type RunOptions struct {
 	BundleRoot       string
+	Context          workflowcontext.Context
 	CommandRunner    CommandRunner
 	ForceRedownload  bool
 	EventSink        StepEventSink
@@ -127,7 +129,10 @@ func Run(ctx context.Context, wf *config.Workflow, opts RunOptions) error {
 		packCachePlan = ComputePackCachePlan(prevPackCacheState, workflowBytesForPlan, wf.Vars, prepareSteps)
 		packCachePlan.WorkflowSHA256 = workflowSHA
 	}
-	ctxData := map[string]any{"bundleRoot": bundleRoot, "stateFile": ""}
+	ctxData := opts.Context.RenderMap()
+	if strings.TrimSpace(opts.Context.Command) == "" {
+		ctxData = map[string]any{"bundleRoot": bundleRoot, "stateFile": ""}
+	}
 
 	for _, phase := range phases {
 		for _, batch := range workflowexec.BuildPhaseBatches(phase) {
@@ -213,7 +218,7 @@ func executePrepareBatch(ctx context.Context, runner CommandRunner, bundleRoot s
 }
 
 func executePrepareStep(ctx context.Context, runner CommandRunner, bundleRoot string, wf *config.Workflow, runtimeSnapshot map[string]any, ctxData map[string]any, phaseName string, batchCtx batchEventContext, step config.Step, opts RunOptions) (prepareBatchResult, error) {
-	ok, err := evaluateWhen(step.When, wf.Vars, runtimeSnapshot)
+	ok, err := evaluateWhenWithContext(step.When, wf.Vars, runtimeSnapshot, ctxData)
 	if err != nil {
 		return prepareBatchResult{}, fmt.Errorf("step %s (%s): %w", step.ID, step.Kind, err)
 	}
@@ -297,11 +302,19 @@ func applyRegister(step config.Step, rendered map[string]any, outputs map[string
 }
 
 func evaluateWhen(expr string, vars map[string]any, runtime map[string]any) (bool, error) {
-	return workflowexec.EvaluateWhen(expr, vars, runtime, errCodePrepareConditionEval)
+	return evaluateWhenWithContext(expr, vars, runtime, nil)
+}
+
+func evaluateWhenWithContext(expr string, vars map[string]any, runtime map[string]any, context map[string]any) (bool, error) {
+	return workflowexec.EvaluateWhenWithContext(expr, vars, runtime, context, errCodePrepareConditionEval)
 }
 
 func EvaluateWhen(expr string, vars map[string]any, runtime map[string]any) (bool, error) {
 	return evaluateWhen(expr, vars, runtime)
+}
+
+func EvaluateWhenWithContext(expr string, vars map[string]any, runtime map[string]any, context map[string]any) (bool, error) {
+	return evaluateWhenWithContext(expr, vars, runtime, context)
 }
 
 func fileManifestEntry(bundleRoot, rel string) (manifestEntry, error) {

--- a/internal/preparecli/service.go
+++ b/internal/preparecli/service.go
@@ -14,6 +14,7 @@ import (
 	"github.com/Airgap-Castaways/deck/internal/hostfs"
 	"github.com/Airgap-Castaways/deck/internal/logs"
 	"github.com/Airgap-Castaways/deck/internal/prepare"
+	"github.com/Airgap-Castaways/deck/internal/workflowcontext"
 	"github.com/Airgap-Castaways/deck/internal/workspacepaths"
 )
 
@@ -93,6 +94,14 @@ func Run(ctx context.Context, opts Options) error {
 	if err != nil {
 		return err
 	}
+	execContext := workflowcontext.Context{
+		Command: workflowcontext.CommandPrepare,
+		Workflow: workflowcontext.Workflow{
+			Source: workflowcontext.SourceFilesystem,
+			Path:   prepareWorkflowPath,
+		},
+		Paths: workflowcontext.Paths{BundleRoot: preparedRoot.Abs(), OutputRoot: preparedRoot.Abs()},
+	}
 	prepareWorkflow, err := config.LoadWithOptions(ctx, prepareWorkflowPath, config.LoadOptions{VarOverrides: opts.VarOverrides, NodeScopedVars: true})
 	if err != nil {
 		return err
@@ -100,7 +109,7 @@ func Run(ctx context.Context, opts Options) error {
 	if err := emitDiagnosticEvent(opts, 1, logs.CLIEvent{Component: "prepare", Event: "run_config", Attrs: map[string]any{"refresh": opts.Refresh, "clean": opts.Clean}}); err != nil {
 		return err
 	}
-	planDiagnostics, err := prepare.InspectPlan(prepareWorkflow, preparedRoot.Abs(), prepare.RunOptions{BundleRoot: preparedRoot.Abs(), ForceRedownload: opts.Refresh})
+	planDiagnostics, err := prepare.InspectPlan(prepareWorkflow, preparedRoot.Abs(), prepare.RunOptions{BundleRoot: preparedRoot.Abs(), Context: execContext, ForceRedownload: opts.Refresh})
 	if err != nil {
 		return err
 	}
@@ -178,7 +187,7 @@ func Run(ctx context.Context, opts Options) error {
 		return fmt.Errorf("create prepared root: %w", err)
 	}
 
-	if err := prepare.Run(ctx, prepareWorkflow, prepare.RunOptions{BundleRoot: preparedRoot.Abs(), ForceRedownload: opts.Refresh, EventSink: opts.EventSink}); err != nil {
+	if err := prepare.Run(ctx, prepareWorkflow, prepare.RunOptions{BundleRoot: preparedRoot.Abs(), Context: execContext, ForceRedownload: opts.Refresh, EventSink: opts.EventSink}); err != nil {
 		return err
 	}
 	if err := emitDiagnosticEvent(opts, 2, logs.CLIEvent{Level: "debug", Component: "prepare", Event: "bundle_root", Attrs: map[string]any{"bundle_root": filepath.ToSlash(preparedRoot.Abs())}}); err != nil {

--- a/internal/schemadoc/render.go
+++ b/internal/schemadoc/render.go
@@ -9,6 +9,8 @@ import (
 	"gopkg.in/yaml.v3"
 
 	"github.com/Airgap-Castaways/deck/internal/schemafacts"
+	"github.com/Airgap-Castaways/deck/internal/workflowcontext"
+	"github.com/Airgap-Castaways/deck/internal/workflowexec"
 )
 
 type PageInput struct {
@@ -164,6 +166,52 @@ func RenderToolDefinitionSchemaPartial(schemaPath string, schema map[string]any,
 
 func RenderComponentFragmentSchemaPartial(schemaPath string, schema map[string]any, meta PageMetadata) []byte {
 	return renderCoreSchemaSection("#### Component Fragment Contract", schemaPath, schema, meta, false)
+}
+
+func RenderSystemVariablesPartial() []byte {
+	var buf bytes.Buffer
+	buf.WriteString("### Built-In Runtime Fields\n\n")
+	buf.WriteString("`runtime.host` is a built-in reserved runtime namespace in both prepare and apply. Use it for detected host facts such as OS family, distro ID, version, architecture, and kernel release. Do not model detected local host facts as static `vars` values.\n\n")
+	buf.WriteString(renderRuntimeFieldTable(workflowexec.RuntimeHostFieldDefinitions()))
+	buf.WriteString("\n### Execution Context Fields\n\n")
+	buf.WriteString("`context` is available in both `when` expressions and templates. Canonical fields are:\n\n")
+	buf.WriteString(renderContextFieldTable(workflowcontext.FieldDefinitions()))
+	buf.WriteString("\nLegacy aliases remain available for existing templates: `context.bundleRoot` maps to `context.paths.bundleRoot`, and `context.stateFile` maps to `context.paths.stateFile`.\n\n")
+	buf.WriteString("When apply state keys are computed, deck includes a fingerprint of the execution context except fields derived from other context values, such as `context.workflow.isServer`, and `context.paths.stateFile`, which is derived from the state key itself.\n")
+	return buf.Bytes()
+}
+
+func renderRuntimeFieldTable(fields []workflowexec.RuntimeFieldDefinition) string {
+	if len(fields) == 0 {
+		return "No documented runtime fields.\n"
+	}
+	var buf bytes.Buffer
+	buf.WriteString("| Field | Type | Description |\n")
+	buf.WriteString("|---|---|---|\n")
+	for _, field := range fields {
+		buf.WriteString("| `" + escapePipe(field.Path) + "` | `" + escapePipe(field.Type) + "` | " + escapeMarkdownTableCell(field.Description) + " |\n")
+	}
+	return buf.String()
+}
+
+func renderContextFieldTable(fields []workflowcontext.FieldDefinition) string {
+	if len(fields) == 0 {
+		return "No documented context fields.\n"
+	}
+	var buf bytes.Buffer
+	buf.WriteString("| Field | Type | Prepare | Apply | Description |\n")
+	buf.WriteString("|---|---|---:|---:|---|\n")
+	for _, field := range fields {
+		buf.WriteString("| `" + escapePipe(field.Path) + "` | `" + escapePipe(field.Type) + "` | " + yesNo(field.Prepare) + " | " + yesNo(field.Apply) + " | " + escapeMarkdownTableCell(field.Description) + " |\n")
+	}
+	return buf.String()
+}
+
+func yesNo(value bool) string {
+	if value {
+		return "yes"
+	}
+	return "no"
 }
 
 func renderCoreSchemaSection(heading string, schemaPath string, schema map[string]any, meta PageMetadata, includeValidation bool) []byte {

--- a/internal/schemadoc/render_test.go
+++ b/internal/schemadoc/render_test.go
@@ -5,7 +5,9 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/Airgap-Castaways/deck/internal/workflowcontext"
 	"github.com/Airgap-Castaways/deck/internal/workflowcontract"
+	"github.com/Airgap-Castaways/deck/internal/workflowexec"
 	"github.com/Airgap-Castaways/deck/schemas"
 )
 
@@ -106,6 +108,20 @@ func TestRenderWorkflowSchemaPartialUsesNestedHeadings(t *testing.T) {
 	for _, want := range []string{"## Workflow Schema Contract", "### Example", "### Validation Rules", "- schema: `../../schemas/deck-workflow.schema.json`"} {
 		if !strings.Contains(rendered, want) {
 			t.Fatalf("expected %q in workflow schema partial:\n%s", want, rendered)
+		}
+	}
+}
+
+func TestRenderSystemVariablesPartialUsesFieldDefinitions(t *testing.T) {
+	rendered := string(RenderSystemVariablesPartial())
+	for _, def := range workflowcontext.FieldDefinitions() {
+		if !strings.Contains(rendered, "`"+def.Path+"`") {
+			t.Fatalf("expected context field %s in system variable docs:\n%s", def.Path, rendered)
+		}
+	}
+	for _, def := range workflowexec.RuntimeHostFieldDefinitions() {
+		if !strings.Contains(rendered, "`"+def.Path+"`") {
+			t.Fatalf("expected runtime field %s in system variable docs:\n%s", def.Path, rendered)
 		}
 	}
 }

--- a/internal/workflowcontext/context.go
+++ b/internal/workflowcontext/context.go
@@ -1,0 +1,166 @@
+package workflowcontext
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"path/filepath"
+	"strings"
+)
+
+const (
+	CommandApply   = "apply"
+	CommandPrepare = "prepare"
+
+	SourceFilesystem = "filesystem"
+	SourceServer     = "server"
+)
+
+type Context struct {
+	Command  string
+	Workflow Workflow
+	Paths    Paths
+}
+
+type Workflow struct {
+	Source   string
+	Path     string
+	Scenario string
+}
+
+type Paths struct {
+	BundleRoot string
+	OutputRoot string
+	StateFile  string
+}
+
+type FieldDefinition struct {
+	Path                      string
+	Type                      string
+	Prepare                   bool
+	Apply                     bool
+	Description               string
+	IncludeInStateFingerprint bool
+}
+
+type contextFieldDefinition struct {
+	FieldDefinition
+	Value func(Context) any
+}
+
+var contextFieldDefinitions = []contextFieldDefinition{
+	{
+		FieldDefinition: FieldDefinition{Path: "context.command", Type: "string", Prepare: true, Apply: true, Description: "Current command, `prepare` or `apply`.", IncludeInStateFingerprint: true},
+		Value:           func(c Context) any { return strings.TrimSpace(c.Command) },
+	},
+	{
+		FieldDefinition: FieldDefinition{Path: "context.workflow.source", Type: "string", Prepare: true, Apply: true, Description: "Workflow source, `filesystem` or `server`.", IncludeInStateFingerprint: true},
+		Value:           func(c Context) any { return strings.TrimSpace(c.Workflow.Source) },
+	},
+	{
+		FieldDefinition: FieldDefinition{Path: "context.workflow.isServer", Type: "boolean", Prepare: true, Apply: true, Description: "Boolean convenience value derived from `context.workflow.source == \"server\"`."},
+		Value:           func(c Context) any { return strings.TrimSpace(c.Workflow.Source) == SourceServer },
+	},
+	{
+		FieldDefinition: FieldDefinition{Path: "context.workflow.path", Type: "string", Prepare: true, Apply: true, Description: "Resolved workflow file path or URL.", IncludeInStateFingerprint: true},
+		Value:           func(c Context) any { return strings.TrimSpace(c.Workflow.Path) },
+	},
+	{
+		FieldDefinition: FieldDefinition{Path: "context.workflow.scenario", Type: "string", Apply: true, Description: "Scenario name when apply resolved a scenario.", IncludeInStateFingerprint: true},
+		Value:           func(c Context) any { return strings.TrimSpace(c.Workflow.Scenario) },
+	},
+	{
+		FieldDefinition: FieldDefinition{Path: "context.paths.bundleRoot", Type: "string", Prepare: true, Apply: true, Description: "Prepared output root during prepare; selected bundle root during apply.", IncludeInStateFingerprint: true},
+		Value:           func(c Context) any { return strings.TrimSpace(c.Paths.BundleRoot) },
+	},
+	{
+		FieldDefinition: FieldDefinition{Path: "context.paths.outputRoot", Type: "string", Prepare: true, Description: "Prepared output root.", IncludeInStateFingerprint: true},
+		Value:           func(c Context) any { return strings.TrimSpace(c.Paths.OutputRoot) },
+	},
+	{
+		FieldDefinition: FieldDefinition{Path: "context.paths.stateFile", Type: "string", Apply: true, Description: "Apply state file path."},
+		Value:           func(c Context) any { return strings.TrimSpace(c.Paths.StateFile) },
+	},
+}
+
+func FieldDefinitions() []FieldDefinition {
+	out := make([]FieldDefinition, len(contextFieldDefinitions))
+	for i, def := range contextFieldDefinitions {
+		out[i] = def.FieldDefinition
+	}
+	return out
+}
+
+func (c Context) RenderMap() map[string]any {
+	out := map[string]any{}
+	for _, def := range contextFieldDefinitions {
+		setDottedPath(out, strings.TrimPrefix(def.Path, "context."), def.Value(c))
+	}
+	out["bundleRoot"] = strings.TrimSpace(c.Paths.BundleRoot)
+	out["stateFile"] = strings.TrimSpace(c.Paths.StateFile)
+	return out
+}
+
+func (c Context) StateFingerprint() string {
+	payload := c.stateFingerprintPayload()
+	raw, err := json.Marshal(payload)
+	if err != nil {
+		return fmt.Sprintf("%v", payload)
+	}
+	h := sha256.Sum256(raw)
+	return hex.EncodeToString(h[:])
+}
+
+func (c Context) stateFingerprintPayload() map[string]any {
+	payload := map[string]any{}
+	for _, def := range contextFieldDefinitions {
+		if !def.IncludeInStateFingerprint {
+			continue
+		}
+		setDottedPath(payload, strings.TrimPrefix(def.Path, "context."), def.Value(c))
+	}
+	return payload
+}
+
+func setDottedPath(root map[string]any, path string, value any) {
+	parts := strings.Split(strings.TrimSpace(path), ".")
+	if len(parts) == 0 {
+		return
+	}
+	current := root
+	for _, part := range parts[:len(parts)-1] {
+		if part == "" {
+			return
+		}
+		next, _ := current[part].(map[string]any)
+		if next == nil {
+			next = map[string]any{}
+			current[part] = next
+		}
+		current = next
+	}
+	if last := parts[len(parts)-1]; last != "" {
+		current[last] = value
+	}
+}
+
+func SourceForWorkflowPath(workflowPath string) string {
+	trimmed := strings.TrimSpace(workflowPath)
+	if strings.HasPrefix(trimmed, "http://") || strings.HasPrefix(trimmed, "https://") {
+		return SourceServer
+	}
+	return SourceFilesystem
+}
+
+func AbsolutePath(path string) string {
+	trimmed := strings.TrimSpace(path)
+	if trimmed == "" || strings.HasPrefix(trimmed, "http://") || strings.HasPrefix(trimmed, "https://") {
+		return trimmed
+	}
+	abs, err := filepath.Abs(trimmed)
+	if err != nil {
+		return trimmed
+	}
+	return abs
+}

--- a/internal/workflowcontext/context.go
+++ b/internal/workflowcontext/context.go
@@ -4,9 +4,9 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
-	"fmt"
-	"path/filepath"
 	"strings"
+
+	"github.com/Airgap-Castaways/deck/internal/maputil"
 )
 
 const (
@@ -95,7 +95,7 @@ func FieldDefinitions() []FieldDefinition {
 func (c Context) RenderMap() map[string]any {
 	out := map[string]any{}
 	for _, def := range contextFieldDefinitions {
-		setDottedPath(out, strings.TrimPrefix(def.Path, "context."), def.Value(c))
+		maputil.SetDottedPath(out, strings.TrimPrefix(def.Path, "context."), def.Value(c))
 	}
 	out["bundleRoot"] = strings.TrimSpace(c.Paths.BundleRoot)
 	out["stateFile"] = strings.TrimSpace(c.Paths.StateFile)
@@ -104,10 +104,7 @@ func (c Context) RenderMap() map[string]any {
 
 func (c Context) StateFingerprint() string {
 	payload := c.stateFingerprintPayload()
-	raw, err := json.Marshal(payload)
-	if err != nil {
-		return fmt.Sprintf("%v", payload)
-	}
+	raw, _ := json.Marshal(payload)
 	h := sha256.Sum256(raw)
 	return hex.EncodeToString(h[:])
 }
@@ -118,31 +115,9 @@ func (c Context) stateFingerprintPayload() map[string]any {
 		if !def.IncludeInStateFingerprint {
 			continue
 		}
-		setDottedPath(payload, strings.TrimPrefix(def.Path, "context."), def.Value(c))
+		maputil.SetDottedPath(payload, strings.TrimPrefix(def.Path, "context."), def.Value(c))
 	}
 	return payload
-}
-
-func setDottedPath(root map[string]any, path string, value any) {
-	parts := strings.Split(strings.TrimSpace(path), ".")
-	if len(parts) == 0 {
-		return
-	}
-	current := root
-	for _, part := range parts[:len(parts)-1] {
-		if part == "" {
-			return
-		}
-		next, _ := current[part].(map[string]any)
-		if next == nil {
-			next = map[string]any{}
-			current[part] = next
-		}
-		current = next
-	}
-	if last := parts[len(parts)-1]; last != "" {
-		current[last] = value
-	}
 }
 
 func SourceForWorkflowPath(workflowPath string) string {
@@ -151,16 +126,4 @@ func SourceForWorkflowPath(workflowPath string) string {
 		return SourceServer
 	}
 	return SourceFilesystem
-}
-
-func AbsolutePath(path string) string {
-	trimmed := strings.TrimSpace(path)
-	if trimmed == "" || strings.HasPrefix(trimmed, "http://") || strings.HasPrefix(trimmed, "https://") {
-		return trimmed
-	}
-	abs, err := filepath.Abs(trimmed)
-	if err != nil {
-		return trimmed
-	}
-	return abs
 }

--- a/internal/workflowcontext/context_test.go
+++ b/internal/workflowcontext/context_test.go
@@ -1,0 +1,73 @@
+package workflowcontext
+
+import "testing"
+
+func TestRenderMapCoversFieldDefinitions(t *testing.T) {
+	ctx := Context{
+		Command:  CommandApply,
+		Workflow: Workflow{Source: SourceServer, Path: "https://deck.example/workflows/apply.yaml", Scenario: "cluster-a"},
+		Paths:    Paths{BundleRoot: "/srv/bundle", OutputRoot: "/srv/output", StateFile: "/var/lib/deck/state.json"},
+	}
+	rendered := ctx.RenderMap()
+
+	for _, def := range FieldDefinitions() {
+		path := trimContextPrefix(def.Path)
+		if _, ok := valueAtPath(rendered, path); !ok {
+			t.Fatalf("missing rendered context field %s", def.Path)
+		}
+	}
+	if got := rendered["bundleRoot"]; got != "/srv/bundle" {
+		t.Fatalf("legacy bundleRoot alias = %#v", got)
+	}
+	if got := rendered["stateFile"]; got != "/var/lib/deck/state.json" {
+		t.Fatalf("legacy stateFile alias = %#v", got)
+	}
+}
+
+func TestStateFingerprintExcludesDerivedAndStateFileFields(t *testing.T) {
+	base := Context{
+		Command:  CommandApply,
+		Workflow: Workflow{Source: SourceServer, Path: "https://deck.example/workflows/apply.yaml", Scenario: "cluster-a"},
+		Paths:    Paths{BundleRoot: "/srv/bundle", OutputRoot: "/srv/output", StateFile: "/var/lib/deck/state-a.json"},
+	}
+	changedStatePath := base
+	changedStatePath.Paths.StateFile = "/var/lib/deck/state-b.json"
+	if base.StateFingerprint() != changedStatePath.StateFingerprint() {
+		t.Fatalf("state fingerprint must ignore context.paths.stateFile")
+	}
+
+	changedSource := base
+	changedSource.Workflow.Source = SourceFilesystem
+	if base.StateFingerprint() == changedSource.StateFingerprint() {
+		t.Fatalf("state fingerprint must include context.workflow.source")
+	}
+}
+
+func trimContextPrefix(path string) string {
+	const prefix = "context."
+	if len(path) >= len(prefix) && path[:len(prefix)] == prefix {
+		return path[len(prefix):]
+	}
+	return path
+}
+
+func valueAtPath(root map[string]any, path string) (any, bool) {
+	current := any(root)
+	start := 0
+	for i := 0; i <= len(path); i++ {
+		if i < len(path) && path[i] != '.' {
+			continue
+		}
+		key := path[start:i]
+		m, ok := current.(map[string]any)
+		if !ok {
+			return nil, false
+		}
+		current, ok = m[key]
+		if !ok {
+			return nil, false
+		}
+		start = i + 1
+	}
+	return current, true
+}

--- a/internal/workflowcontract/public.go
+++ b/internal/workflowcontract/public.go
@@ -4,13 +4,13 @@ import "strings"
 
 const (
 	WhenLanguage    = "CEL"
-	whenDescription = "CEL expression evaluated at runtime. The step is skipped when it evaluates to false. Use `vars.` for input variables and `runtime.` for registered outputs and host facts."
+	whenDescription = "CEL expression evaluated at runtime. The step is skipped when it evaluates to false. Use `vars.` for input variables, `runtime.` for registered outputs and host facts, and `context.` for execution metadata."
 	whenExample     = `vars.skipKubeadm != "true"`
 	registerDesc    = "Map of runtime variable names to step output keys. Exported values are available to later steps, or to later batches when the step runs inside a parallel group, via `runtime.` in `when` expressions and `.runtime` in templates."
 	registerExample = "{outputPath:path}"
 )
 
-var whenNamespaces = []string{"runtime", "vars"}
+var whenNamespaces = []string{"context", "runtime", "vars"}
 
 func WhenNamespaces() []string {
 	out := make([]string, len(whenNamespaces))

--- a/internal/workflowexec/conditions.go
+++ b/internal/workflowexec/conditions.go
@@ -7,7 +7,11 @@ import (
 )
 
 func EvaluateWhen(expr string, vars map[string]any, runtime map[string]any, errCode string) (bool, error) {
-	result, err := workflowexpr.EvaluateWhen(expr, workflowexpr.Inputs{Vars: vars, Runtime: runtime})
+	return EvaluateWhenWithContext(expr, vars, runtime, nil, errCode)
+}
+
+func EvaluateWhenWithContext(expr string, vars map[string]any, runtime map[string]any, context map[string]any, errCode string) (bool, error) {
+	result, err := workflowexpr.EvaluateWhen(expr, workflowexpr.Inputs{Vars: vars, Runtime: runtime, Context: context})
 	if err != nil {
 		return false, fmt.Errorf("%s: %w", errCode, err)
 	}

--- a/internal/workflowexec/hostfacts.go
+++ b/internal/workflowexec/hostfacts.go
@@ -1,6 +1,10 @@
 package workflowexec
 
-import "strings"
+import (
+	"strings"
+
+	"github.com/Airgap-Castaways/deck/internal/maputil"
+)
 
 type HostFactsReader func(string) ([]byte, error)
 
@@ -96,31 +100,9 @@ func DetectHostFacts(goos string, goarch string, readFile HostFactsReader) map[s
 	}
 	out := map[string]any{}
 	for _, def := range runtimeHostFieldDefinitions {
-		setDottedPath(out, strings.TrimPrefix(def.Path, "runtime.host."), def.Value(source))
+		maputil.SetDottedPath(out, strings.TrimPrefix(def.Path, "runtime.host."), def.Value(source))
 	}
 	return out
-}
-
-func setDottedPath(root map[string]any, path string, value any) {
-	parts := strings.Split(strings.TrimSpace(path), ".")
-	if len(parts) == 0 {
-		return
-	}
-	current := root
-	for _, part := range parts[:len(parts)-1] {
-		if part == "" {
-			return
-		}
-		next, _ := current[part].(map[string]any)
-		if next == nil {
-			next = map[string]any{}
-			current[part] = next
-		}
-		current = next
-	}
-	if last := parts[len(parts)-1]; last != "" {
-		current[last] = value
-	}
 }
 
 func normalizeHostArch(v string) string {

--- a/internal/workflowexec/hostfacts.go
+++ b/internal/workflowexec/hostfacts.go
@@ -4,6 +4,75 @@ import "strings"
 
 type HostFactsReader func(string) ([]byte, error)
 
+type RuntimeFieldDefinition struct {
+	Path        string
+	Type        string
+	Description string
+}
+
+type hostFactSource struct {
+	osName        string
+	arch          string
+	osID          string
+	osFamily      string
+	osVersion     string
+	osVersionID   string
+	osIDLike      string
+	kernelRelease string
+}
+
+type runtimeHostFieldDefinition struct {
+	RuntimeFieldDefinition
+	Value func(hostFactSource) any
+}
+
+var runtimeHostFieldDefinitions = []runtimeHostFieldDefinition{
+	{
+		RuntimeFieldDefinition: RuntimeFieldDefinition{Path: "runtime.host.os.name", Type: "string", Description: "Operating system name reported by the Go runtime."},
+		Value:                  func(src hostFactSource) any { return src.osName },
+	},
+	{
+		RuntimeFieldDefinition: RuntimeFieldDefinition{Path: "runtime.host.os.id", Type: "string", Description: "Distribution ID from `/etc/os-release` `ID`, lowercased."},
+		Value:                  func(src hostFactSource) any { return src.osID },
+	},
+	{
+		RuntimeFieldDefinition: RuntimeFieldDefinition{Path: "runtime.host.os.family", Type: "string", Description: "Inferred distribution family such as `debian` or `rhel`, or empty when unknown."},
+		Value:                  func(src hostFactSource) any { return src.osFamily },
+	},
+	{
+		RuntimeFieldDefinition: RuntimeFieldDefinition{Path: "runtime.host.os.version", Type: "string", Description: "Distribution version from `/etc/os-release` `VERSION`."},
+		Value:                  func(src hostFactSource) any { return src.osVersion },
+	},
+	{
+		RuntimeFieldDefinition: RuntimeFieldDefinition{Path: "runtime.host.os.versionId", Type: "string", Description: "Distribution version ID from `/etc/os-release` `VERSION_ID`."},
+		Value:                  func(src hostFactSource) any { return src.osVersionID },
+	},
+	{
+		RuntimeFieldDefinition: RuntimeFieldDefinition{Path: "runtime.host.os.release", Type: "string", Description: "Alias of `runtime.host.os.versionId` retained for existing workflows."},
+		Value:                  func(src hostFactSource) any { return src.osVersionID },
+	},
+	{
+		RuntimeFieldDefinition: RuntimeFieldDefinition{Path: "runtime.host.os.idLike", Type: "string", Description: "Distribution compatibility IDs from `/etc/os-release` `ID_LIKE`, lowercased."},
+		Value:                  func(src hostFactSource) any { return src.osIDLike },
+	},
+	{
+		RuntimeFieldDefinition: RuntimeFieldDefinition{Path: "runtime.host.arch", Type: "string", Description: "Normalized host architecture such as `amd64` or `arm64`."},
+		Value:                  func(src hostFactSource) any { return src.arch },
+	},
+	{
+		RuntimeFieldDefinition: RuntimeFieldDefinition{Path: "runtime.host.kernel.release", Type: "string", Description: "Kernel release from `/proc/sys/kernel/osrelease`."},
+		Value:                  func(src hostFactSource) any { return src.kernelRelease },
+	},
+}
+
+func RuntimeHostFieldDefinitions() []RuntimeFieldDefinition {
+	out := make([]RuntimeFieldDefinition, len(runtimeHostFieldDefinitions))
+	for i, def := range runtimeHostFieldDefinitions {
+		out[i] = def.RuntimeFieldDefinition
+	}
+	return out
+}
+
 func DetectHostFacts(goos string, goarch string, readFile HostFactsReader) map[string]any {
 	osName := strings.TrimSpace(goos)
 	arch := normalizeHostArch(strings.TrimSpace(goarch))
@@ -15,20 +84,42 @@ func DetectHostFacts(goos string, goarch string, readFile HostFactsReader) map[s
 	osFamily := inferOSFamily(osID, osLike)
 	kernelRelease := readKernelRelease(readFile)
 
-	return map[string]any{
-		"os": map[string]any{
-			"name":      osName,
-			"id":        osID,
-			"family":    osFamily,
-			"version":   osVersion,
-			"versionId": osVersionID,
-			"release":   osVersionID,
-			"idLike":    osLike,
-		},
-		"arch": arch,
-		"kernel": map[string]any{
-			"release": kernelRelease,
-		},
+	source := hostFactSource{
+		osName:        osName,
+		arch:          arch,
+		osID:          osID,
+		osFamily:      osFamily,
+		osVersion:     osVersion,
+		osVersionID:   osVersionID,
+		osIDLike:      osLike,
+		kernelRelease: kernelRelease,
+	}
+	out := map[string]any{}
+	for _, def := range runtimeHostFieldDefinitions {
+		setDottedPath(out, strings.TrimPrefix(def.Path, "runtime.host."), def.Value(source))
+	}
+	return out
+}
+
+func setDottedPath(root map[string]any, path string, value any) {
+	parts := strings.Split(strings.TrimSpace(path), ".")
+	if len(parts) == 0 {
+		return
+	}
+	current := root
+	for _, part := range parts[:len(parts)-1] {
+		if part == "" {
+			return
+		}
+		next, _ := current[part].(map[string]any)
+		if next == nil {
+			next = map[string]any{}
+			current[part] = next
+		}
+		current = next
+	}
+	if last := parts[len(parts)-1]; last != "" {
+		current[last] = value
 	}
 }
 

--- a/internal/workflowexec/hostfacts_test.go
+++ b/internal/workflowexec/hostfacts_test.go
@@ -1,0 +1,62 @@
+package workflowexec
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestDetectHostFactsCoversRuntimeHostDefinitions(t *testing.T) {
+	facts := DetectHostFacts("linux", "x86_64", func(path string) ([]byte, error) {
+		switch path {
+		case "/etc/os-release":
+			return []byte("ID=ubuntu\nVERSION=22.04.4 LTS\nVERSION_ID=22.04\nID_LIKE=debian\n"), nil
+		case "/proc/sys/kernel/osrelease":
+			return []byte("6.8.0-test\n"), nil
+		default:
+			return nil, os.ErrNotExist
+		}
+	})
+
+	for _, def := range RuntimeHostFieldDefinitions() {
+		path := strings.TrimPrefix(def.Path, "runtime.host.")
+		if _, ok := valueAtRuntimePath(facts, path); !ok {
+			t.Fatalf("missing runtime host field %s", def.Path)
+		}
+	}
+	checks := map[string]any{
+		"os.name":        "linux",
+		"os.id":          "ubuntu",
+		"os.family":      "debian",
+		"os.version":     "22.04.4 LTS",
+		"os.versionId":   "22.04",
+		"os.release":     "22.04",
+		"os.idLike":      "debian",
+		"arch":           "amd64",
+		"kernel.release": "6.8.0-test",
+	}
+	for path, want := range checks {
+		got, ok := valueAtRuntimePath(facts, path)
+		if !ok {
+			t.Fatalf("missing runtime host field %s", path)
+		}
+		if got != want {
+			t.Fatalf("runtime host field %s = %#v, want %#v", path, got, want)
+		}
+	}
+}
+
+func valueAtRuntimePath(root map[string]any, path string) (any, bool) {
+	current := any(root)
+	for _, key := range strings.Split(path, ".") {
+		m, ok := current.(map[string]any)
+		if !ok {
+			return nil, false
+		}
+		current, ok = m[key]
+		if !ok {
+			return nil, false
+		}
+	}
+	return current, true
+}

--- a/internal/workflowexpr/contract_test.go
+++ b/internal/workflowexpr/contract_test.go
@@ -10,7 +10,7 @@ func TestPublicContract(t *testing.T) {
 	if contract.Language != "CEL" {
 		t.Fatalf("expected CEL language, got %q", contract.Language)
 	}
-	wantNamespaces := []string{"runtime", "vars"}
+	wantNamespaces := []string{"context", "runtime", "vars"}
 	if !reflect.DeepEqual(contract.Namespaces, wantNamespaces) {
 		t.Fatalf("unexpected namespaces: got %v want %v", contract.Namespaces, wantNamespaces)
 	}

--- a/internal/workflowexpr/eval.go
+++ b/internal/workflowexpr/eval.go
@@ -15,6 +15,7 @@ import (
 type Inputs struct {
 	Vars    map[string]any
 	Runtime map[string]any
+	Context map[string]any
 }
 
 type Program struct {
@@ -71,6 +72,7 @@ func (p Program) Eval(in Inputs) (bool, error) {
 	out, _, err := p.program.Eval(map[string]any{
 		"vars":    cloneMap(in.Vars),
 		"runtime": cloneMap(in.Runtime),
+		"context": cloneMap(in.Context),
 	})
 	if err != nil {
 		return false, fmt.Errorf("evaluate CEL expression: %w", err)
@@ -90,6 +92,7 @@ func (p Program) Eval(in Inputs) (bool, error) {
 func env() (*cel.Env, error) {
 	envOnce.Do(func() {
 		envInst, errEnv = cel.NewEnv(
+			cel.Variable("context", cel.MapType(cel.StringType, cel.DynType)),
 			cel.Variable("vars", cel.MapType(cel.StringType, cel.DynType)),
 			cel.Variable("runtime", cel.MapType(cel.StringType, cel.DynType)),
 		)
@@ -172,7 +175,7 @@ func maskStringLiterals(expr string) string {
 
 func unknownIdentifierError(id string) error {
 	if strings.Contains(id, ".") {
-		return fmt.Errorf("unknown identifier %q; supported prefixes are vars. and runtime", id)
+		return fmt.Errorf("unknown identifier %q; supported prefixes are context., vars., and runtime", id)
 	}
 	return fmt.Errorf("unknown identifier %q; use vars.%s", id, id)
 }

--- a/internal/workflowexpr/eval_test.go
+++ b/internal/workflowexpr/eval_test.go
@@ -33,6 +33,7 @@ func TestEvaluateWhen_NamespaceEnforced(t *testing.T) {
 	inputs := Inputs{
 		Vars:    map[string]any{"nodeRole": "worker"},
 		Runtime: map[string]any{"hostPassed": true},
+		Context: map[string]any{"nodeRole": "worker"},
 	}
 
 	ok, err := EvaluateWhen(`vars.nodeRole == "worker"`, inputs)
@@ -51,19 +52,19 @@ func TestEvaluateWhen_NamespaceEnforced(t *testing.T) {
 		t.Fatalf("expected bare identifier guidance, got %v", err)
 	}
 
-	_, err = EvaluateWhen(`context.nodeRole == "worker"`, inputs)
-	if err == nil {
-		t.Fatalf("expected context namespace to fail")
+	ok, err = EvaluateWhen(`context.nodeRole == "worker"`, inputs)
+	if err != nil {
+		t.Fatalf("expected context namespace expression to pass, got %v", err)
 	}
-	if !strings.Contains(err.Error(), `unknown identifier "context.nodeRole"; supported prefixes are vars. and runtime`) {
-		t.Fatalf("expected namespace restriction message, got %v", err)
+	if !ok {
+		t.Fatalf("expected context namespace expression to be true")
 	}
 
 	_, err = EvaluateWhen(`other.nodeRole == "worker"`, inputs)
 	if err == nil {
 		t.Fatalf("expected unknown dotted namespace to fail")
 	}
-	if !strings.Contains(err.Error(), `unknown identifier "other.nodeRole"; supported prefixes are vars. and runtime`) {
+	if !strings.Contains(err.Error(), `unknown identifier "other.nodeRole"; supported prefixes are context., vars., and runtime`) {
 		t.Fatalf("expected namespace restriction message, got %v", err)
 	}
 }


### PR DESCRIPTION
## Summary
- Add `context.*` as a public workflow namespace for `when` expressions and templates across prepare, plan, and apply.
- Remove implicit `./bundle.tar` apply fallback while preserving explicit bundle archive paths.
- Generate `runtime.host.*` and `context.*` reference docs from code-owned metadata.

## Verification
- `make generate`
- `make verify-generated`
- `make test`
- `make lint`