### PR TITLE
fix: document verbosity range

### DIFF
--- a/cmd/deck/help_completion_test.go
+++ b/cmd/deck/help_completion_test.go
@@ -27,6 +27,9 @@ func TestRunUsageShowsTopLevelAxes(t *testing.T) {
 			t.Fatalf("usage must include %q, got %q", section, msg)
 		}
 	}
+	if !strings.Contains(msg, "diagnostic verbosity level (0-3; higher is more detailed)") {
+		t.Fatalf("usage must include verbosity range, got %q", msg)
+	}
 	if strings.Index(msg, "Core Commands:\n") > strings.Index(msg, "Additional Commands:\n") {
 		t.Fatalf("core commands section must appear before additional commands: %q", msg)
 	}

--- a/cmd/deck/root_cobra.go
+++ b/cmd/deck/root_cobra.go
@@ -32,7 +32,7 @@ func newRootCommand(env *cliEnv) *cobra.Command {
 			return nil
 		},
 	}
-	cmd.PersistentFlags().IntVar(&env.verbosity, "v", 0, "diagnostic verbosity level")
+	cmd.PersistentFlags().IntVar(&env.verbosity, "v", 0, "diagnostic verbosity level (0-3; higher is more detailed)")
 	cmd.PersistentFlags().StringVar(&env.logFormat, "log-format", "text", "diagnostic log format (text|json)")
 
 	cmd.CompletionOptions.DisableDefaultCmd = true

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -91,7 +91,7 @@ Use [Server Audit Log](server-audit-log.md) for the current emitted record shape
 
 `deck cache list -o json` and `deck server logs -o json` keep machine-readable output on stdout while `--v=<n>` sends path and count diagnostics to stderr.
 
-Global `--v=<n>` writes diagnostics to stderr without changing stdout result contracts. Current levels follow this pattern:
+Global `--v=<n>` writes diagnostics to stderr without changing stdout result contracts. Supported levels are 0-3:
 
 - `--v=0`: result only
 - `--v=1`: workflow/source/path decisions and high-level execution context


### PR DESCRIPTION
## Summary
- Show the supported `--v` range directly in CLI help.
- Update CLI reference docs to state that verbosity levels are 0-3.
- Add help-output coverage for the verbosity range text.

## Verification
- `go test ./cmd/deck`
- `make test && make lint`