### PR TITLE
Add vars file overlays

### DIFF
--- a/.github/workflows/ci-reusable.yml
+++ b/.github/workflows/ci-reusable.yml
@@ -67,11 +67,11 @@ jobs:
         run: |
           make test
           ./bin/deck lint --root test
-          ./bin/deck lint --file docs/guides/examples/vagrant-smoke-install.yaml
-          ./bin/deck lint --file test/workflows/scenarios/control-plane-bootstrap.yaml
-          ./bin/deck lint --file test/workflows/scenarios/worker-join.yaml
-          ./bin/deck lint --file test/workflows/scenarios/node-reset.yaml
-          ./bin/deck lint --file test/workflows/scenarios/upgrade.yaml
+          ./bin/deck lint --workflow docs/guides/examples/vagrant-smoke-install.yaml
+          ./bin/deck lint --workflow test/workflows/scenarios/control-plane-bootstrap.yaml
+          ./bin/deck lint --workflow test/workflows/scenarios/worker-join.yaml
+          ./bin/deck lint --workflow test/workflows/scenarios/node-reset.yaml
+          ./bin/deck lint --workflow test/workflows/scenarios/upgrade.yaml
 
       - name: Validate docs examples (mode=validate)
         run: |
@@ -90,7 +90,7 @@ jobs:
             fi
 
             echo "linting ${example_path}"
-            ./bin/deck lint --file "${example_path}"
+            ./bin/deck lint --workflow "${example_path}"
           done < docs/guides/examples/cases.tsv
 
   security:

--- a/cmd/deck/apply_cli_test.go
+++ b/cmd/deck/apply_cli_test.go
@@ -130,6 +130,62 @@ phases:
 	}
 }
 
