### PR TITLE
Add plan vars inspection

### DIFF
--- a/cmd/deck/apply_cli_test.go
+++ b/cmd/deck/apply_cli_test.go
@@ -186,6 +186,142 @@ phases:
 	}
 }
 
+func TestPlanVarsApplyShowsEffectiveInputs(t *testing.T) {
+	root := t.TempDir()
+	workflowDir := filepath.Join(root, "workflows")
+	scenarioDir := filepath.Join(workflowDir, "scenarios")
+	varsDir := filepath.Join(workflowDir, "vars")
+	if err := os.MkdirAll(scenarioDir, 0o755); err != nil {
+		t.Fatalf("mkdir scenarios: %v", err)
+	}
+	if err := os.MkdirAll(varsDir, 0o755); err != nil {
+		t.Fatalf("mkdir vars dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(workflowDir, "vars.yaml"), []byte("cluster: base\nmode: base\n"), 0o644); err != nil {
+		t.Fatalf("write vars.yaml: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(varsDir, "site.yaml"), []byte("mode: site\nrole: worker\n"), 0o644); err != nil {
+		t.Fatalf("write site vars: %v", err)
+	}
+	workflowPath := filepath.Join(scenarioDir, "apply.yaml")
+	writeWorkflowYAML(t, workflowPath, `version: v1alpha1
+phases:
+  - name: install
+    steps:
+      - id: capture
+        kind: CheckHost
+        register:
+          captured: passed
+        spec:
+          checks: [os]
+`)
+
+	res := execute([]string{"plan", "vars", "--workflow", workflowPath, "-f", "vars/site.yaml", "--var", "mode=cli", "-o", "json"})
+	if res.err != nil {
+		t.Fatalf("expected success, got %v", res.err)
+	}
+	var payload struct {
+		Command      string         `json:"command"`
+		WorkflowPath string         `json:"workflowPath"`
+		Vars         map[string]any `json:"vars"`
+		Context      map[string]any `json:"context"`
+		Runtime      struct {
+			Initial map[string]any `json:"initial"`
+			Planned []struct {
+				Key    string `json:"key"`
+				Step   string `json:"step"`
+				Output string `json:"output"`
+				Phase  string `json:"phase"`
+			} `json:"planned"`
+		} `json:"runtime"`
+	}
+	if err := json.Unmarshal([]byte(res.stdout), &payload); err != nil {
+		t.Fatalf("parse json: %v stdout=%q", err, res.stdout)
+	}
+	if payload.Command != "apply" || payload.WorkflowPath != workflowPath {
+		t.Fatalf("unexpected command/workflow: %+v", payload)
+	}
+	if payload.Vars["cluster"] != "base" || payload.Vars["role"] != "worker" || payload.Vars["mode"] != "cli" {
+		t.Fatalf("unexpected vars: %+v", payload.Vars)
+	}
+	if payload.Context["command"] != "apply" {
+		t.Fatalf("unexpected context: %+v", payload.Context)
+	}
+	if _, ok := payload.Runtime.Initial["host"]; !ok {
+		t.Fatalf("expected runtime.host in initial runtime: %+v", payload.Runtime.Initial)
+	}
+	if len(payload.Runtime.Planned) != 1 || payload.Runtime.Planned[0].Key != "captured" || payload.Runtime.Planned[0].Step != "capture" || payload.Runtime.Planned[0].Output != "passed" || payload.Runtime.Planned[0].Phase != "install" {
+		t.Fatalf("unexpected planned runtime: %+v", payload.Runtime.Planned)
+	}
+}
+
+func TestPlanVarsPrepareShowsEffectiveInputs(t *testing.T) {
+	root := t.TempDir()
+	workflowDir := filepath.Join(root, "workflows")
+	varsDir := filepath.Join(workflowDir, "vars")
+	if err := os.MkdirAll(varsDir, 0o755); err != nil {
+		t.Fatalf("mkdir vars dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(workflowDir, "vars.yaml"), []byte("mode: base\n"), 0o644); err != nil {
+		t.Fatalf("write vars.yaml: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(varsDir, "prepare.yaml"), []byte("mode: file\n"), 0o644); err != nil {
+		t.Fatalf("write prepare vars: %v", err)
+	}
+	writeWorkflowYAML(t, filepath.Join(workflowDir, "prepare.yaml"), `version: v1alpha1
+phases:
+  - name: prepare
+    steps:
+      - id: check-host
+        kind: CheckHost
+        register:
+          hostPassed: passed
+        spec:
+          checks: [os]
+`)
+	originalCWD, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	if err := os.Chdir(root); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+	defer func() { _ = os.Chdir(originalCWD) }()
+
+	res := execute([]string{"plan", "vars", "--command", "prepare", "-f", "vars/prepare.yaml", "--var", "mode=cli", "-o", "json"})
+	if res.err != nil {
+		t.Fatalf("expected success, got %v", res.err)
+	}
+	var payload struct {
+		Command string         `json:"command"`
+		Vars    map[string]any `json:"vars"`
+		Context map[string]any `json:"context"`
+		Runtime struct {
+			Initial map[string]any `json:"initial"`
+			Planned []struct {
+				Key    string `json:"key"`
+				Step   string `json:"step"`
+				Output string `json:"output"`
+			} `json:"planned"`
+		} `json:"runtime"`
+	}
+	if err := json.Unmarshal([]byte(res.stdout), &payload); err != nil {
+		t.Fatalf("parse json: %v stdout=%q", err, res.stdout)
+	}
+	if payload.Command != "prepare" || payload.Vars["mode"] != "cli" {
+		t.Fatalf("unexpected payload: %+v", payload)
+	}
+	if payload.Context["command"] != "prepare" {
+		t.Fatalf("unexpected context: %+v", payload.Context)
+	}
+	if _, ok := payload.Runtime.Initial["host"]; !ok {
+		t.Fatalf("expected runtime.host in initial runtime: %+v", payload.Runtime.Initial)
+	}
+	if len(payload.Runtime.Planned) != 1 || payload.Runtime.Planned[0].Key != "hostPassed" || payload.Runtime.Planned[0].Step != "check-host" || payload.Runtime.Planned[0].Output != "passed" {
+		t.Fatalf("unexpected planned runtime: %+v", payload.Runtime.Planned)
+	}
+}
+
 func TestPlanAndApplySelectNodeScopedVarsByHostname(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 	hostname, err := os.Hostname()

--- a/cmd/deck/apply_cli_test.go
+++ b/cmd/deck/apply_cli_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"sync"
 	"testing"
@@ -250,8 +251,14 @@ phases:
 	if _, ok := payload.Runtime.Initial["host"]; !ok {
 		t.Fatalf("expected runtime.host in initial runtime: %+v", payload.Runtime.Initial)
 	}
-	if len(payload.Runtime.Planned) != 1 || payload.Runtime.Planned[0].Key != "captured" || payload.Runtime.Planned[0].Step != "capture" || payload.Runtime.Planned[0].Output != "passed" || payload.Runtime.Planned[0].Phase != "install" {
-		t.Fatalf("unexpected planned runtime: %+v", payload.Runtime.Planned)
+	expectedPlanned := []struct {
+		Key    string `json:"key"`
+		Step   string `json:"step"`
+		Output string `json:"output"`
+		Phase  string `json:"phase"`
+	}{{Key: "captured", Step: "capture", Output: "passed", Phase: "install"}}
+	if !reflect.DeepEqual(payload.Runtime.Planned, expectedPlanned) {
+		t.Fatalf("unexpected planned runtime:\ngot:  %+v\nwant: %+v", payload.Runtime.Planned, expectedPlanned)
 	}
 }
 
@@ -317,8 +324,13 @@ phases:
 	if _, ok := payload.Runtime.Initial["host"]; !ok {
 		t.Fatalf("expected runtime.host in initial runtime: %+v", payload.Runtime.Initial)
 	}
-	if len(payload.Runtime.Planned) != 1 || payload.Runtime.Planned[0].Key != "hostPassed" || payload.Runtime.Planned[0].Step != "check-host" || payload.Runtime.Planned[0].Output != "passed" {
-		t.Fatalf("unexpected planned runtime: %+v", payload.Runtime.Planned)
+	expectedPlanned := []struct {
+		Key    string `json:"key"`
+		Step   string `json:"step"`
+		Output string `json:"output"`
+	}{{Key: "hostPassed", Step: "check-host", Output: "passed"}}
+	if !reflect.DeepEqual(payload.Runtime.Planned, expectedPlanned) {
+		t.Fatalf("unexpected planned runtime:\ngot:  %+v\nwant: %+v", payload.Runtime.Planned, expectedPlanned)
 	}
 }
 

--- a/cmd/deck/cmd_apply.go
+++ b/cmd/deck/cmd_apply.go
@@ -9,6 +9,8 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/Airgap-Castaways/deck/internal/applycli"
+	"github.com/Airgap-Castaways/deck/internal/planvars"
+	"github.com/Airgap-Castaways/deck/internal/workspacepaths"
 )
 
 type diffOptions struct {
@@ -17,6 +19,19 @@ type diffOptions struct {
 	source        string
 	fresh         bool
 	selectedPhase string
+	output        string
+	varOverrides  map[string]string
+	varsFiles     []string
+}
+
+type planVarsOptions struct {
+	command       string
+	workflowPath  string
+	scenario      string
+	source        string
+	selectedPhase string
+	preparedRoot  string
+	fresh         bool
 	output        string
 	varOverrides  map[string]string
 	varsFiles     []string
@@ -77,7 +92,108 @@ func newPlanCommand(env *cliEnv) *cobra.Command {
 	cmd.Flags().Var(vars, "var", "set variable override (key=value), repeatable")
 	registerScenarioSourceCompletion(cmd, "source", false)
 	registerScenarioNameCompletion(cmd, "scenario", "source", "", false)
+	cmd.AddCommand(newPlanVarsCommand(env))
 	return cmd
+}
+
+func newPlanVarsCommand(env *cliEnv) *cobra.Command {
+	vars := &varFlag{}
+	varsFiles := &stringSliceFlag{}
+	cmd := &cobra.Command{
+		Use:   "vars",
+		Short: "Show effective vars, context, and initial runtime values",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			command, err := cmdFlagValue(cmd, "command")
+			if err != nil {
+				return err
+			}
+			workflowPath, err := cmdFlagValue(cmd, "workflow")
+			if err != nil {
+				return err
+			}
+			scenario, err := cmdFlagValue(cmd, "scenario")
+			if err != nil {
+				return err
+			}
+			source, err := cmdFlagValue(cmd, "source")
+			if err != nil {
+				return err
+			}
+			selectedPhase, err := cmdFlagValue(cmd, "phase")
+			if err != nil {
+				return err
+			}
+			preparedRoot, err := cmdFlagValue(cmd, "root")
+			if err != nil {
+				return err
+			}
+			fresh, err := cmdFlagBoolValue(cmd, "fresh")
+			if err != nil {
+				return err
+			}
+			output, err := cmdFlagValue(cmd, "output")
+			if err != nil {
+				return err
+			}
+			return runPlanVarsWithOptions(env, cmd.Context(), planVarsOptions{
+				command:       command,
+				workflowPath:  workflowPath,
+				scenario:      scenario,
+				source:        source,
+				selectedPhase: selectedPhase,
+				preparedRoot:  preparedRoot,
+				fresh:         fresh,
+				output:        output,
+				varOverrides:  vars.AsMap(),
+				varsFiles:     varsFiles.Values(),
+			})
+		},
+	}
+	cmd.Flags().String("command", planvars.CommandApply, "execution command to inspect (apply|prepare)")
+	cmd.Flags().String("workflow", "", "path or URL to apply workflow file")
+	cmd.Flags().String("scenario", "", "scenario name to inspect for apply")
+	cmd.Flags().String("source", scenarioSourceLocal, "scenario source for apply (local|server)")
+	cmd.Flags().String("phase", "", "phase name to inspect (defaults to all phases)")
+	cmd.Flags().String("root", workspacepaths.DefaultPreparedRoot("."), "prepared bundle output directory for --command prepare")
+	cmd.Flags().Bool("fresh", false, "ignore saved apply state for this invocation")
+	cmd.Flags().StringP("output", "o", "text", "output format (text|json)")
+	cmd.Flags().VarP(varsFiles, "vars-file", "f", "vars file overlay relative to workflows/ (repeatable)")
+	cmd.Flags().Var(vars, "var", "set variable override (key=value), repeatable")
+	registerScenarioSourceCompletion(cmd, "source", false)
+	registerScenarioNameCompletion(cmd, "scenario", "source", "", false)
+	return cmd
+}
+
+func runPlanVarsWithOptions(env *cliEnv, ctx context.Context, opts planVarsOptions) error {
+	resolvedOutput, err := resolveOutputFormat(opts.output)
+	if err != nil {
+		return err
+	}
+	command := strings.TrimSpace(opts.command)
+	if command == "" {
+		command = planvars.CommandApply
+	}
+	workflowPath := strings.TrimSpace(opts.workflowPath)
+	if command == planvars.CommandApply {
+		workflowPath, err = resolvePlanWorkflowPath(ctx, workflowPath, strings.TrimSpace(opts.scenario), strings.TrimSpace(opts.source))
+		if err != nil {
+			return err
+		}
+	}
+	return planvars.Execute(ctx, planvars.Options{
+		Command:         command,
+		WorkflowPath:    workflowPath,
+		Scenario:        strings.TrimSpace(opts.scenario),
+		SelectedPhase:   strings.TrimSpace(opts.selectedPhase),
+		PreparedRoot:    strings.TrimSpace(opts.preparedRoot),
+		Fresh:           opts.fresh,
+		VarOverrides:    varsAsAnyMap(opts.varOverrides),
+		VarsFiles:       append([]string(nil), opts.varsFiles...),
+		Output:          resolvedOutput,
+		StdoutPrintf:    env.stdoutPrintf,
+		JSONEncoderFunc: env.stdoutJSONEncoder,
+	})
 }
 
 func runDiffWithOptions(env *cliEnv, ctx context.Context, opts diffOptions) error {

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -81,6 +81,8 @@ These commands are additive. They do not replace the default local execution pat
 
 `deck plan -o json` returns the resolved workflow path, state path, runtime var keys, per-step actions, and a summary section.
 
+`deck plan vars -o json` returns the execution input snapshot: effective `vars`, resolved `context`, initial `runtime` values known before execution, and planned `runtime` keys that later steps may register.
+
 `deck server health -o json` returns the resolved server URL, `/healthz` URL, and HTTP status.
 
 `deck server up` writes structured audit records under `.deck/logs/server-audit.log`. The current audit schema is version 2 and uses top-level fields such as `component`, `event`, `method`, `path`, `status`, and `duration_ms`. Raw consumers that read the log file directly should expect this version-2 shape going forward.
@@ -237,10 +239,12 @@ deck prepare --bundle-binary-source local --bundle-binary-dir ../test/artifacts/
 deck prepare --bundle-binary-source release --bundle-binary-exclude darwin/amd64 --bundle-binary-exclude darwin/arm64
 deck prepare --bundle-binary-source release --bundle-binary-version v0.1.0 --bundle-binary linux/amd64
 deck prepare -f vars/site.yaml --var registryHost=mirror.local --var kubernetesVersion=v1.30.1
+deck plan vars --command prepare -f vars/site.yaml --var registryHost=mirror.local
 deck bundle build --out ./bundle.tar
 deck plan --scenario apply --source local
 deck plan --scenario apply --source local -o json
 deck plan --scenario apply --source local -f vars/worker.yaml --var role=worker
+deck plan vars --scenario apply --source local -f vars/worker.yaml --var role=worker
 deck apply --scenario apply --source local
 deck apply --scenario apply --source local -f vars/cp1.yaml --var role=control-plane --var nodeIP=10.0.0.10
 deck cache clean --older-than 30d --dry-run

--- a/docs/reference/workflow-model.md
+++ b/docs/reference/workflow-model.md
@@ -105,6 +105,8 @@ Hostname matching tries the detected hostname first, then the short hostname bef
 
 Runtime values flow separately through `register` outputs and built-in runtime facts such as `runtime.host`. Execution context values under `context.*` are deck-supplied metadata resolved at command runtime, such as the command name, workflow source, workflow path, bundle root, output root, and state file.
 
+Use `deck plan vars` to inspect the input snapshot before running `prepare` or `apply`. It prints effective `vars`, resolved `context`, initial `runtime` values known before execution, and planned runtime keys that may be registered by workflow steps. Registered runtime values are not predicted before their producing step runs.
+
 **`workflows/vars.yaml`** — define shared defaults once:
 
 ```yaml

--- a/internal/planvars/report.go
+++ b/internal/planvars/report.go
@@ -1,0 +1,387 @@
+package planvars
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+
+	"github.com/Airgap-Castaways/deck/internal/applycli"
+	"github.com/Airgap-Castaways/deck/internal/config"
+	"github.com/Airgap-Castaways/deck/internal/install"
+	"github.com/Airgap-Castaways/deck/internal/workflowcontext"
+	"github.com/Airgap-Castaways/deck/internal/workspacepaths"
+)
+
+const (
+	CommandApply   = "apply"
+	CommandPrepare = "prepare"
+)
+
+type Options struct {
+	Command         string
+	WorkflowPath    string
+	Scenario        string
+	SelectedPhase   string
+	PreparedRoot    string
+	Fresh           bool
+	VarOverrides    map[string]any
+	VarsFiles       []string
+	Output          string
+	StdoutPrintf    func(format string, args ...any) error
+	JSONEncoderFunc func() *json.Encoder
+}
+
+type Report struct {
+	Command       string         `json:"command"`
+	WorkflowPath  string         `json:"workflowPath"`
+	SelectedPhase string         `json:"selectedPhase,omitempty"`
+	StatePath     string         `json:"statePath,omitempty"`
+	Vars          map[string]any `json:"vars"`
+	Context       map[string]any `json:"context"`
+	Runtime       RuntimeReport  `json:"runtime"`
+}
+
+type RuntimeReport struct {
+	Initial map[string]any      `json:"initial"`
+	Planned []PlannedRuntimeVar `json:"planned"`
+}
+
+type PlannedRuntimeVar struct {
+	Key    string `json:"key"`
+	Step   string `json:"step"`
+	Output string `json:"output"`
+	Phase  string `json:"phase,omitempty"`
+}
+
+func Execute(ctx context.Context, opts Options) error {
+	if ctx == nil {
+		return fmt.Errorf("context is nil")
+	}
+	if opts.StdoutPrintf == nil {
+		return fmt.Errorf("stdout printf is nil")
+	}
+	report, err := BuildReport(ctx, opts)
+	if err != nil {
+		return err
+	}
+	if strings.TrimSpace(opts.Output) == "json" {
+		if opts.JSONEncoderFunc == nil {
+			return fmt.Errorf("json encoder factory is nil")
+		}
+		enc := opts.JSONEncoderFunc()
+		enc.SetIndent("", "  ")
+		return enc.Encode(report)
+	}
+	return writeTextReport(opts.StdoutPrintf, report)
+}
+
+func BuildReport(ctx context.Context, opts Options) (Report, error) {
+	switch strings.TrimSpace(opts.Command) {
+	case "", CommandApply:
+		return buildApplyReport(ctx, opts)
+	case CommandPrepare:
+		return buildPrepareReport(ctx, opts)
+	default:
+		return Report{}, fmt.Errorf("unsupported vars plan command: %s", opts.Command)
+	}
+}
+
+func buildApplyReport(ctx context.Context, opts Options) (Report, error) {
+	request, err := applycli.ResolveExecutionRequest(ctx, applycli.ExecutionRequestOptions{
+		CommandName:                  CommandApply,
+		WorkflowPath:                 strings.TrimSpace(opts.WorkflowPath),
+		AllowRemoteWorkflow:          true,
+		VarOverrides:                 opts.VarOverrides,
+		VarsFiles:                    append([]string(nil), opts.VarsFiles...),
+		NodeScopedVars:               true,
+		Fresh:                        opts.Fresh,
+		SelectedPhase:                strings.TrimSpace(opts.SelectedPhase),
+		DefaultPhase:                 "",
+		BuildExecutionWorkflow:       true,
+		ResolveStatePath:             true,
+		StatePathFromExecutionTarget: true,
+	})
+	if err != nil {
+		return Report{}, err
+	}
+	execContext, err := buildApplyContext(&request, strings.TrimSpace(opts.Scenario))
+	if err != nil {
+		return Report{}, err
+	}
+	if err := applyContextStateKey(&request, execContext); err != nil {
+		return Report{}, err
+	}
+	execContext.Paths.StateFile = request.StatePath
+
+	state, err := applycli.LoadInstallDryRunState(request)
+	if err != nil {
+		return Report{}, err
+	}
+	runtimeInitial := map[string]any{}
+	for key, value := range state.RuntimeVars {
+		runtimeInitial[key] = value
+	}
+	runtimeInitial["host"] = install.CurrentHostFacts()
+
+	return Report{
+		Command:       CommandApply,
+		WorkflowPath:  request.WorkflowPath,
+		SelectedPhase: request.SelectedPhase,
+		StatePath:     request.StatePath,
+		Vars:          cloneMap(request.ExecutionWorkflow.Vars),
+		Context:       execContext.RenderMap(),
+		Runtime:       RuntimeReport{Initial: runtimeInitial, Planned: plannedRuntimeVars(request.ExecutionWorkflow)},
+	}, nil
+}
+
+func buildPrepareReport(ctx context.Context, opts Options) (Report, error) {
+	workflowPath, err := discoverPrepareWorkflow(ctx)
+	if err != nil {
+		return Report{}, err
+	}
+	preparedRoot := strings.TrimSpace(opts.PreparedRoot)
+	if preparedRoot == "" {
+		preparedRoot = workspacepaths.DefaultPreparedRoot(".")
+	}
+	preparedRootAbs, err := filepath.Abs(preparedRoot)
+	if err != nil {
+		return Report{}, fmt.Errorf("resolve --root: %w", err)
+	}
+	wf, err := config.LoadWithOptions(ctx, workflowPath, config.LoadOptions{VarOverrides: opts.VarOverrides, VarsFiles: append([]string(nil), opts.VarsFiles...), NodeScopedVars: true})
+	if err != nil {
+		return Report{}, err
+	}
+	executionWorkflow, err := applycli.BuildExecutionWorkflow(wf, strings.TrimSpace(opts.SelectedPhase))
+	if err != nil {
+		return Report{}, err
+	}
+	execContext := workflowcontext.Context{
+		Command: workflowcontext.CommandPrepare,
+		Workflow: workflowcontext.Workflow{
+			Source: workflowcontext.SourceFilesystem,
+			Path:   workflowPath,
+		},
+		Paths: workflowcontext.Paths{BundleRoot: preparedRootAbs, OutputRoot: preparedRootAbs},
+	}
+	return Report{
+		Command:       CommandPrepare,
+		WorkflowPath:  workflowPath,
+		SelectedPhase: strings.TrimSpace(opts.SelectedPhase),
+		Vars:          cloneMap(executionWorkflow.Vars),
+		Context:       execContext.RenderMap(),
+		Runtime:       RuntimeReport{Initial: map[string]any{"host": install.CurrentHostFacts()}, Planned: plannedRuntimeVars(executionWorkflow)},
+	}, nil
+}
+
+func buildApplyContext(request *applycli.ExecutionRequest, scenario string) (workflowcontext.Context, error) {
+	if request == nil {
+		return workflowcontext.Context{}, fmt.Errorf("execution request is nil")
+	}
+	bundleRoot := ""
+	if !applycli.IsHTTPWorkflowPath(request.WorkflowPath) {
+		inferred, err := inferBundleRootFromWorkflowPath(request.WorkflowPath)
+		if err != nil {
+			return workflowcontext.Context{}, err
+		}
+		bundleRoot = inferred
+	}
+	return workflowcontext.Context{
+		Command: workflowcontext.CommandApply,
+		Workflow: workflowcontext.Workflow{
+			Source:   workflowcontext.SourceForWorkflowPath(request.WorkflowPath),
+			Path:     request.WorkflowPath,
+			Scenario: strings.TrimSpace(scenario),
+		},
+		Paths: workflowcontext.Paths{BundleRoot: bundleRoot},
+	}, nil
+}
+
+func applyContextStateKey(request *applycli.ExecutionRequest, execContext workflowcontext.Context) error {
+	if request == nil || request.Workflow == nil {
+		return fmt.Errorf("workflow is nil")
+	}
+	stateKey := config.StateKeyWithContext(request.Workflow.StateKey, execContext.StateFingerprint())
+	if stateKey == "" {
+		return fmt.Errorf("workflow state key is empty")
+	}
+	request.Workflow.StateKey = stateKey
+	if request.ExecutionWorkflow != nil {
+		request.ExecutionWorkflow.StateKey = stateKey
+	}
+	statePath, err := applycli.ResolveInstallStatePath(request.Workflow)
+	if err != nil {
+		return err
+	}
+	request.StatePath = statePath
+	return nil
+}
+
+func inferBundleRootFromWorkflowPath(workflowPath string) (string, error) {
+	trimmed := strings.TrimSpace(workflowPath)
+	if trimmed == "" || applycli.IsHTTPWorkflowPath(trimmed) {
+		return "", nil
+	}
+	abs, err := filepath.Abs(trimmed)
+	if err != nil {
+		return "", fmt.Errorf("resolve workflow path: %w", err)
+	}
+	workflowDir := string(filepath.Separator) + workspacepaths.WorkflowRootDir + string(filepath.Separator)
+	idx := strings.LastIndex(abs, workflowDir)
+	if idx < 0 {
+		return "", nil
+	}
+	return abs[:idx], nil
+}
+
+func discoverPrepareWorkflow(ctx context.Context) (string, error) {
+	workflowDir := filepath.Join(".", workspacepaths.WorkflowRootDir)
+	absWorkflowDir, err := filepath.Abs(workflowDir)
+	if err != nil {
+		return "", fmt.Errorf("resolve workflow directory: %w", err)
+	}
+	info, err := os.Stat(absWorkflowDir)
+	if err != nil || !info.IsDir() {
+		return "", fmt.Errorf("workflow directory not found: %s", absWorkflowDir)
+	}
+	preferred := workspacepaths.CanonicalPrepareWorkflowPath(filepath.Dir(absWorkflowDir))
+	preferredInfo, statErr := os.Stat(preferred)
+	if statErr != nil || preferredInfo.IsDir() {
+		return "", fmt.Errorf("prepare workflow not found: %s", preferred)
+	}
+	if _, loadErr := config.LoadWithOptions(ctx, preferred, config.LoadOptions{NodeScopedVars: true}); loadErr != nil {
+		return "", loadErr
+	}
+	return preferred, nil
+}
+
+func plannedRuntimeVars(wf *config.Workflow) []PlannedRuntimeVar {
+	if wf == nil {
+		return nil
+	}
+	planned := make([]PlannedRuntimeVar, 0)
+	for _, phase := range config.NormalizedPhases(wf) {
+		for _, step := range phase.Steps {
+			keys := make([]string, 0, len(step.Register))
+			for key := range step.Register {
+				keys = append(keys, key)
+			}
+			slices.Sort(keys)
+			for _, key := range keys {
+				planned = append(planned, PlannedRuntimeVar{Key: key, Step: step.ID, Output: step.Register[key], Phase: phase.Name})
+			}
+		}
+	}
+	return planned
+}
+
+func cloneMap(input map[string]any) map[string]any {
+	if len(input) == 0 {
+		return map[string]any{}
+	}
+	out := make(map[string]any, len(input))
+	for key, value := range input {
+		out[key] = value
+	}
+	return out
+}
+
+func writeTextReport(stdoutPrintf func(format string, args ...any) error, report Report) error {
+	if err := stdoutPrintf("VARS command=%s workflow=%s selectedPhase=%s\n", report.Command, report.WorkflowPath, displayValueOrDash(report.SelectedPhase)); err != nil {
+		return err
+	}
+	if err := stdoutPrintf("\nvars:\n"); err != nil {
+		return err
+	}
+	if err := writeMap(stdoutPrintf, "  ", report.Vars); err != nil {
+		return err
+	}
+	if err := stdoutPrintf("\ncontext:\n"); err != nil {
+		return err
+	}
+	if err := writeMap(stdoutPrintf, "  ", report.Context); err != nil {
+		return err
+	}
+	if err := stdoutPrintf("\nruntime:\n  initial:\n"); err != nil {
+		return err
+	}
+	if err := writeMap(stdoutPrintf, "    ", report.Runtime.Initial); err != nil {
+		return err
+	}
+	if err := stdoutPrintf("\n  planned:\n"); err != nil {
+		return err
+	}
+	if len(report.Runtime.Planned) == 0 {
+		return stdoutPrintf("    -\n")
+	}
+	for _, planned := range report.Runtime.Planned {
+		if err := stdoutPrintf("    %s:\n", planned.Key); err != nil {
+			return err
+		}
+		if err := stdoutPrintf("      step: %s\n", planned.Step); err != nil {
+			return err
+		}
+		if strings.TrimSpace(planned.Phase) != "" {
+			if err := stdoutPrintf("      phase: %s\n", planned.Phase); err != nil {
+				return err
+			}
+		}
+		if err := stdoutPrintf("      output: %s\n", planned.Output); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func writeMap(stdoutPrintf func(format string, args ...any) error, indent string, values map[string]any) error {
+	if len(values) == 0 {
+		return stdoutPrintf("%s-\n", indent)
+	}
+	keys := make([]string, 0, len(values))
+	for key := range values {
+		keys = append(keys, key)
+	}
+	slices.Sort(keys)
+	for _, key := range keys {
+		value := values[key]
+		if nested, ok := value.(map[string]any); ok {
+			if err := stdoutPrintf("%s%s:\n", indent, key); err != nil {
+				return err
+			}
+			if err := writeMap(stdoutPrintf, indent+"  ", nested); err != nil {
+				return err
+			}
+			continue
+		}
+		if err := stdoutPrintf("%s%s: %s\n", indent, key, formatValue(value)); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func formatValue(value any) string {
+	switch typed := value.(type) {
+	case string:
+		return typed
+	case nil:
+		return "null"
+	default:
+		raw, err := json.Marshal(typed)
+		if err != nil {
+			return fmt.Sprint(typed)
+		}
+		return string(raw)
+	}
+}
+
+func displayValueOrDash(value string) string {
+	trimmed := strings.TrimSpace(value)
+	if trimmed == "" {
+		return "-"
+	}
+	return trimmed
+}

--- a/internal/planvars/report.go
+++ b/internal/planvars/report.go
@@ -108,7 +108,7 @@ func buildApplyReport(ctx context.Context, opts Options) (Report, error) {
 	if err != nil {
 		return Report{}, err
 	}
-	execContext, err := buildApplyContext(&request, strings.TrimSpace(opts.Scenario))
+	execContext, err := buildApplyContext(request, strings.TrimSpace(opts.Scenario))
 	if err != nil {
 		return Report{}, err
 	}
@@ -177,10 +177,7 @@ func buildPrepareReport(ctx context.Context, opts Options) (Report, error) {
 	}, nil
 }
 
-func buildApplyContext(request *applycli.ExecutionRequest, scenario string) (workflowcontext.Context, error) {
-	if request == nil {
-		return workflowcontext.Context{}, fmt.Errorf("execution request is nil")
-	}
+func buildApplyContext(request applycli.ExecutionRequest, scenario string) (workflowcontext.Context, error) {
 	bundleRoot := ""
 	if !applycli.IsHTTPWorkflowPath(request.WorkflowPath) {
 		inferred, err := inferBundleRootFromWorkflowPath(request.WorkflowPath)


### PR DESCRIPTION
## Summary
- Add `deck plan vars` to show effective `vars`, resolved `context`, initial `runtime`, and planned registered runtime keys before execution.
- Support apply and prepare inspection with existing vars-file and `--var` overlay behavior.
- Document the new command and add CLI coverage for apply and prepare reports.

## Verification
- `make test`
- `make lint`
- `make verify-generated`
- `make build && ./bin/deck plan vars --help`