+func TestPlanAndApplyVarsFileOverlays(t *testing.T) {
+	root := t.TempDir()
+	workflowDir := filepath.Join(root, "workflows")
+	scenarioDir := filepath.Join(workflowDir, "scenarios")
+	varsDir := filepath.Join(workflowDir, "vars")
+	if err := os.MkdirAll(scenarioDir, 0o755); err != nil {
+		t.Fatalf("mkdir scenarios: %v", err)
+	}
+	if err := os.MkdirAll(varsDir, 0o755); err != nil {
+		t.Fatalf("mkdir vars dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(workflowDir, "vars.yaml"), []byte("cluster: base\nrole: base\nmode: base\n"), 0o644); err != nil {
+		t.Fatalf("write vars.yaml: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(varsDir, "site.yaml"), []byte("role: worker\nmode: site\n"), 0o644); err != nil {
+		t.Fatalf("write site vars: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(varsDir, "node.yaml"), []byte("mode: node\n"), 0o644); err != nil {
+		t.Fatalf("write node vars: %v", err)
+	}
+	workflowPath := filepath.Join(scenarioDir, "apply.yaml")
+	writeWorkflowYAML(t, workflowPath, `version: v1alpha1
+vars:
+  role: workflow
+phases:
+  - name: install
+    steps:
+      - id: vars-file-match
+        kind: Command
+        when: vars.cluster == "base" && vars.role == "worker" && vars.mode == "node"
+        spec:
+          command: ["true"]
+      - id: vars-file-miss
+        kind: Command
+        when: vars.role == "workflow"
+        spec:
+          command: ["true"]
+`)
+
+	planOut, err := runWithCapturedStdout([]string{"plan", "--workflow", workflowPath, "-f", "vars/site.yaml", "--vars-file", "vars/node.yaml"})
+	if err != nil {
+		t.Fatalf("plan failed: %v", err)
+	}
+	if !strings.Contains(planOut, "vars-file-match Command RUN") || !strings.Contains(planOut, "vars-file-miss Command SKIP") {
+		t.Fatalf("expected plan to use vars-file overlays, got %q", planOut)
+	}
+
+	applyOut, err := runWithCapturedStdout([]string{"apply", "--workflow", workflowPath, "--dry-run", "-f", "vars/site.yaml", "--vars-file", "vars/node.yaml", root})
+	if err != nil {
+		t.Fatalf("apply dry-run failed: %v", err)
+	}
+	if !strings.Contains(applyOut, "vars-file-match Command PLAN") || !strings.Contains(applyOut, "vars-file-miss Command SKIP") {
+		t.Fatalf("expected apply to use vars-file overlays, got %q", applyOut)
+	}
+}
+
 func TestPlanAndApplySelectNodeScopedVarsByHostname(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 	hostname, err := os.Hostname()

--- a/cmd/deck/apply_cli_test.go
+++ b/cmd/deck/apply_cli_test.go
@@ -153,7 +153,7 @@ func TestPlanAndApplyVarsFileOverlays(t *testing.T) {
 	workflowPath := filepath.Join(scenarioDir, "apply.yaml")
 	writeWorkflowYAML(t, workflowPath, `version: v1alpha1
 vars:
-  role: workflow
+  workflowOnly: present
 phases:
   - name: install
     steps:

--- a/cmd/deck/cmd_apply.go
+++ b/cmd/deck/cmd_apply.go
@@ -19,10 +19,12 @@ type diffOptions struct {
 	selectedPhase string
 	output        string
 	varOverrides  map[string]string
+	varsFiles     []string
 }
 
 func newPlanCommand(env *cliEnv) *cobra.Command {
 	vars := &varFlag{}
+	varsFiles := &stringSliceFlag{}
 	cmd := &cobra.Command{
 		Use:     "plan",
 		Aliases: []string{"diff"},
@@ -60,6 +62,7 @@ func newPlanCommand(env *cliEnv) *cobra.Command {
 				selectedPhase: selectedPhase,
 				output:        output,
 				varOverrides:  vars.AsMap(),
+				varsFiles:     varsFiles.Values(),
 			})
 		},
 	}
@@ -70,6 +73,7 @@ func newPlanCommand(env *cliEnv) *cobra.Command {
 	cmd.Flags().String("phase", "", "phase name to plan (defaults to all phases)")
 	cmd.Flags().Bool("fresh", false, "ignore saved apply state for this invocation")
 	cmd.Flags().StringP("output", "o", "text", "output format (text|json)")
+	cmd.Flags().VarP(varsFiles, "vars-file", "f", "vars file overlay relative to workflows/ (repeatable)")
 	cmd.Flags().Var(vars, "var", "set variable override (key=value), repeatable")
 	registerScenarioSourceCompletion(cmd, "source", false)
 	registerScenarioNameCompletion(cmd, "scenario", "source", "", false)
@@ -82,10 +86,10 @@ func runDiffWithOptions(env *cliEnv, ctx context.Context, opts diffOptions) erro
 		return err
 	}
 	selectedPhase := strings.TrimSpace(opts.selectedPhase)
-	return executeDiff(env, ctx, workflowPath, strings.TrimSpace(opts.scenario), selectedPhase, opts.output, opts.fresh, varsAsAnyMap(opts.varOverrides))
+	return executeDiff(env, ctx, workflowPath, strings.TrimSpace(opts.scenario), selectedPhase, opts.output, opts.fresh, opts.varsFiles, varsAsAnyMap(opts.varOverrides))
 }
 
-func executeDiff(env *cliEnv, ctx context.Context, workflowPath, scenario, selectedPhase, output string, fresh bool, varOverrides map[string]any) error {
+func executeDiff(env *cliEnv, ctx context.Context, workflowPath, scenario, selectedPhase, output string, fresh bool, varsFiles []string, varOverrides map[string]any) error {
 	return applycli.RunPlanCommand(ctx, applycli.PlanCommandOptions{
 		WorkflowPath:    workflowPath,
 		Scenario:        scenario,
@@ -93,6 +97,7 @@ func executeDiff(env *cliEnv, ctx context.Context, workflowPath, scenario, selec
 		Output:          output,
 		Fresh:           fresh,
 		VarOverrides:    varOverrides,
+		VarsFiles:       append([]string(nil), varsFiles...),
 		Verbosef:        env.verbosef,
 		StdoutPrintf:    env.stdoutPrintf,
 		JSONEncoderFunc: env.stdoutJSONEncoder,
@@ -108,11 +113,13 @@ type applyOptions struct {
 	fresh         bool
 	dryRun        bool
 	varOverrides  map[string]string
+	varsFiles     []string
 	positional    []string
 }
 
 func newApplyCommand(env *cliEnv) *cobra.Command {
 	vars := &varFlag{}
+	varsFiles := &stringSliceFlag{}
 	cmd := &cobra.Command{
 		Use:   "apply [workflow] [bundle]",
 		Short: "Execute an apply file against a bundle",
@@ -155,6 +162,7 @@ func newApplyCommand(env *cliEnv) *cobra.Command {
 				fresh:         fresh,
 				dryRun:        dryRun,
 				varOverrides:  vars.AsMap(),
+				varsFiles:     varsFiles.Values(),
 				positional:    args,
 			})
 		},
@@ -166,6 +174,7 @@ func newApplyCommand(env *cliEnv) *cobra.Command {
 	cmd.Flags().String("phase", "", "phase name to execute (defaults to all phases)")
 	cmd.Flags().Bool("fresh", false, "ignore saved apply state for this invocation")
 	cmd.Flags().Bool("dry-run", false, "print apply plan without executing steps")
+	cmd.Flags().VarP(varsFiles, "vars-file", "f", "vars file overlay relative to workflows/ (repeatable)")
 	cmd.Flags().Var(vars, "var", "set variable override (key=value), repeatable")
 	registerScenarioSourceCompletion(cmd, "source", false)
 	registerScenarioNameCompletion(cmd, "scenario", "source", "", false)
@@ -197,6 +206,7 @@ func runApplyWithOptions(env *cliEnv, ctx context.Context, opts applyOptions) er
 		Fresh:          opts.fresh,
 		DryRun:         opts.dryRun,
 		VarOverrides:   varsAsAnyMap(opts.varOverrides),
+		VarsFiles:      append([]string(nil), opts.varsFiles...),
 		Verbosef:       env.verbosef,
 		StdoutPrintf:   env.stdoutPrintf,
 		StdoutPrintln:  env.stdoutPrintln,

--- a/cmd/deck/cmd_apply_events.go
+++ b/cmd/deck/cmd_apply_events.go
@@ -43,7 +43,7 @@ func resolveApplyWorkflowAndBundle(ctx context.Context, opts applyOptions, posit
 	})
 }
 
-func executeLint(env *cliEnv, ctx context.Context, root string, file string, scenario string, output string) error {
+func executeLint(env *cliEnv, ctx context.Context, root string, file string, scenario string, output string, varsFiles []string) error {
 	resolvedOutput, err := resolveOutputFormat(output)
 	if err != nil {
 		return err
@@ -53,6 +53,7 @@ func executeLint(env *cliEnv, ctx context.Context, root string, file string, sce
 		File:            file,
 		Scenario:        scenario,
 		Output:          resolvedOutput,
+		VarsFiles:       append([]string(nil), varsFiles...),
 		Verbosef:        env.verbosef,
 		StdoutPrintf:    env.stdoutPrintf,
 		JSONEncoderFunc: env.stdoutJSONEncoder,

--- a/cmd/deck/cmd_prepare.go
+++ b/cmd/deck/cmd_prepare.go
@@ -19,10 +19,12 @@ type prepareOptions struct {
 	binaries       []string
 	binaryExcludes []string
 	varOverrides   map[string]string
+	varsFiles      []string
 }
 
 func newPrepareCommand(env *cliEnv) *cobra.Command {
 	vars := &varFlag{}
+	varsFiles := &stringSliceFlag{}
 	binaries := &stringSliceFlag{}
 	excludes := &stringSliceFlag{}
 	cmd := &cobra.Command{
@@ -69,6 +71,7 @@ func newPrepareCommand(env *cliEnv) *cobra.Command {
 				binaries:       binaries.Values(),
 				binaryExcludes: excludes.Values(),
 				varOverrides:   vars.AsMap(),
+				varsFiles:      varsFiles.Values(),
 			})
 		},
 	}
@@ -81,6 +84,7 @@ func newPrepareCommand(env *cliEnv) *cobra.Command {
 	cmd.Flags().String("bundle-binary-version", "", "release version override for --bundle-binary-source=release")
 	cmd.Flags().Var(binaries, "bundle-binary", "runtime binary target tuple (os/arch), repeatable")
 	cmd.Flags().Var(excludes, "bundle-binary-exclude", "runtime binary target tuple (os/arch) to exclude, repeatable")
+	cmd.Flags().VarP(varsFiles, "vars-file", "f", "vars file overlay relative to workflows/ (repeatable)")
 	cmd.Flags().Var(vars, "var", "set variable override (key=value), repeatable")
 	return cmd
 }
@@ -100,6 +104,7 @@ func runPrepareWithOptions(env *cliEnv, cmd *cobra.Command, opts prepareOptions)
 		Binaries:       opts.binaries,
 		BinaryExcludes: opts.binaryExcludes,
 		VarOverrides:   varsAsAnyMap(opts.varOverrides),
+		VarsFiles:      append([]string(nil), opts.varsFiles...),
 		Stdout:         env.stdoutWriter(),
 		Diagnosticf:    env.verbosef,
 		EventSink:      verbosePrepareStepSink(env),

--- a/cmd/deck/cobra_simple_leaf_commands.go
+++ b/cmd/deck/cobra_simple_leaf_commands.go
@@ -8,6 +8,7 @@ import (
 )
 
 func newLintCommand(env *cliEnv) *cobra.Command {
+	varsFiles := &stringSliceFlag{}
 	cmd := &cobra.Command{
 		Use:   "lint [scenario]",
 		Short: "Lint the workflow tree or a single workflow file",
@@ -21,7 +22,7 @@ func newLintCommand(env *cliEnv) *cobra.Command {
 			if err != nil {
 				return err
 			}
-			file, err := cmdFlagValue(cmd, "file")
+			workflow, err := cmdFlagValue(cmd, "workflow")
 			if err != nil {
 				return err
 			}
@@ -29,11 +30,12 @@ func newLintCommand(env *cliEnv) *cobra.Command {
 			if err != nil {
 				return err
 			}
-			return executeLint(env, cmd.Context(), root, file, scenario, output)
+			return executeLint(env, cmd.Context(), root, workflow, scenario, output, varsFiles.Values())
 		},
 	}
 	cmd.Flags().String("root", ".", "workspace root containing workflows/")
-	cmd.Flags().StringP("file", "f", "", "path or URL to workflow file")
+	cmd.Flags().String("workflow", "", "path or URL to workflow file")
+	cmd.Flags().VarP(varsFiles, "vars-file", "f", "vars file overlay relative to workflows/ (repeatable)")
 	cmd.Flags().StringP("output", "o", "text", "output format (text|json)")
 	return cmd
 }

--- a/cmd/deck/prepare_cli_test.go
+++ b/cmd/deck/prepare_cli_test.go
@@ -108,6 +108,69 @@ func TestRunPrepareDryRunDoesNotWrite(t *testing.T) {
 	}
 }
 
+func TestRunPrepareVarsFileOverlay(t *testing.T) {
+	root := t.TempDir()
+	workflowsDir := filepath.Join(root, "workflows")
+	varsDir := filepath.Join(workflowsDir, "vars")
+	if err := os.MkdirAll(filepath.Join(workflowsDir, "scenarios"), 0o755); err != nil {
+		t.Fatalf("mkdir scenarios: %v", err)
+	}
+	if err := os.MkdirAll(varsDir, 0o755); err != nil {
+		t.Fatalf("mkdir vars dir: %v", err)
+	}
+	seedDir := filepath.Join(root, "seed", "files")
+	if err := os.MkdirAll(seedDir, 0o755); err != nil {
+		t.Fatalf("mkdir seed dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(seedDir, "source.bin"), []byte("seed\n"), 0o644); err != nil {
+		t.Fatalf("write seed source: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(workflowsDir, "vars.yaml"), []byte("prepareEnabled: false\n"), 0o644); err != nil {
+		t.Fatalf("write vars.yaml: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(varsDir, "prepare.yaml"), []byte("prepareEnabled: true\n"), 0o644); err != nil {
+		t.Fatalf("write prepare vars: %v", err)
+	}
+	writeWorkflowYAML(t, filepath.Join(workflowsDir, "prepare.yaml"), fmt.Sprintf(`version: v1alpha1
+phases:
+  - name: prepare
+    steps:
+      - id: overlay-seed
+        kind: DownloadFile
+        when: vars.prepareEnabled == true
+        spec:
+          source:
+            path: files/source.bin
+          fetch:
+            sources:
+              - type: local
+                path: %q
+          outputPath: files/overlay.bin
+`, filepath.Join(root, "seed")))
+	if err := os.WriteFile(filepath.Join(workflowsDir, "scenarios", "apply.yaml"), []byte("version: v1alpha1\nsteps: []\n"), 0o644); err != nil {
+		t.Fatalf("write apply workflow: %v", err)
+	}
+
+	originalCWD, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	if err := os.Chdir(root); err != nil {
+		t.Fatalf("chdir root: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(originalCWD) })
+
+	res := execute([]string{"prepare", "--dry-run", "--v=2", "--bundle-binary-source", "local", "-f", "vars/prepare.yaml"})
+	if res.err != nil {
+		t.Fatalf("prepare dry-run failed: %v", res.err)
+	}
+	for _, want := range []string{"component=prepare", "event=cache_artifact", "step=overlay-seed", "action=FETCH"} {
+		if !strings.Contains(res.stderr, want) {
+			t.Fatalf("expected %q in stderr, got %q", want, res.stderr)
+		}
+	}
+}
+
 func TestRunPrepareVerboseDiagnostics(t *testing.T) {
 	root := t.TempDir()
 	workflowsDir := filepath.Join(root, "workflows")

--- a/cmd/deck/server_misc_cli_test.go
+++ b/cmd/deck/server_misc_cli_test.go
@@ -495,8 +495,8 @@ func TestSourceCommandRemoved(t *testing.T) {
 func TestRunWorkflowLintAndLegacyValidateMigration(t *testing.T) {
 	wf := writeValidateWorkflowFixture(t)
 
-	t.Run("lint with -f", func(t *testing.T) {
-		out, err := runWithCapturedStdout([]string{"lint", "-f", wf})
+	t.Run("lint with --workflow", func(t *testing.T) {
+		out, err := runWithCapturedStdout([]string{"lint", "--workflow", wf})
 		if err != nil {
 			t.Fatalf("expected success, got %v", err)
 		}
@@ -505,18 +505,34 @@ func TestRunWorkflowLintAndLegacyValidateMigration(t *testing.T) {
 		}
 	})
 
-	t.Run("lint with --file", func(t *testing.T) {
-		out, err := runWithCapturedStdout([]string{"lint", "--file", wf})
+	t.Run("lint with vars-file", func(t *testing.T) {
+		root := t.TempDir()
+		workflowPath := filepath.Join(root, "workflows", "scenarios", "apply.yaml")
+		varsPath := filepath.Join(root, "workflows", "vars", "site.yaml")
+		if err := os.MkdirAll(filepath.Dir(workflowPath), 0o755); err != nil {
+			t.Fatalf("mkdir workflow dir: %v", err)
+		}
+		if err := os.MkdirAll(filepath.Dir(varsPath), 0o755); err != nil {
+			t.Fatalf("mkdir vars dir: %v", err)
+		}
+		if err := os.WriteFile(varsPath, []byte("command:\n  - \"true\"\n"), 0o644); err != nil {
+			t.Fatalf("write vars file: %v", err)
+		}
+		if err := os.WriteFile(workflowPath, []byte("version: v1alpha1\nphases:\n  - name: install\n    steps:\n      - id: rendered-command\n        kind: Command\n        spec:\n          command: '{{ .vars.command }}'\n"), 0o644); err != nil {
+			t.Fatalf("write workflow: %v", err)
+		}
+
+		out, err := runWithCapturedStdout([]string{"lint", "--workflow", workflowPath, "-f", "vars/site.yaml"})
 		if err != nil {
 			t.Fatalf("expected success, got %v", err)
 		}
-		if out != fmt.Sprintf("lint: ok (%s)\nSUMMARY mode=file workflows=1 warnings=1 errors=0 supportedVersion=v1alpha1 modes=prepare,apply topLevelModes=phases,steps\n", wf) {
+		if out != "lint: ok (1 workflows)\nSUMMARY mode=entrypoint workflows=1 warnings=1 errors=0 supportedVersion=v1alpha1 modes=prepare,apply topLevelModes=phases,steps\n" {
 			t.Fatalf("unexpected output: %q", out)
 		}
 	})
 
 	t.Run("lint json output", func(t *testing.T) {
-		res := execute([]string{"lint", "--file", wf, "-o", "json"})
+		res := execute([]string{"lint", "--workflow", wf, "-o", "json"})
 		if res.err != nil {
 			t.Fatalf("expected success, got %v", res.err)
 		}
@@ -570,14 +586,14 @@ func TestRunWorkflowLintAndLegacyValidateMigration(t *testing.T) {
 	})
 
 	t.Run("lint verbose diagnostics stay on stderr", func(t *testing.T) {
-		res := execute([]string{"lint", "--file", wf, "--v=2"})
+		res := execute([]string{"lint", "--workflow", wf, "--v=2"})
 		if res.err != nil {
 			t.Fatalf("expected success, got %v", res.err)
 		}
 		if res.stdout != fmt.Sprintf("lint: ok (%s)\nSUMMARY mode=file workflows=1 warnings=1 errors=0 supportedVersion=v1alpha1 modes=prepare,apply topLevelModes=phases,steps\n", wf) {
 			t.Fatalf("unexpected stdout: %q", res.stdout)
 		}
-		for _, want := range []string{"component=lint", "event=lint_requested", "file=" + wf, fmt.Sprintf("workflow=%s", wf), "event=workflow", "event=finding", "code=W_COMMAND_OPAQUE", "severity=warning"} {
+		for _, want := range []string{"component=lint", "event=lint_requested", fmt.Sprintf("workflow=%s", wf), "event=workflow", "event=finding", "code=W_COMMAND_OPAQUE", "severity=warning"} {
 			if !strings.Contains(res.stderr, want) {
 				t.Fatalf("expected %q in stderr, got %q", want, res.stderr)
 			}
@@ -616,7 +632,7 @@ func TestRunWorkflowLintAndLegacyValidateMigration(t *testing.T) {
 		}
 		defer func() { _ = os.Chdir(oldWD) }()
 
-		res := execute([]string{"lint", "--file", applyPath, "--root", root, "--v=2"})
+		res := execute([]string{"lint", "--workflow", applyPath, "--root", root, "--v=2"})
 		if res.err != nil {
 			t.Fatalf("expected success, got %v", res.err)
 		}
@@ -689,7 +705,7 @@ func TestRunWorkflowLintAndLegacyValidateMigration(t *testing.T) {
 		path := filepath.Join(t.TempDir(), "prepare.yaml")
 		writeWorkflowYAML(t, path, "version: v1alpha1\nphases:\n  - name: prepare\n    steps:\n      - id: rpm\n        kind: DownloadFile\n        spec:\n          source:\n            url: https://example.com/pkg.rpm\n          outputPath: files/pkg.rpm\n")
 
-		res := execute([]string{"lint", "--file", path, "-o", "json"})
+		res := execute([]string{"lint", "--workflow", path, "-o", "json"})
 		if res.err != nil {
 			t.Fatalf("expected success, got %v", res.err)
 		}
@@ -719,7 +735,7 @@ func TestRunWorkflowLintAndLegacyValidateMigration(t *testing.T) {
 		if err := os.WriteFile(componentPath, []byte("version: v1alpha1\nsteps: []\n"), 0o644); err != nil {
 			t.Fatalf("write component: %v", err)
 		}
-		_, err := runWithCapturedStdout([]string{"lint", "--file", componentPath})
+		_, err := runWithCapturedStdout([]string{"lint", "--workflow", componentPath})
 		if err == nil {
 			t.Fatalf("expected component entrypoint error")
 		}
@@ -729,7 +745,7 @@ func TestRunWorkflowLintAndLegacyValidateMigration(t *testing.T) {
 	})
 
 	t.Run("legacy workflow namespace is removed", func(t *testing.T) {
-		err := run([]string{"workflow", "lint", "-f", wf})
+		err := run([]string{"workflow", "lint", "--workflow", wf})
 		if err == nil {
 			t.Fatalf("expected unknown command error")
 		}

--- a/docs/guides/examples/README.md
+++ b/docs/guides/examples/README.md
@@ -33,7 +33,7 @@ For walkthrough-oriented context, start with [Quick Start](../quick-start.md) an
 Use `deck lint` for schema-level checks:
 
 ```bash
-deck lint --file docs/guides/examples/offline-k8s-control-plane.yaml
+deck lint --workflow docs/guides/examples/offline-k8s-control-plane.yaml
 ```
 
 `cases.tsv` is the lightweight example index used by repository maintainers and CI.

--- a/docs/guides/offline-kubernetes.md
+++ b/docs/guides/offline-kubernetes.md
@@ -51,10 +51,10 @@ deck prepare
 deck bundle build --out ./bundle.tar
 ```
 
-During local testing, use repeatable `--var key=value` overrides instead of editing shared vars files for every site-specific change:
+During local testing, use repeatable `-f, --vars-file` overlays or `--var key=value` overrides instead of editing shared vars files for every site-specific change:
 
 ```bash
-deck prepare --var kubernetesVersion=v1.30.1 --var registryHost=mirror.local
+deck prepare -f vars/lab.yaml --var kubernetesVersion=v1.30.1 --var registryHost=mirror.local
 ```
 
 The bundle includes the canonical workspace inputs: `outputs/packages/`, `outputs/images/`, `outputs/files/`, `outputs/bin/`, `workflows/`, the root `deck` launcher, and `.deck/manifest.json` checksums.

--- a/docs/guides/offline-kubernetes.md
+++ b/docs/guides/offline-kubernetes.md
@@ -93,7 +93,7 @@ Keep that choice explicit and secondary. The core workflow centers on local `dec
 
 ```bash
 deck lint
-deck lint --file ./workflows/scenarios/apply.yaml
+deck lint --workflow ./workflows/scenarios/apply.yaml
 ```
 
 For planning and diagnostics, also review:

--- a/docs/guides/quick-start.md
+++ b/docs/guides/quick-start.md
@@ -50,7 +50,7 @@ Use `vars.yaml` or inline `vars` to keep site-specific values out of the step de
 
 ```bash
 deck lint
-deck lint --file ./demo/workflows/scenarios/apply.yaml
+deck lint --workflow ./demo/workflows/scenarios/apply.yaml
 ```
 
 `deck lint` checks the workflow structure and the schema for each typed step. Catching mistakes here is cheaper than discovering them inside the air gap.

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -159,7 +159,12 @@ To enable completion for all future shell sessions, add the sourcing command to 
 
 `lint`, `prepare`, `plan`, and `apply` support repeatable `-f, --vars-file` YAML overlays. `prepare`, `plan`, and `apply` also support repeatable `--var key=value` overrides for one invocation.
 
-Use these when you want to test a different site value without editing `workflows/vars.yaml` or the scenario file itself. Vars files are merged on top of `workflows/vars.yaml` in the order provided before node-scoped `all:` and `hosts:` values are selected, then workflow `vars:` and final `--var` overrides are applied.
+Use these when you want to test a different site value without editing `workflows/vars.yaml` or the scenario file itself.
+
+- Vars files are merged on top of `workflows/vars.yaml` in the order provided.
+- Node-scoped `all:` and `hosts:` values are selected after vars-file overlays are merged.
+- Workflow `vars:` are applied after node-scoped selection.
+- `--var` overrides are applied last and have the highest precedence.
 
 ```bash
 deck prepare -f vars/site.yaml --var registryHost=mirror.local --var kubernetesVersion=v1.30.1

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -157,7 +157,7 @@ To enable completion for all future shell sessions, add the sourcing command to 
 
 ### Variable overrides
 
-`prepare`, `plan`, and `apply` support repeatable `-f, --vars-file` YAML overlays and repeatable `--var key=value` overrides for one invocation.
+`lint`, `prepare`, `plan`, and `apply` support repeatable `-f, --vars-file` YAML overlays. `prepare`, `plan`, and `apply` also support repeatable `--var key=value` overrides for one invocation.
 
 Use these when you want to test a different site value without editing `workflows/vars.yaml` or the scenario file itself. Vars files are merged on top of `workflows/vars.yaml` in the order provided before node-scoped `all:` and `hosts:` values are selected, then workflow `vars:` and final `--var` overrides are applied.
 
@@ -222,9 +222,9 @@ deck version
 deck version -o json
 deck list --source local
 deck completion bash > ./deck.bash
-deck lint --file ./demo/workflows/scenarios/apply.yaml
-deck lint --file ./demo/workflows/scenarios/apply.yaml -o json
-deck lint --file ./demo/workflows/prepare.yaml
+deck lint --workflow ./demo/workflows/scenarios/apply.yaml
+deck lint --workflow ./demo/workflows/scenarios/apply.yaml -o json
+deck lint --workflow ./demo/workflows/prepare.yaml
 
 cd ./demo
 deck prepare

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -157,15 +157,17 @@ To enable completion for all future shell sessions, add the sourcing command to 
 
 ### Variable overrides
 
-`prepare`, `plan`, and `apply` support repeatable `--var key=value` overrides for one invocation.
+`prepare`, `plan`, and `apply` support repeatable `-f, --vars-file` YAML overlays and repeatable `--var key=value` overrides for one invocation.
 
-Use this when you want to test a different site value without editing `workflows/vars.yaml` or the scenario file itself.
+Use these when you want to test a different site value without editing `workflows/vars.yaml` or the scenario file itself. Vars files are merged on top of `workflows/vars.yaml` in the order provided, then `--var` overrides are applied last.
 
 ```bash
-deck prepare --var registryHost=mirror.local --var kubernetesVersion=v1.30.1
-deck plan --scenario apply --var role=worker
-deck apply --scenario apply --var role=control-plane --var nodeIP=10.0.0.10
+deck prepare -f vars/site.yaml --var registryHost=mirror.local --var kubernetesVersion=v1.30.1
+deck plan --scenario apply -f vars/site.yaml -f vars/worker.yaml --var role=worker
+deck apply --scenario apply -f vars/site.yaml -f vars/cp1.yaml --var role=control-plane --var nodeIP=10.0.0.10
 ```
+
+Vars file paths are relative to the same `workflows/` location that contains `vars.yaml`. For example, `-f vars/site.yaml` reads `workflows/vars/site.yaml` for a local workflow tree.
 
 ### Node-scoped workflow variables
 
@@ -183,7 +185,7 @@ hosts:
 
 If the hostname is not listed, these commands still run with ordinary `vars.yaml` values and `all:` values. Workflows that branch on host-specific fields should provide safe defaults in `all:`, such as `role: ""`, then use conditions such as `vars.role == "control-plane"`.
 
-CLI `--var` overrides remain highest precedence. For example, `--var kubernetesVersion=v1.35.6` overrides a value from `all:`.
+CLI vars files are merged after the selected node-scoped values, and `--var` overrides remain highest precedence. For example, `--var kubernetesVersion=v1.35.6` overrides a value from `all:` or any `-f` file.
 
 ### `server up` operational flags
 
@@ -229,13 +231,13 @@ deck prepare
 deck prepare --bundle-binary-source local --bundle-binary-dir ../test/artifacts/bin --bundle-binary linux/amd64 --bundle-binary linux/arm64
 deck prepare --bundle-binary-source release --bundle-binary-exclude darwin/amd64 --bundle-binary-exclude darwin/arm64
 deck prepare --bundle-binary-source release --bundle-binary-version v0.1.0 --bundle-binary linux/amd64
-deck prepare --var registryHost=mirror.local --var kubernetesVersion=v1.30.1
+deck prepare -f vars/site.yaml --var registryHost=mirror.local --var kubernetesVersion=v1.30.1
 deck bundle build --out ./bundle.tar
 deck plan --scenario apply --source local
 deck plan --scenario apply --source local -o json
-deck plan --scenario apply --source local --var role=worker
+deck plan --scenario apply --source local -f vars/worker.yaml --var role=worker
 deck apply --scenario apply --source local
-deck apply --scenario apply --source local --var role=control-plane --var nodeIP=10.0.0.10
+deck apply --scenario apply --source local -f vars/cp1.yaml --var role=control-plane --var nodeIP=10.0.0.10
 deck cache clean --older-than 30d --dry-run
 ```
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -159,7 +159,7 @@ To enable completion for all future shell sessions, add the sourcing command to 
 
 `prepare`, `plan`, and `apply` support repeatable `-f, --vars-file` YAML overlays and repeatable `--var key=value` overrides for one invocation.
 
-Use these when you want to test a different site value without editing `workflows/vars.yaml` or the scenario file itself. Vars files are merged on top of `workflows/vars.yaml` in the order provided, then `--var` overrides are applied last.
+Use these when you want to test a different site value without editing `workflows/vars.yaml` or the scenario file itself. Vars files are merged on top of `workflows/vars.yaml` in the order provided before node-scoped `all:` and `hosts:` values are selected, then workflow `vars:` and final `--var` overrides are applied.
 
 ```bash
 deck prepare -f vars/site.yaml --var registryHost=mirror.local --var kubernetesVersion=v1.30.1
@@ -185,7 +185,7 @@ hosts:
 
 If the hostname is not listed, these commands still run with ordinary `vars.yaml` values and `all:` values. Workflows that branch on host-specific fields should provide safe defaults in `all:`, such as `role: ""`, then use conditions such as `vars.role == "control-plane"`.
 
-CLI vars files are merged after the selected node-scoped values, and `--var` overrides remain highest precedence. For example, `--var kubernetesVersion=v1.35.6` overrides a value from `all:` or any `-f` file.
+CLI vars files are merged into shared vars before the selected node-scoped values, and `--var` overrides remain highest precedence. For example, `--var kubernetesVersion=v1.35.6` overrides a value from `all:` or any `-f` file.
 
 ### `server up` operational flags
 

--- a/docs/reference/workflow-model.md
+++ b/docs/reference/workflow-model.md
@@ -70,8 +70,8 @@ Variables, runtime values, and execution context come from distinct sources:
 Static `vars` flow from four sources, in order of precedence:
 
 1. CLI `--var` overrides
-2. CLI `-f, --vars-file` overlays
-3. `vars:` block in the scenario file
+2. `vars:` block in the scenario file
+3. CLI `-f, --vars-file` overlays merged into shared vars before node-scoped selection
 4. `workflows/vars.yaml` shared defaults
 
 `deck lint`, `deck prepare`, `deck plan`, and `deck apply` also support node-scoped shared variables in `workflows/vars.yaml`. When `hosts:` is present, deck detects the local hostname at execution time, applies optional `all:` values as shared defaults, and merges the matching host entry into top-level `vars`. If the hostname is not listed, execution continues with ordinary `vars.yaml` values and `all:` values.
@@ -93,14 +93,13 @@ hosts:
     role: worker
 ```
 
-For `deck lint`, `deck prepare`, `deck plan`, and `deck apply`, the effective variable precedence is:
+For `deck lint`, `deck prepare`, `deck plan`, and `deck apply`, deck first builds the shared vars document from `workflows/vars.yaml` plus any `-f, --vars-file` overlays supplied to `prepare`, `plan`, or `apply`. Later vars files override earlier files with the same deep-merge behavior as `vars.yaml`. The effective variable precedence is:
 
-1. ordinary `workflows/vars.yaml` values, excluding `all` and `hosts` when `hosts:` is present
-2. `workflows/vars.yaml` `all:` values
-3. selected host values from `hosts.<hostname>`
+1. ordinary shared vars values, excluding `all` and `hosts` when `hosts:` is present
+2. shared vars `all:` values
+3. selected host values from shared vars `hosts.<hostname>`
 4. selected workflow or scenario `vars:` values
-5. CLI `-f, --vars-file` overlays for `prepare`, `plan`, and `apply`, in the order provided
-6. CLI `--var` overrides
+5. CLI `--var` overrides
 
 Hostname matching tries the detected hostname first, then the short hostname before the first `.`. Missing host entries are not fatal. Workflows that branch on host-specific fields should provide safe defaults in `all:`, such as `role: ""`, then use conditions such as `vars.role == "control-plane"`.
 
@@ -126,7 +125,7 @@ vars:
 deck apply --scenario apply -f vars/site.yaml -f vars/cp1.yaml
 ```
 
-Vars file paths are relative to the same `workflows/` location that contains `vars.yaml`. Local `-f vars/site.yaml` resolves to `workflows/vars/site.yaml`; remote workflows resolve the same relative path from the remote `workflows/` URL. Later files override earlier files with the same deep-merge behavior as `vars.yaml`, and `--var` remains the final override.
+Vars file paths are relative to the same `workflows/` location that contains `vars.yaml`. Local `-f vars/site.yaml` resolves to `workflows/vars/site.yaml`; remote workflows resolve the same relative path from the remote `workflows/` URL. Deck deep-merges these files into `workflows/vars.yaml` before extracting `all:` and `hosts:` node-scoped values. `--var` remains the final override.
 
 **Template interpolation** — use `{{ .vars.NAME }}` inside string fields:
 

--- a/docs/reference/workflow-model.md
+++ b/docs/reference/workflow-model.md
@@ -67,11 +67,12 @@ steps:
 
 Variables, runtime values, and execution context come from distinct sources:
 
-Static `vars` flow from three sources, in order of precedence:
+Static `vars` flow from four sources, in order of precedence:
 
 1. CLI `--var` overrides
-2. `vars:` block in the scenario file
-3. `workflows/vars.yaml` shared defaults
+2. CLI `-f, --vars-file` overlays
+3. `vars:` block in the scenario file
+4. `workflows/vars.yaml` shared defaults
 
 `deck lint`, `deck prepare`, `deck plan`, and `deck apply` also support node-scoped shared variables in `workflows/vars.yaml`. When `hosts:` is present, deck detects the local hostname at execution time, applies optional `all:` values as shared defaults, and merges the matching host entry into top-level `vars`. If the hostname is not listed, execution continues with ordinary `vars.yaml` values and `all:` values.
 
@@ -98,7 +99,8 @@ For `deck lint`, `deck prepare`, `deck plan`, and `deck apply`, the effective va
 2. `workflows/vars.yaml` `all:` values
 3. selected host values from `hosts.<hostname>`
 4. selected workflow or scenario `vars:` values
-5. CLI `--var` overrides
+5. CLI `-f, --vars-file` overlays for `prepare`, `plan`, and `apply`, in the order provided
+6. CLI `--var` overrides
 
 Hostname matching tries the detected hostname first, then the short hostname before the first `.`. Missing host entries are not fatal. Workflows that branch on host-specific fields should provide safe defaults in `all:`, such as `role: ""`, then use conditions such as `vars.role == "control-plane"`.
 
@@ -117,6 +119,14 @@ version: v1alpha1
 vars:
   clusterName: staging-k8s   # overrides vars.yaml
 ```
+
+**CLI vars files** — overlay site or node values without editing `workflows/vars.yaml`:
+
+```bash
+deck apply --scenario apply -f vars/site.yaml -f vars/cp1.yaml
+```
+
+Vars file paths are relative to the same `workflows/` location that contains `vars.yaml`. Local `-f vars/site.yaml` resolves to `workflows/vars/site.yaml`; remote workflows resolve the same relative path from the remote `workflows/` URL. Later files override earlier files with the same deep-merge behavior as `vars.yaml`, and `--var` remains the final override.
 
 **Template interpolation** — use `{{ .vars.NAME }}` inside string fields:
 

--- a/docs/reference/workflow-model.md
+++ b/docs/reference/workflow-model.md
@@ -125,7 +125,13 @@ vars:
 deck apply --scenario apply -f vars/site.yaml -f vars/cp1.yaml
 ```
 
-Vars file paths are relative to the same `workflows/` location that contains `vars.yaml`. Local `-f vars/site.yaml` resolves to `workflows/vars/site.yaml`; remote workflows resolve the same relative path from the remote `workflows/` URL. Deck deep-merges these files into `workflows/vars.yaml` before extracting `all:` and `hosts:` node-scoped values. `--var` remains the final override.
+Vars file paths are relative to the same `workflows/` location that contains `vars.yaml`.
+
+- For local workflows, `-f vars/site.yaml` resolves to `workflows/vars/site.yaml`.
+- For remote workflows, the same relative path is resolved from the remote `workflows/` URL.
+- Later files override earlier files with the same deep-merge behavior as `vars.yaml`.
+- Deck extracts `all:` and `hosts:` node-scoped values after vars-file overlays are merged.
+- `--var` remains the final override with the highest precedence.
 
 **Template interpolation** — use `{{ .vars.NAME }}` inside string fields:
 

--- a/internal/applycli/command.go
+++ b/internal/applycli/command.go
@@ -20,6 +20,7 @@ type PlanCommandOptions struct {
 	Output          string
 	Fresh           bool
 	VarOverrides    map[string]any
+	VarsFiles       []string
 	Hostname        string
 	DetectHostname  func() (string, error)
 	Verbosef        func(level int, format string, args ...any) error
@@ -37,6 +38,7 @@ type ApplyCommandOptions struct {
 	Fresh          bool
 	DryRun         bool
 	VarOverrides   map[string]any
+	VarsFiles      []string
 	Hostname       string
 	DetectHostname func() (string, error)
 	Verbosef       func(level int, format string, args ...any) error
@@ -61,6 +63,7 @@ func RunPlanCommand(ctx context.Context, opts PlanCommandOptions) error {
 		CommandName:                  "diff",
 		WorkflowPath:                 strings.TrimSpace(opts.WorkflowPath),
 		VarOverrides:                 opts.VarOverrides,
+		VarsFiles:                    append([]string(nil), opts.VarsFiles...),
 		NodeScopedVars:               true,
 		Hostname:                     opts.Hostname,
 		DetectHostname:               opts.DetectHostname,
@@ -101,6 +104,7 @@ func RunApplyCommand(ctx context.Context, opts ApplyCommandOptions) error {
 		WorkflowPath:                 strings.TrimSpace(opts.WorkflowPath),
 		AllowRemoteWorkflow:          true,
 		VarOverrides:                 opts.VarOverrides,
+		VarsFiles:                    append([]string(nil), opts.VarsFiles...),
 		NodeScopedVars:               true,
 		Hostname:                     opts.Hostname,
 		DetectHostname:               opts.DetectHostname,

--- a/internal/applycli/request.go
+++ b/internal/applycli/request.go
@@ -33,6 +33,7 @@ type ExecutionRequestOptions struct {
 	AllowRemoteWorkflow          bool
 	NormalizeLocalWorkflowPath   bool
 	VarOverrides                 map[string]any
+	VarsFiles                    []string
 	NodeScopedVars               bool
 	Hostname                     string
 	DetectHostname               func() (string, error)
@@ -90,6 +91,7 @@ func ResolveExecutionRequest(ctx context.Context, opts ExecutionRequestOptions) 
 
 	wf, err := config.LoadWithOptions(ctx, workflowPath, config.LoadOptions{
 		VarOverrides:   opts.VarOverrides,
+		VarsFiles:      append([]string(nil), opts.VarsFiles...),
 		NodeScopedVars: opts.NodeScopedVars,
 		Hostname:       opts.Hostname,
 		DetectHostname: opts.DetectHostname,

--- a/internal/config/loader.go
+++ b/internal/config/loader.go
@@ -52,16 +52,16 @@ func LoadWithOptions(ctx context.Context, source string, opts LoadOptions) (*Wor
 	if err != nil {
 		return nil, err
 	}
-	varsFileOverlays, err := loadVarsFileOverlays(ctx, origin, opts)
+	sharedVars, err := loadSharedVars(ctx, origin, baseVars, opts)
 	if err != nil {
 		return nil, err
 	}
-	baseVarsForMerge := baseVars
+	baseVarsForMerge := sharedVars
 	allVars := map[string]any(nil)
 	hostVars := map[string]any(nil)
 	if opts.NodeScopedVars {
 		var scoped bool
-		baseVarsForMerge, allVars, hostVars, scoped, err = resolveNodeScopedVars(baseVars, opts)
+		baseVarsForMerge, allVars, hostVars, scoped, err = resolveNodeScopedVars(sharedVars, opts)
 		if err != nil {
 			return nil, err
 		}
@@ -76,9 +76,6 @@ func LoadWithOptions(ctx context.Context, source string, opts LoadOptions) (*Wor
 	mergeVars(effectiveVars, allVars)
 	mergeVars(effectiveVars, hostVars)
 	mergeVars(effectiveVars, resolved.Vars)
-	for _, overlay := range varsFileOverlays {
-		mergeVars(effectiveVars, overlay)
-	}
 	mergeVars(effectiveVars, opts.VarOverrides)
 
 	resolved.Vars = effectiveVars

--- a/internal/config/loader.go
+++ b/internal/config/loader.go
@@ -16,6 +16,7 @@ import (
 
 type LoadOptions struct {
 	VarOverrides   map[string]any
+	VarsFiles      []string
 	NodeScopedVars bool
 	Hostname       string
 	DetectHostname func() (string, error)
@@ -51,6 +52,10 @@ func LoadWithOptions(ctx context.Context, source string, opts LoadOptions) (*Wor
 	if err != nil {
 		return nil, err
 	}
+	varsFileOverlays, err := loadVarsFileOverlays(ctx, origin, opts)
+	if err != nil {
+		return nil, err
+	}
 	baseVarsForMerge := baseVars
 	allVars := map[string]any(nil)
 	hostVars := map[string]any(nil)
@@ -71,6 +76,9 @@ func LoadWithOptions(ctx context.Context, source string, opts LoadOptions) (*Wor
 	mergeVars(effectiveVars, allVars)
 	mergeVars(effectiveVars, hostVars)
 	mergeVars(effectiveVars, resolved.Vars)
+	for _, overlay := range varsFileOverlays {
+		mergeVars(effectiveVars, overlay)
+	}
 	mergeVars(effectiveVars, opts.VarOverrides)
 
 	resolved.Vars = effectiveVars

--- a/internal/config/loader_test.go
+++ b/internal/config/loader_test.go
@@ -160,7 +160,7 @@ hosts:
 `), 0o644); err != nil {
 		t.Fatalf("write site vars: %v", err)
 	}
-	if err := os.WriteFile(workflowPath, []byte("version: v1alpha1\nvars:\n  role: workflow\nphases: []\n"), 0o644); err != nil {
+	if err := os.WriteFile(workflowPath, []byte("version: v1alpha1\nvars:\n  workflowOnly: present\nphases: []\n"), 0o644); err != nil {
 		t.Fatalf("write workflow: %v", err)
 	}
 
@@ -170,6 +170,9 @@ hosts:
 	}
 	if got := wf.Vars["role"]; got != "worker" {
 		t.Fatalf("expected vars-file host overlay to win, got %#v", got)
+	}
+	if got := wf.Vars["workflowOnly"]; got != "present" {
+		t.Fatalf("expected workflow var to survive, got %#v", got)
 	}
 	if got := wf.Vars["site"]; got != "lab-a" {
 		t.Fatalf("expected vars-file all overlay, got %#v", got)
@@ -452,8 +455,8 @@ func TestVarsURLFetch(t *testing.T) {
 		if err != nil {
 			t.Fatalf("LoadWithOptions failed: %v", err)
 		}
-		if got := wf.Vars["mode"]; got != "site" {
-			t.Fatalf("expected remote vars-file overlay, got %#v", got)
+		if got := wf.Vars["mode"]; got != "workflow" {
+			t.Fatalf("expected workflow vars to override remote vars-file overlay, got %#v", got)
 		}
 		if got := wf.Vars["region"]; got != "lab" {
 			t.Fatalf("expected base vars.yaml value, got %#v", got)

--- a/internal/config/loader_test.go
+++ b/internal/config/loader_test.go
@@ -92,6 +92,93 @@ func TestVarsDeepMerge(t *testing.T) {
 	}
 }
 
+func TestVarsFilesOverlayBaseWorkflowAndCLI(t *testing.T) {
+	root := t.TempDir()
+	workflowDir := filepath.Join(root, "workflows", "scenarios")
+	if err := os.MkdirAll(filepath.Join(root, "workflows", "vars"), 0o755); err != nil {
+		t.Fatalf("mkdir vars dir: %v", err)
+	}
+	workflowPath := filepath.Join(workflowDir, "apply.yaml")
+	if err := os.MkdirAll(filepath.Dir(workflowPath), 0o755); err != nil {
+		t.Fatalf("mkdir workflow dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "workflows", "vars.yaml"), []byte("registry:\n  host: base.example.invalid\n  port: 5000\nmode: base\n"), 0o644); err != nil {
+		t.Fatalf("write vars.yaml: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "workflows", "vars", "site.yaml"), []byte("registry:\n  host: site.example.invalid\nsiteOnly: site\n"), 0o644); err != nil {
+		t.Fatalf("write site vars: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "workflows", "vars", "node.yaml"), []byte("registry:\n  port: 5443\nmode: node\n"), 0o644); err != nil {
+		t.Fatalf("write node vars: %v", err)
+	}
+	if err := os.WriteFile(workflowPath, []byte("version: v1alpha1\nvars:\n  mode: workflow\n  workflowOnly: present\nphases: []\n"), 0o644); err != nil {
+		t.Fatalf("write workflow: %v", err)
+	}
+
+	wf, err := LoadWithOptions(context.Background(), workflowPath, LoadOptions{
+		VarsFiles:    []string{"vars/site.yaml", "vars/node.yaml"},
+		VarOverrides: map[string]any{"mode": "cli"},
+	})
+	if err != nil {
+		t.Fatalf("LoadWithOptions failed: %v", err)
+	}
+
+	registry, ok := wf.Vars["registry"].(map[string]any)
+	if !ok {
+		t.Fatalf("registry should be a map, got %#v", wf.Vars["registry"])
+	}
+	if got := registry["host"]; got != "site.example.invalid" {
+		t.Fatalf("expected vars-file host override, got %#v", got)
+	}
+	if got := registry["port"]; got != 5443 {
+		t.Fatalf("expected later vars-file port override, got %#v", got)
+	}
+	if got := wf.Vars["mode"]; got != "cli" {
+		t.Fatalf("expected CLI override to win, got %#v", got)
+	}
+	if got := wf.Vars["workflowOnly"]; got != "present" {
+		t.Fatalf("expected workflow var to survive, got %#v", got)
+	}
+	if got := wf.Vars["siteOnly"]; got != "site" {
+		t.Fatalf("expected vars-file-only value, got %#v", got)
+	}
+}
+
+func TestVarsFileOverlaySupportsNodeScopedVars(t *testing.T) {
+	dir := t.TempDir()
+	workflowPath := filepath.Join(dir, "apply.yaml")
+	if err := os.WriteFile(filepath.Join(dir, "vars.yaml"), []byte("role: base\n"), 0o644); err != nil {
+		t.Fatalf("write vars.yaml: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "site.yaml"), []byte(`all:
+  site: lab-a
+hosts:
+  node-a:
+    role: worker
+  node-b:
+    role: control-plane
+`), 0o644); err != nil {
+		t.Fatalf("write site vars: %v", err)
+	}
+	if err := os.WriteFile(workflowPath, []byte("version: v1alpha1\nvars:\n  role: workflow\nphases: []\n"), 0o644); err != nil {
+		t.Fatalf("write workflow: %v", err)
+	}
+
+	wf, err := LoadWithOptions(context.Background(), workflowPath, LoadOptions{NodeScopedVars: true, Hostname: "node-a", VarsFiles: []string{"site.yaml"}})
+	if err != nil {
+		t.Fatalf("LoadWithOptions failed: %v", err)
+	}
+	if got := wf.Vars["role"]; got != "worker" {
+		t.Fatalf("expected vars-file host overlay to win, got %#v", got)
+	}
+	if got := wf.Vars["site"]; got != "lab-a" {
+		t.Fatalf("expected vars-file all overlay, got %#v", got)
+	}
+	if _, ok := wf.Vars["hosts"]; ok {
+		t.Fatalf("did not expect hosts key to leak into effective vars: %#v", wf.Vars)
+	}
+}
+
 func TestVarsOverridesDeepMerge(t *testing.T) {
 	dir := t.TempDir()
 	workflowPath := filepath.Join(dir, "apply.yaml")
@@ -345,6 +432,33 @@ func TestVarsURLFetch(t *testing.T) {
 			t.Fatalf("workflow vars missing, got %v", got)
 		}
 	})
+
+	t.Run("loads vars file overlays relative to remote workflows root", func(t *testing.T) {
+		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			switch r.URL.Path {
+			case "/workflows/scenarios/apply.yaml":
+				_, _ = w.Write([]byte("version: v1alpha1\nvars:\n  mode: workflow\nphases: []\n"))
+			case "/workflows/vars.yaml":
+				_, _ = w.Write([]byte("mode: base\nregion: lab\n"))
+			case "/workflows/vars/site.yaml":
+				_, _ = w.Write([]byte("mode: site\n"))
+			default:
+				http.NotFound(w, r)
+			}
+		}))
+		defer ts.Close()
+
+		wf, err := LoadWithOptions(context.Background(), ts.URL+"/workflows/scenarios/apply.yaml", LoadOptions{VarsFiles: []string{"vars/site.yaml"}})
+		if err != nil {
+			t.Fatalf("LoadWithOptions failed: %v", err)
+		}
+		if got := wf.Vars["mode"]; got != "site" {
+			t.Fatalf("expected remote vars-file overlay, got %#v", got)
+		}
+		if got := wf.Vars["region"]; got != "lab" {
+			t.Fatalf("expected base vars.yaml value, got %#v", got)
+		}
+	})
 }
 
 func TestLoadRejectsBothPhasesAndSteps(t *testing.T) {
@@ -420,6 +534,36 @@ func TestStateKey(t *testing.T) {
 
 		if wf1.StateKey == wf2.StateKey {
 			t.Fatalf("expected state key to change when --var override changes")
+		}
+	})
+
+	t.Run("changes when vars file overlay changes", func(t *testing.T) {
+		dir := t.TempDir()
+		workflowPath := filepath.Join(dir, "apply.yaml")
+		workflowContent := []byte("version: v1alpha1\nphases: []\n")
+		if err := os.WriteFile(workflowPath, workflowContent, 0o644); err != nil {
+			t.Fatalf("write workflow: %v", err)
+		}
+		if err := os.WriteFile(filepath.Join(dir, "vars.yaml"), []byte("name: base\n"), 0o644); err != nil {
+			t.Fatalf("write vars.yaml: %v", err)
+		}
+		if err := os.WriteFile(filepath.Join(dir, "overlay-a.yaml"), []byte("name: overlay-a\n"), 0o644); err != nil {
+			t.Fatalf("write overlay-a: %v", err)
+		}
+		if err := os.WriteFile(filepath.Join(dir, "overlay-b.yaml"), []byte("name: overlay-b\n"), 0o644); err != nil {
+			t.Fatalf("write overlay-b: %v", err)
+		}
+
+		wf1, err := LoadWithOptions(context.Background(), workflowPath, LoadOptions{VarsFiles: []string{"overlay-a.yaml"}})
+		if err != nil {
+			t.Fatalf("LoadWithOptions(context.Background(), overlay-a) failed: %v", err)
+		}
+		wf2, err := LoadWithOptions(context.Background(), workflowPath, LoadOptions{VarsFiles: []string{"overlay-b.yaml"}})
+		if err != nil {
+			t.Fatalf("LoadWithOptions(context.Background(), overlay-b) failed: %v", err)
+		}
+		if wf1.StateKey == wf2.StateKey {
+			t.Fatalf("expected state key to change when vars file overlay changes")
 		}
 	})
 

--- a/internal/config/vars.go
+++ b/internal/config/vars.go
@@ -3,9 +3,11 @@ package config
 import (
 	"context"
 	"fmt"
+	"net/url"
 	"os"
 	"path"
 	"path/filepath"
+	"strings"
 
 	"gopkg.in/yaml.v3"
 
@@ -16,13 +18,7 @@ import (
 
 func loadBaseVars(ctx context.Context, origin workflowOrigin) (map[string]any, error) {
 	if origin.localPath != "" {
-		workflowRoot, err := WorkflowRootForPath(origin.localPath)
-		varsPath := ""
-		if err == nil {
-			varsPath = filepath.Join(workflowRoot, workspacepaths.WorkflowVarsRel)
-		} else {
-			varsPath = filepath.Join(filepath.Dir(origin.localPath), workspacepaths.WorkflowVarsRel)
-		}
+		varsPath := localVarsPath(origin)
 		root, err := fsutil.NewRoot(filepath.Dir(varsPath))
 		if err != nil {
 			return nil, err
@@ -38,12 +34,7 @@ func loadBaseVars(ctx context.Context, origin workflowOrigin) (map[string]any, e
 	}
 
 	if origin.remoteURL != nil {
-		workflowRoot, err := remoteWorkflowRoot(origin.remoteURL)
-		varsURL := *siblingURL(origin.remoteURL, workspacepaths.WorkflowVarsRel)
-		if err == nil {
-			varsURL = *workflowRoot
-			varsURL.Path = path.Join(varsURL.Path, workspacepaths.WorkflowVarsRel)
-		}
+		varsURL := remoteVarsURL(origin)
 		b, ok, err := getOptionalHTTP(ctx, varsURL.String())
 		if err != nil {
 			return nil, err
@@ -55,6 +46,97 @@ func loadBaseVars(ctx context.Context, origin workflowOrigin) (map[string]any, e
 	}
 
 	return map[string]any{}, nil
+}
+
+func loadVarsFileOverlays(ctx context.Context, origin workflowOrigin, opts LoadOptions) ([]map[string]any, error) {
+	if len(opts.VarsFiles) == 0 {
+		return nil, nil
+	}
+	overlays := make([]map[string]any, 0, len(opts.VarsFiles))
+	for _, rawPath := range opts.VarsFiles {
+		vars, err := loadVarsFile(ctx, origin, rawPath)
+		if err != nil {
+			return nil, err
+		}
+		if opts.NodeScopedVars {
+			ordinary, allVars, hostVars, scoped, err := resolveNodeScopedVars(vars, opts)
+			if err != nil {
+				return nil, err
+			}
+			if scoped {
+				merged := map[string]any{}
+				mergeVars(merged, ordinary)
+				mergeVars(merged, allVars)
+				mergeVars(merged, hostVars)
+				overlays = append(overlays, merged)
+				continue
+			}
+		}
+		overlays = append(overlays, vars)
+	}
+	return overlays, nil
+}
+
+func loadVarsFile(ctx context.Context, origin workflowOrigin, rawPath string) (map[string]any, error) {
+	varsFile, err := normalizeVarsFileRef(rawPath)
+	if err != nil {
+		return nil, err
+	}
+	if origin.localPath != "" {
+		varsPath := localVarsPath(origin)
+		root, err := fsutil.NewRoot(filepath.Dir(varsPath))
+		if err != nil {
+			return nil, err
+		}
+		b, _, err := root.ReadFile(filepath.FromSlash(varsFile))
+		if err != nil {
+			return nil, fmt.Errorf("read vars file %q: %w", rawPath, err)
+		}
+		return parseVarsYAML(b)
+	}
+	if origin.remoteURL != nil {
+		varsURL := remoteVarsURL(origin)
+		varsURL.Path = path.Join(path.Dir(varsURL.Path), varsFile)
+		b, err := getRequiredHTTP(ctx, varsURL.String())
+		if err != nil {
+			return nil, fmt.Errorf("read vars file %q: %w", rawPath, err)
+		}
+		return parseVarsYAML(b)
+	}
+	return map[string]any{}, nil
+}
+
+func localVarsPath(origin workflowOrigin) string {
+	workflowRoot, err := WorkflowRootForPath(origin.localPath)
+	if err == nil {
+		return filepath.Join(workflowRoot, workspacepaths.WorkflowVarsRel)
+	}
+	return filepath.Join(filepath.Dir(origin.localPath), workspacepaths.WorkflowVarsRel)
+}
+
+func remoteVarsURL(origin workflowOrigin) url.URL {
+	workflowRoot, err := remoteWorkflowRoot(origin.remoteURL)
+	varsURL := *siblingURL(origin.remoteURL, workspacepaths.WorkflowVarsRel)
+	if err == nil {
+		varsURL = *workflowRoot
+		varsURL.Path = path.Join(varsURL.Path, workspacepaths.WorkflowVarsRel)
+	}
+	return varsURL
+}
+
+func normalizeVarsFileRef(rawPath string) (string, error) {
+	trimmed := strings.TrimSpace(strings.ReplaceAll(rawPath, "\\", "/"))
+	if trimmed == "" {
+		return "", fmt.Errorf("vars file path is empty")
+	}
+	if strings.HasPrefix(trimmed, "/") || strings.Contains(trimmed, "://") {
+		return "", fmt.Errorf("vars file path must be relative to %s/: %s", workspacepaths.WorkflowRootDir, rawPath)
+	}
+	cleaned := path.Clean(trimmed)
+	if cleaned == "." || cleaned == "" || cleaned == ".." || strings.HasPrefix(cleaned, "../") {
+		return "", fmt.Errorf("vars file path must stay under %s/: %s", workspacepaths.WorkflowRootDir, rawPath)
+	}
+	return cleaned, nil
 }
 
 func parseVarsYAML(content []byte) (map[string]any, error) {

--- a/internal/config/vars.go
+++ b/internal/config/vars.go
@@ -48,33 +48,16 @@ func loadBaseVars(ctx context.Context, origin workflowOrigin) (map[string]any, e
 	return map[string]any{}, nil
 }
 
-func loadVarsFileOverlays(ctx context.Context, origin workflowOrigin, opts LoadOptions) ([]map[string]any, error) {
-	if len(opts.VarsFiles) == 0 {
-		return nil, nil
-	}
-	overlays := make([]map[string]any, 0, len(opts.VarsFiles))
+func loadSharedVars(ctx context.Context, origin workflowOrigin, baseVars map[string]any, opts LoadOptions) (map[string]any, error) {
+	sharedVars := cloneVars(baseVars)
 	for _, rawPath := range opts.VarsFiles {
 		vars, err := loadVarsFile(ctx, origin, rawPath)
 		if err != nil {
 			return nil, err
 		}
-		if opts.NodeScopedVars {
-			ordinary, allVars, hostVars, scoped, err := resolveNodeScopedVars(vars, opts)
-			if err != nil {
-				return nil, err
-			}
-			if scoped {
-				merged := map[string]any{}
-				mergeVars(merged, ordinary)
-				mergeVars(merged, allVars)
-				mergeVars(merged, hostVars)
-				overlays = append(overlays, merged)
-				continue
-			}
-		}
-		overlays = append(overlays, vars)
+		mergeVars(sharedVars, vars)
 	}
-	return overlays, nil
+	return sharedVars, nil
 }
 
 func loadVarsFile(ctx context.Context, origin workflowOrigin, rawPath string) (map[string]any, error) {

--- a/internal/lintcli/service.go
+++ b/internal/lintcli/service.go
@@ -8,7 +8,6 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/Airgap-Castaways/deck/internal/config"
 	"github.com/Airgap-Castaways/deck/internal/logs"
 	"github.com/Airgap-Castaways/deck/internal/validate"
 	"github.com/Airgap-Castaways/deck/internal/workspacepaths"
@@ -56,6 +55,7 @@ type Options struct {
 	File            string
 	Scenario        string
 	Output          string
+	VarsFiles       []string
 	Verbosef        func(level int, format string, args ...any) error
 	StdoutPrintf    func(format string, args ...any) error
 	JSONEncoderFunc func() *json.Encoder
@@ -102,12 +102,12 @@ func BuildReport(ctx context.Context, opts Options) (Report, error) {
 	if resolvedRoot == "" {
 		resolvedRoot = "."
 	}
-	if err := verboseEvent(opts.Verbosef, 1, logs.CLIEvent{Component: "lint", Event: "lint_requested", Attrs: map[string]any{"root": resolvedRoot, "file": resolvedFile, "scenario": resolvedScenario}}); err != nil {
+	if err := verboseEvent(opts.Verbosef, 1, logs.CLIEvent{Component: "lint", Event: "lint_requested", Attrs: map[string]any{"root": resolvedRoot, "workflow": resolvedFile, "scenario": resolvedScenario}}); err != nil {
 		return Report{}, err
 	}
 	if resolvedScenario != "" {
 		if resolvedFile != "" {
-			return Report{}, fmt.Errorf("lint accepts either --file or a scenario name, not both")
+			return Report{}, fmt.Errorf("lint accepts either --workflow or a scenario name, not both")
 		}
 		resolvedPath, err := resolveScenarioPath(resolvedRoot, resolvedScenario, opts.WorkflowRootDir, opts.ScenarioDirName)
 		if err != nil {
@@ -116,7 +116,7 @@ func BuildReport(ctx context.Context, opts Options) (Report, error) {
 		if err := verboseEvent(opts.Verbosef, 1, logs.CLIEvent{Component: "lint", Event: "entrypoint_selected", Attrs: map[string]any{"entrypoint": resolvedPath}}); err != nil {
 			return Report{}, err
 		}
-		files, err := validate.EntrypointWithContext(ctx, resolvedPath)
+		files, err := validate.EntrypointWithOptions(ctx, resolvedPath, validate.Options{VarsFiles: opts.VarsFiles})
 		if err != nil {
 			return Report{}, err
 		}
@@ -130,25 +130,18 @@ func BuildReport(ctx context.Context, opts Options) (Report, error) {
 			if err := verboseEvent(opts.Verbosef, 1, logs.CLIEvent{Component: "lint", Event: "entrypoint_selected", Attrs: map[string]any{"entrypoint": resolvedFile}}); err != nil {
 				return Report{}, err
 			}
-			files, err := validate.EntrypointWithContext(ctx, resolvedFile)
+			files, err := validate.EntrypointWithOptions(ctx, resolvedFile, validate.Options{VarsFiles: opts.VarsFiles})
 			if err != nil {
 				return Report{}, err
 			}
 			return finalizeReport(ctx, Report{Mode: "entrypoint", Entrypoint: resolvedFile, Workflows: files, Summary: Summary{WorkflowCount: len(files)}})
 		}
-		if err := validate.FileWithContext(ctx, resolvedFile); err != nil {
-			return Report{}, err
-		}
-		wf, err := config.Load(ctx, resolvedFile)
-		if err != nil {
-			return Report{}, err
-		}
-		if err := validate.Workflow(resolvedFile, wf); err != nil {
+		if err := validate.FileWithOptions(ctx, resolvedFile, validate.Options{VarsFiles: opts.VarsFiles}); err != nil {
 			return Report{}, err
 		}
 		return finalizeReport(ctx, Report{Mode: "file", Entrypoint: resolvedFile, Workflows: []string{resolvedFile}, Summary: Summary{WorkflowCount: 1}})
 	}
-	files, err := validate.WorkspaceWithContext(ctx, resolvedRoot)
+	files, err := validate.WorkspaceWithOptions(ctx, resolvedRoot, validate.Options{VarsFiles: opts.VarsFiles})
 	if err != nil {
 		return Report{}, err
 	}

--- a/internal/preparecli/service.go
+++ b/internal/preparecli/service.go
@@ -29,6 +29,7 @@ type Options struct {
 	Binaries          []string
 	BinaryExcludes    []string
 	VarOverrides      map[string]any
+	VarsFiles         []string
 	Stdout            io.Writer
 	Diagnosticf       func(level int, format string, args ...any) error
 	EventSink         prepare.StepEventSink
@@ -102,7 +103,7 @@ func Run(ctx context.Context, opts Options) error {
 		},
 		Paths: workflowcontext.Paths{BundleRoot: preparedRoot.Abs(), OutputRoot: preparedRoot.Abs()},
 	}
-	prepareWorkflow, err := config.LoadWithOptions(ctx, prepareWorkflowPath, config.LoadOptions{VarOverrides: opts.VarOverrides, NodeScopedVars: true})
+	prepareWorkflow, err := config.LoadWithOptions(ctx, prepareWorkflowPath, config.LoadOptions{VarOverrides: opts.VarOverrides, VarsFiles: opts.VarsFiles, NodeScopedVars: true})
 	if err != nil {
 		return err
 	}

--- a/internal/validate/validate.go
+++ b/internal/validate/validate.go
@@ -38,6 +38,10 @@ type componentFragment struct {
 	Steps []config.Step `yaml:"steps"`
 }
 
+type Options struct {
+	VarsFiles []string
+}
+
 // File validates workflow structure and semantic rules.
 // It is a convenience wrapper for CLI-style callers that do not own a request context.
 func File(path string) error {
@@ -58,6 +62,38 @@ func FileWithContext(ctx context.Context, path string) error {
 	return withWorkflowName(path, Bytes(path, content))
 }
 
+func FileWithOptions(ctx context.Context, path string, opts Options) error {
+	if ctx == nil {
+		return fmt.Errorf("context is nil")
+	}
+	if path == "" {
+		return fmt.Errorf("file path is empty")
+	}
+	content, err := fsutil.ReadFile(path)
+	if err != nil {
+		return fmt.Errorf("read workflow file: %w", err)
+	}
+	if err := validateSingleBraceTemplates(path, content); err != nil {
+		return withWorkflowName(path, err)
+	}
+	kind := detectDocumentKind(path)
+	if err := validateSchema(path, content, kind); err != nil {
+		return withWorkflowName(path, err)
+	}
+	if kind == documentKindComponentFragment {
+		fragment, err := parseComponentFragment(content)
+		if err != nil {
+			return withWorkflowName(path, err)
+		}
+		return withWorkflowName(path, validateComponentFragment(path, fragment))
+	}
+	wf, err := config.LoadWithOptions(ctx, path, config.LoadOptions{VarsFiles: append([]string(nil), opts.VarsFiles...), NodeScopedVars: true})
+	if err != nil {
+		return withWorkflowName(path, err)
+	}
+	return Workflow(path, wf)
+}
+
 // Workspace validates every scenario entrypoint under a workflow root.
 // It is a convenience wrapper for callers that do not own a request context.
 func Workspace(root string) ([]string, error) {
@@ -65,6 +101,10 @@ func Workspace(root string) ([]string, error) {
 }
 
 func WorkspaceWithContext(ctx context.Context, root string) ([]string, error) {
+	return WorkspaceWithOptions(ctx, root, Options{})
+}
+
+func WorkspaceWithOptions(ctx context.Context, root string, opts Options) ([]string, error) {
 	if ctx == nil {
 		return nil, fmt.Errorf("context is nil")
 	}
@@ -123,7 +163,7 @@ func WorkspaceWithContext(ctx context.Context, root string) ([]string, error) {
 		if err := ctx.Err(); err != nil {
 			return nil, err
 		}
-		validatedFiles, err := lintLocalEntrypoint(ctx, path, nil, workflowSupportedVersion, visited)
+		validatedFiles, err := lintLocalEntrypoint(ctx, path, nil, workflowSupportedVersion, visited, opts.VarsFiles)
 		if err != nil {
 			return nil, err
 		}
@@ -139,6 +179,10 @@ func Entrypoint(path string) ([]string, error) {
 }
 
 func EntrypointWithContext(ctx context.Context, path string) ([]string, error) {
+	return EntrypointWithOptions(ctx, path, Options{})
+}
+
+func EntrypointWithOptions(ctx context.Context, path string, opts Options) ([]string, error) {
 	if ctx == nil {
 		return nil, fmt.Errorf("context is nil")
 	}
@@ -149,7 +193,7 @@ func EntrypointWithContext(ctx context.Context, path string) ([]string, error) {
 	if err != nil {
 		return nil, fmt.Errorf("resolve workflow path: %w", err)
 	}
-	return lintLocalEntrypoint(ctx, absPath, nil, workflowSupportedVersion, map[string]bool{})
+	return lintLocalEntrypoint(ctx, absPath, nil, workflowSupportedVersion, map[string]bool{}, opts.VarsFiles)
 }
 
 func Workflow(name string, wf *config.Workflow) error {
@@ -205,7 +249,7 @@ func withWorkflowName(name string, err error) error {
 	return fmt.Errorf("%s%w", prefix, err)
 }
 
-func lintLocalEntrypoint(ctx context.Context, path string, inheritedVars map[string]any, workflowVersion string, visiting map[string]bool) ([]string, error) {
+func lintLocalEntrypoint(ctx context.Context, path string, inheritedVars map[string]any, workflowVersion string, visiting map[string]bool, varsFiles []string) ([]string, error) {
 	absPath, err := filepath.Abs(path)
 	if err != nil {
 		return nil, fmt.Errorf("resolve workflow path: %w", err)
@@ -243,7 +287,7 @@ func lintLocalEntrypoint(ctx context.Context, path string, inheritedVars map[str
 		return nil, withWorkflowName(absPath, fmt.Errorf("parse yaml: %w", err))
 	}
 
-	loadOpts := config.LoadOptions{VarOverrides: cloneAnyMap(inheritedVars), NodeScopedVars: true}
+	loadOpts := config.LoadOptions{VarOverrides: cloneAnyMap(inheritedVars), VarsFiles: append([]string(nil), varsFiles...), NodeScopedVars: true}
 	wf, err := config.LoadWithOptions(ctx, absPath, loadOpts)
 	if err != nil {
 		return nil, withWorkflowName(absPath, err)
@@ -256,7 +300,7 @@ func lintLocalEntrypoint(ctx context.Context, path string, inheritedVars map[str
 			if err != nil {
 				return nil, withWorkflowName(absPath, err)
 			}
-			files, err := lintLocalEntrypoint(ctx, child, wf.Vars, wf.Version, visiting)
+			files, err := lintLocalEntrypoint(ctx, child, wf.Vars, wf.Version, visiting, varsFiles)
 			if err != nil {
 				return nil, err
 			}

--- a/test/workflows/README.md
+++ b/test/workflows/README.md
@@ -13,7 +13,7 @@
 
 Each canonical scenario keeps scenario meaning in explicit entry workflow files instead of spreading it across harness scripts or per-scenario subdirectories:
 
-- `scenarios/<name>.yaml`, the scenario entry workflow passed to `deck lint --file` and the scenario runner
+- `scenarios/<name>.yaml`, the scenario entry workflow passed to `deck lint --workflow` and the scenario runner
 - `scenarios/<name>-verify.yaml`, explicit verification entrypoints when a scenario needs a separate verify workflow
 - `components/...`, reusable step fragments imported by the scenario entrypoints
 - `vars.yaml`, shared workflow defaults loaded automatically and overridden by scenario `vars:` blocks when needed


### PR DESCRIPTION
## Summary
- Add repeatable `-f, --vars-file` overlays to `lint`, `prepare`, `plan`, and `apply`.
- Merge vars files on top of `workflows/vars.yaml`, in flag order, before node-scoped selection, workflow vars, and final `--var` overrides.
- Support local/remote workflow-relative vars files and move explicit lint workflow selection to `--workflow`.

## Verification
- `go test ./cmd/deck -run 'TestRunWorkflowLintAndLegacyValidateMigration'`
- `go test ./internal/lintcli ./internal/validate`
- `make test`
- `make lint`
- `make verify-generated`
- `git diff --check`
- `make build && ./bin/deck --help && ./bin/deck version && ./bin/deck lint --help`