### PR TITLE
Fix DownloadImage artifact reuse

### DIFF
--- a/docs/reference/bundle-layout.md
+++ b/docs/reference/bundle-layout.md
@@ -45,6 +45,8 @@ The operator unpacks this on the target node, then runs `./deck apply`. The laun
 - `DownloadPackage` now records SHA256 metadata for published package outputs and exported package cache payloads, then revalidates those checksums before reuse.
 - `DownloadImage` now records SHA256 metadata for saved image archives and revalidates those checksums before reuse.
 
+`DownloadImage` reuse requires the saved tar files and the `outputs/images/.deck-cache-images.json` metadata written by a previous successful `prepare` run. The metadata can track multiple image/platform sets in the same output directory. A matching tar file without that metadata is treated as a cache miss. `deck prepare --refresh` bypasses image reuse and downloads the archives again.
+
 Remaining drift gap:
 
 - package reuse still does not detect upstream repository drift on its own; closing that gap likely requires repository snapshot metadata such as repodata/release fingerprints or explicit mirror version contracts.

--- a/internal/prepare/download_images.go
+++ b/internal/prepare/download_images.go
@@ -29,6 +29,10 @@ type imageArtifactMeta struct {
 	SourceDigests map[string]string `json:"sourceDigests,omitempty"`
 }
 
+type imageArtifactMetaFile struct {
+	Artifacts []imageArtifactMeta `json:"artifacts,omitempty"`
+}
+
 type imageDownloadOps struct {
 	parseReference func(string) (name.Reference, error)
 	fetchImage     func(name.Reference, *v1.Platform, ...remote.Option) (v1.Image, error)
@@ -112,20 +116,23 @@ type imagePlatformSelection struct {
 func runGoContainerRegistryDownloads(ctx context.Context, bundleRoot, dir string, images []string, platforms []imagePlatformSelection, auth imageRegistryAuthMap, opts RunOptions) ([]string, error) {
 	deps := resolveDownloadImageOps(opts)
 	platformKeys := imagePlatformKeys(platforms)
-	if files, reused, err := tryReuseImageArtifact(bundleRoot, dir, images, platformKeys, opts); err != nil {
-		return nil, err
-	} else if reused {
-		return files, nil
-	}
 	fetchTargets := imageFetchTargets(platforms)
 	files := make([]string, 0, len(images)*len(fetchTargets))
-	sourceDigests := map[string]string{}
 	for _, img := range images {
+		if reusedFiles, reused, err := tryReuseImageArtifact(bundleRoot, dir, []string{img}, platformKeys, opts); err != nil {
+			return nil, err
+		} else if reused {
+			files = append(files, reusedFiles...)
+			continue
+		}
+
 		ref, err := deps.parseReference(img)
 		if err != nil {
 			return nil, fmt.Errorf("parse image reference %s: %w", img, err)
 		}
 		registry := ref.Context().RegistryStr()
+		imageFiles := make([]string, 0, len(fetchTargets))
+		sourceDigests := map[string]string{}
 
 		for _, fetchTarget := range fetchTargets {
 			rel := imageArchiveRel(dir, img, fetchTarget.raw)
@@ -163,11 +170,12 @@ func runGoContainerRegistryDownloads(ctx context.Context, bundleRoot, dir string
 				return nil, fmt.Errorf("write image archive %s%s: empty archive", img, imagePlatformErrorSuffix(fetchTarget.raw))
 			}
 
-			files = append(files, rel)
+			imageFiles = append(imageFiles, rel)
 		}
-	}
-	if err := writeImageArtifactMeta(bundleRoot, dir, images, platformKeys, files, sourceDigests); err != nil {
-		return nil, err
+		if err := writeImageArtifactMeta(bundleRoot, dir, []string{img}, platformKeys, imageFiles, sourceDigests); err != nil {
+			return nil, err
+		}
+		files = append(files, imageFiles...)
 	}
 	return files, nil
 }
@@ -224,11 +232,33 @@ func readImageArtifactMetaFile(path string) ([]byte, bool) {
 	return raw, true
 }
 
-func parseImageArtifactMeta(raw []byte) (imageArtifactMeta, bool) {
+func parseImageArtifactMetas(raw []byte) ([]imageArtifactMeta, bool) {
+	var file imageArtifactMetaFile
+	if err := json.Unmarshal(raw, &file); err == nil && len(file.Artifacts) > 0 {
+		metas := make([]imageArtifactMeta, 0, len(file.Artifacts))
+		for _, meta := range file.Artifacts {
+			if normalized, ok := normalizeImageArtifactMeta(meta); ok {
+				metas = append(metas, normalized)
+			}
+		}
+		if len(metas) == 0 {
+			return nil, false
+		}
+		return metas, true
+	}
+
 	var meta imageArtifactMeta
 	if err := json.Unmarshal(raw, &meta); err != nil {
-		return imageArtifactMeta{}, false
+		return nil, false
 	}
+	meta, ok := normalizeImageArtifactMeta(meta)
+	if !ok {
+		return nil, false
+	}
+	return []imageArtifactMeta{meta}, true
+}
+
+func normalizeImageArtifactMeta(meta imageArtifactMeta) (imageArtifactMeta, bool) {
 	meta.Images = normalizeStrings(meta.Images)
 	meta.Platforms = normalizeStrings(meta.Platforms)
 	meta.Files = normalizeStrings(meta.Files)
@@ -240,16 +270,27 @@ func parseImageArtifactMeta(raw []byte) (imageArtifactMeta, bool) {
 	return meta, true
 }
 
-func loadImageArtifactMeta(bundleRoot, dir string) (imageArtifactMeta, bool, error) {
+func loadImageArtifactMetas(bundleRoot, dir string) ([]imageArtifactMeta, bool, error) {
 	raw, ok := readImageArtifactMetaFile(imageMetaFileAbs(bundleRoot, dir))
 	if !ok {
-		return imageArtifactMeta{}, false, nil
+		return nil, false, nil
 	}
-	meta, ok := parseImageArtifactMeta(raw)
+	metas, ok := parseImageArtifactMetas(raw)
+	if !ok {
+		return nil, false, nil
+	}
+	return metas, true, nil
+}
+
+func loadImageArtifactMeta(bundleRoot, dir string) (imageArtifactMeta, bool, error) {
+	metas, ok, err := loadImageArtifactMetas(bundleRoot, dir)
+	if err != nil {
+		return imageArtifactMeta{}, false, err
+	}
 	if !ok {
 		return imageArtifactMeta{}, false, nil
 	}
-	return meta, true, nil
+	return metas[0], true, nil
 }
 
 func writeImageArtifactMeta(bundleRoot, dir string, images, platforms, files []string, sourceDigests map[string]string) error {
@@ -264,7 +305,12 @@ func writeImageArtifactMeta(bundleRoot, dir string, images, platforms, files []s
 		Checksums:     checksums,
 		SourceDigests: normalizeChecksumMap(sourceDigests),
 	}
-	raw, err := json.Marshal(meta)
+	metas, _, err := loadImageArtifactMetas(bundleRoot, dir)
+	if err != nil {
+		return err
+	}
+	merged := mergeImageArtifactMetas(metas, meta)
+	raw, err := json.Marshal(imageArtifactMetaFile{Artifacts: merged})
 	if err != nil {
 		return err
 	}
@@ -275,34 +321,103 @@ func writeImageArtifactMeta(bundleRoot, dir string, images, platforms, files []s
 	return filemode.WriteArtifactFile(path, raw)
 }
 
+func mergeImageArtifactMetas(metas []imageArtifactMeta, meta imageArtifactMeta) []imageArtifactMeta {
+	merged := make([]imageArtifactMeta, 0, len(metas)+1)
+	replaced := false
+	for _, existing := range metas {
+		if equalStrings(existing.Images, meta.Images) && equalStrings(existing.Platforms, meta.Platforms) {
+			if !replaced {
+				merged = append(merged, meta)
+				replaced = true
+			}
+			continue
+		}
+		merged = append(merged, existing)
+	}
+	if !replaced {
+		merged = append(merged, meta)
+	}
+	return merged
+}
+
+func imageArtifactReuseCandidate(meta imageArtifactMeta, dir string, images, platforms []string) ([]string, bool) {
+	if !equalStrings(meta.Platforms, platforms) {
+		return nil, false
+	}
+	if equalStrings(meta.Images, images) {
+		return meta.Files, true
+	}
+	if !containsAllStrings(meta.Images, images) {
+		return nil, false
+	}
+	expected := imageArtifactExpectedFiles(dir, images, platforms)
+	if !containsAllStrings(meta.Files, expected) {
+		return nil, false
+	}
+	return expected, true
+}
+
+func imageArtifactExpectedFiles(dir string, images, platforms []string) []string {
+	if len(platforms) == 0 {
+		files := make([]string, 0, len(images))
+		for _, img := range images {
+			files = append(files, imageArchiveRel(dir, img, ""))
+		}
+		return normalizeStrings(files)
+	}
+	files := make([]string, 0, len(images)*len(platforms))
+	for _, img := range images {
+		for _, platform := range platforms {
+			files = append(files, imageArchiveRel(dir, img, platform))
+		}
+	}
+	return normalizeStrings(files)
+}
+
+func containsAllStrings(haystack, needles []string) bool {
+	seen := make(map[string]struct{}, len(haystack))
+	for _, value := range haystack {
+		seen[value] = struct{}{}
+	}
+	for _, value := range needles {
+		if _, ok := seen[value]; !ok {
+			return false
+		}
+	}
+	return true
+}
+
 func tryReuseImageArtifact(bundleRoot, dir string, images, platforms []string, opts RunOptions) ([]string, bool, error) {
 	if opts.ForceRedownload {
 		return nil, false, nil
 	}
-	meta, ok, err := loadImageArtifactMeta(bundleRoot, dir)
+	metas, ok, err := loadImageArtifactMetas(bundleRoot, dir)
 	if err != nil {
 		return nil, false, err
 	}
 	if !ok {
 		return nil, false, nil
 	}
-	if !equalStrings(normalizeStrings(images), meta.Images) {
-		return nil, false, nil
-	}
-	if !equalStrings(normalizeStrings(platforms), meta.Platforms) {
-		return nil, false, nil
-	}
-	checksumsOK, err := verifyArtifactChecksums(bundleRoot, meta.Files, meta.Checksums)
-	if err != nil {
-		if os.IsNotExist(err) {
-			return nil, false, nil
+	wantImages := normalizeStrings(images)
+	wantPlatforms := normalizeStrings(platforms)
+	for _, meta := range metas {
+		candidateFiles, ok := imageArtifactReuseCandidate(meta, dir, wantImages, wantPlatforms)
+		if !ok {
+			continue
 		}
-		return nil, false, err
+		checksumsOK, err := verifyArtifactChecksums(bundleRoot, candidateFiles, meta.Checksums)
+		if err != nil {
+			if os.IsNotExist(err) {
+				continue
+			}
+			return nil, false, err
+		}
+		if !checksumsOK {
+			continue
+		}
+		return candidateFiles, true, nil
 	}
-	if !checksumsOK {
-		return nil, false, nil
-	}
-	return meta.Files, true, nil
+	return nil, false, nil
 }
 
 type imageRegistryAuth struct {

--- a/internal/prepare/download_images.go
+++ b/internal/prepare/download_images.go
@@ -117,9 +117,13 @@ func runGoContainerRegistryDownloads(ctx context.Context, bundleRoot, dir string
 	deps := resolveDownloadImageOps(opts)
 	platformKeys := imagePlatformKeys(platforms)
 	fetchTargets := imageFetchTargets(platforms)
+	metas, _, err := loadImageArtifactMetas(bundleRoot, dir)
+	if err != nil {
+		return nil, err
+	}
 	files := make([]string, 0, len(images)*len(fetchTargets))
 	for _, img := range images {
-		if reusedFiles, reused, err := tryReuseImageArtifact(bundleRoot, dir, []string{img}, platformKeys, opts); err != nil {
+		if reusedFiles, reused, err := tryReuseImageArtifactFromMetas(bundleRoot, dir, metas, []string{img}, platformKeys, opts); err != nil {
 			return nil, err
 		} else if reused {
 			files = append(files, reusedFiles...)
@@ -172,7 +176,12 @@ func runGoContainerRegistryDownloads(ctx context.Context, bundleRoot, dir string
 
 			imageFiles = append(imageFiles, rel)
 		}
-		if err := writeImageArtifactMeta(bundleRoot, dir, []string{img}, platformKeys, imageFiles, sourceDigests); err != nil {
+		meta, err := buildImageArtifactMeta(bundleRoot, []string{img}, platformKeys, imageFiles, sourceDigests)
+		if err != nil {
+			return nil, err
+		}
+		metas, err = writeImageArtifactMetas(bundleRoot, dir, metas, meta)
+		if err != nil {
 			return nil, err
 		}
 		files = append(files, imageFiles...)
@@ -293,32 +302,34 @@ func loadImageArtifactMeta(bundleRoot, dir string) (imageArtifactMeta, bool, err
 	return metas[0], true, nil
 }
 
-func writeImageArtifactMeta(bundleRoot, dir string, images, platforms, files []string, sourceDigests map[string]string) error {
+func buildImageArtifactMeta(bundleRoot string, images, platforms, files []string, sourceDigests map[string]string) (imageArtifactMeta, error) {
 	checksums, err := computeArtifactChecksums(bundleRoot, files)
 	if err != nil {
-		return err
+		return imageArtifactMeta{}, err
 	}
-	meta := imageArtifactMeta{
+	return imageArtifactMeta{
 		Images:        normalizeStrings(images),
 		Platforms:     normalizeStrings(platforms),
 		Files:         normalizeStrings(files),
 		Checksums:     checksums,
 		SourceDigests: normalizeChecksumMap(sourceDigests),
-	}
-	metas, _, err := loadImageArtifactMetas(bundleRoot, dir)
-	if err != nil {
-		return err
-	}
+	}, nil
+}
+
+func writeImageArtifactMetas(bundleRoot, dir string, metas []imageArtifactMeta, meta imageArtifactMeta) ([]imageArtifactMeta, error) {
 	merged := mergeImageArtifactMetas(metas, meta)
 	raw, err := json.Marshal(imageArtifactMetaFile{Artifacts: merged})
 	if err != nil {
-		return err
+		return nil, err
 	}
 	path := imageMetaFileAbs(bundleRoot, dir)
 	if err := filemode.EnsureParentArtifactDir(path); err != nil {
-		return err
+		return nil, err
 	}
-	return filemode.WriteArtifactFile(path, raw)
+	if err := filemode.WriteArtifactFile(path, raw); err != nil {
+		return nil, err
+	}
+	return merged, nil
 }
 
 func mergeImageArtifactMetas(metas []imageArtifactMeta, meta imageArtifactMeta) []imageArtifactMeta {
@@ -341,10 +352,10 @@ func mergeImageArtifactMetas(metas []imageArtifactMeta, meta imageArtifactMeta) 
 }
 
 func imageArtifactReuseCandidate(meta imageArtifactMeta, dir string, images, platforms []string) ([]string, bool) {
-	if !equalStrings(meta.Platforms, platforms) {
+	if !containsAllStrings(meta.Platforms, platforms) {
 		return nil, false
 	}
-	if equalStrings(meta.Images, images) {
+	if equalStrings(meta.Images, images) && equalStrings(meta.Platforms, platforms) {
 		return meta.Files, true
 	}
 	if !containsAllStrings(meta.Images, images) {
@@ -387,15 +398,8 @@ func containsAllStrings(haystack, needles []string) bool {
 	return true
 }
 
-func tryReuseImageArtifact(bundleRoot, dir string, images, platforms []string, opts RunOptions) ([]string, bool, error) {
+func tryReuseImageArtifactFromMetas(bundleRoot, dir string, metas []imageArtifactMeta, images, platforms []string, opts RunOptions) ([]string, bool, error) {
 	if opts.ForceRedownload {
-		return nil, false, nil
-	}
-	metas, ok, err := loadImageArtifactMetas(bundleRoot, dir)
-	if err != nil {
-		return nil, false, err
-	}
-	if !ok {
 		return nil, false, nil
 	}
 	wantImages := normalizeStrings(images)

--- a/internal/prepare/download_images_test.go
+++ b/internal/prepare/download_images_test.go
@@ -143,6 +143,47 @@ func TestRunDownloadImageUsesExplicitPlatforms(t *testing.T) {
 	}
 }
 
+func TestRunDownloadImageReusesPlatformSubset(t *testing.T) {
+	bundle := t.TempDir()
+	fetches := 0
+	imageOps := imageDownloadOps{
+		parseReference: func(v string) (name.Reference, error) {
+			return name.ParseReference(v, name.WeakValidation)
+		},
+		fetchImage: func(_ name.Reference, _ *v1.Platform, _ ...remote.Option) (v1.Image, error) {
+			fetches++
+			return empty.Image, nil
+		},
+		writeArchive: func(path string, _ name.Reference, _ v1.Image, _ ...tarball.WriteOption) error {
+			return os.WriteFile(path, []byte(filepath.Base(path)), 0o644)
+		},
+	}
+	allPlatforms := map[string]any{
+		"images":    []any{"registry.k8s.io/pause:3.9"},
+		"platforms": []any{"linux/amd64", "linux/arm64"},
+	}
+	amd64Only := map[string]any{
+		"images":    []any{"registry.k8s.io/pause:3.9"},
+		"platforms": []any{"linux/amd64"},
+	}
+
+	if _, err := runDownloadImage(context.Background(), nil, bundle, allPlatforms, RunOptions{imageDownloadOps: imageOps}); err != nil {
+		t.Fatalf("first runDownloadImage failed: %v", err)
+	}
+	files, err := runDownloadImage(context.Background(), nil, bundle, amd64Only, RunOptions{imageDownloadOps: imageOps})
+	if err != nil {
+		t.Fatalf("second runDownloadImage failed: %v", err)
+	}
+
+	if fetches != 2 {
+		t.Fatalf("expected platform subset reuse to skip second fetch, got %d fetches", fetches)
+	}
+	wantFiles := []string{"images/registry.k8s.io_pause_3.9_linux_amd64.tar"}
+	if strings.Join(files, "\n") != strings.Join(wantFiles, "\n") {
+		t.Fatalf("unexpected reused files: got %#v want %#v", files, wantFiles)
+	}
+}
+
 func TestRunDownloadImageReusesExistingArtifact(t *testing.T) {
 	bundle := t.TempDir()
 	fetches := 0

--- a/internal/prepare/download_images_test.go
+++ b/internal/prepare/download_images_test.go
@@ -2,6 +2,7 @@ package prepare
 
 import (
 	"context"
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"strings"
@@ -139,6 +140,339 @@ func TestRunDownloadImageUsesExplicitPlatforms(t *testing.T) {
 	}
 	if strings.Join(meta.Platforms, ",") != "linux/amd64,linux/arm64" {
 		t.Fatalf("expected platforms in metadata, got %#v", meta.Platforms)
+	}
+}
+
+func TestRunDownloadImageReusesExistingArtifact(t *testing.T) {
+	bundle := t.TempDir()
+	fetches := 0
+	imageOps := imageDownloadOps{
+		parseReference: func(v string) (name.Reference, error) {
+			return name.ParseReference(v, name.WeakValidation)
+		},
+		fetchImage: func(_ name.Reference, _ *v1.Platform, _ ...remote.Option) (v1.Image, error) {
+			fetches++
+			return empty.Image, nil
+		},
+		writeArchive: func(path string, _ name.Reference, _ v1.Image, _ ...tarball.WriteOption) error {
+			return os.WriteFile(path, []byte(filepath.Base(path)), 0o644)
+		},
+	}
+	spec := map[string]any{"images": []any{"registry.k8s.io/pause:3.9"}}
+
+	if _, err := runDownloadImage(context.Background(), nil, bundle, spec, RunOptions{imageDownloadOps: imageOps}); err != nil {
+		t.Fatalf("first runDownloadImage failed: %v", err)
+	}
+	files, err := runDownloadImage(context.Background(), nil, bundle, spec, RunOptions{imageDownloadOps: imageOps})
+	if err != nil {
+		t.Fatalf("second runDownloadImage failed: %v", err)
+	}
+
+	if fetches != 1 {
+		t.Fatalf("expected image artifact reuse to skip second fetch, got %d fetches", fetches)
+	}
+	if len(files) != 1 || files[0] != "images/registry.k8s.io_pause_3.9.tar" {
+		t.Fatalf("unexpected reused files: %#v", files)
+	}
+}
+
+func TestRunDownloadImageForceRedownloadBypassesReuse(t *testing.T) {
+	bundle := t.TempDir()
+	fetches := 0
+	imageOps := imageDownloadOps{
+		parseReference: func(v string) (name.Reference, error) {
+			return name.ParseReference(v, name.WeakValidation)
+		},
+		fetchImage: func(_ name.Reference, _ *v1.Platform, _ ...remote.Option) (v1.Image, error) {
+			fetches++
+			return empty.Image, nil
+		},
+		writeArchive: func(path string, _ name.Reference, _ v1.Image, _ ...tarball.WriteOption) error {
+			return os.WriteFile(path, []byte(filepath.Base(path)), 0o644)
+		},
+	}
+	spec := map[string]any{"images": []any{"registry.k8s.io/pause:3.9"}}
+
+	if _, err := runDownloadImage(context.Background(), nil, bundle, spec, RunOptions{imageDownloadOps: imageOps}); err != nil {
+		t.Fatalf("first runDownloadImage failed: %v", err)
+	}
+	if _, err := runDownloadImage(context.Background(), nil, bundle, spec, RunOptions{ForceRedownload: true, imageDownloadOps: imageOps}); err != nil {
+		t.Fatalf("forced runDownloadImage failed: %v", err)
+	}
+
+	if fetches != 2 {
+		t.Fatalf("expected forced redownload to fetch again, got %d fetches", fetches)
+	}
+}
+
+func TestRunDownloadImageReusesMultipleArtifactsInSameOutputDir(t *testing.T) {
+	bundle := t.TempDir()
+	fetches := 0
+	imageOps := imageDownloadOps{
+		parseReference: func(v string) (name.Reference, error) {
+			return name.ParseReference(v, name.WeakValidation)
+		},
+		fetchImage: func(_ name.Reference, _ *v1.Platform, _ ...remote.Option) (v1.Image, error) {
+			fetches++
+			return empty.Image, nil
+		},
+		writeArchive: func(path string, _ name.Reference, _ v1.Image, _ ...tarball.WriteOption) error {
+			return os.WriteFile(path, []byte(filepath.Base(path)), 0o644)
+		},
+	}
+	specA := map[string]any{"images": []any{"registry.k8s.io/pause:3.9"}}
+	specB := map[string]any{"images": []any{"registry.k8s.io/coredns/coredns:v1.11.1"}}
+
+	for _, spec := range []map[string]any{specA, specB, specA, specB} {
+		if _, err := runDownloadImage(context.Background(), nil, bundle, spec, RunOptions{imageDownloadOps: imageOps}); err != nil {
+			t.Fatalf("runDownloadImage failed: %v", err)
+		}
+	}
+
+	if fetches != 2 {
+		t.Fatalf("expected each image artifact to be fetched once, got %d fetches", fetches)
+	}
+}
+
+func TestRunDownloadImageReusesArtifactsAcrossDifferentOutputDirs(t *testing.T) {
+	bundle := t.TempDir()
+	fetches := 0
+	imageOps := imageDownloadOps{
+		parseReference: func(v string) (name.Reference, error) {
+			return name.ParseReference(v, name.WeakValidation)
+		},
+		fetchImage: func(_ name.Reference, _ *v1.Platform, _ ...remote.Option) (v1.Image, error) {
+			fetches++
+			return empty.Image, nil
+		},
+		writeArchive: func(path string, _ name.Reference, _ v1.Image, _ ...tarball.WriteOption) error {
+			return os.WriteFile(path, []byte(filepath.Base(path)), 0o644)
+		},
+	}
+	specA := map[string]any{"images": []any{"registry.k8s.io/pause:3.9"}, "outputDir": "images/pause"}
+	specB := map[string]any{"images": []any{"registry.k8s.io/coredns/coredns:v1.11.1"}, "outputDir": "images/coredns"}
+
+	for _, spec := range []map[string]any{specA, specB, specA, specB} {
+		if _, err := runDownloadImage(context.Background(), nil, bundle, spec, RunOptions{imageDownloadOps: imageOps}); err != nil {
+			t.Fatalf("runDownloadImage failed: %v", err)
+		}
+	}
+
+	if fetches != 2 {
+		t.Fatalf("expected artifacts in different output dirs to be fetched once each, got %d fetches", fetches)
+	}
+}
+
+func TestRunDownloadImageRefetchesOnlyCorruptedImageInMultiImageStep(t *testing.T) {
+	bundle := t.TempDir()
+	fetches := 0
+	imageOps := imageDownloadOps{
+		parseReference: func(v string) (name.Reference, error) {
+			return name.ParseReference(v, name.WeakValidation)
+		},
+		fetchImage: func(_ name.Reference, _ *v1.Platform, _ ...remote.Option) (v1.Image, error) {
+			fetches++
+			return empty.Image, nil
+		},
+		writeArchive: func(path string, _ name.Reference, _ v1.Image, _ ...tarball.WriteOption) error {
+			return os.WriteFile(path, []byte(filepath.Base(path)), 0o644)
+		},
+	}
+	spec := map[string]any{"images": []any{"registry.k8s.io/pause:3.9", "registry.k8s.io/coredns/coredns:v1.11.1"}}
+
+	if _, err := runDownloadImage(context.Background(), nil, bundle, spec, RunOptions{imageDownloadOps: imageOps}); err != nil {
+		t.Fatalf("first runDownloadImage failed: %v", err)
+	}
+	corrupted := filepath.Join(bundle, filepath.FromSlash("images/registry.k8s.io_pause_3.9.tar"))
+	if err := os.WriteFile(corrupted, []byte("corrupted"), 0o644); err != nil {
+		t.Fatalf("corrupt image archive: %v", err)
+	}
+	if _, err := runDownloadImage(context.Background(), nil, bundle, spec, RunOptions{imageDownloadOps: imageOps}); err != nil {
+		t.Fatalf("second runDownloadImage failed: %v", err)
+	}
+
+	if fetches != 3 {
+		t.Fatalf("expected only corrupted image to be fetched again, got %d fetches", fetches)
+	}
+}
+
+func TestRunDownloadImageReusesLegacySingleArtifactMeta(t *testing.T) {
+	bundle := t.TempDir()
+	rel := "images/registry.k8s.io_pause_3.9.tar"
+	path := filepath.Join(bundle, filepath.FromSlash(rel))
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir image dir: %v", err)
+	}
+	if err := os.WriteFile(path, []byte(filepath.Base(path)), 0o644); err != nil {
+		t.Fatalf("write image archive: %v", err)
+	}
+	checksums, err := computeArtifactChecksums(bundle, []string{rel})
+	if err != nil {
+		t.Fatalf("computeArtifactChecksums: %v", err)
+	}
+	raw, err := json.Marshal(imageArtifactMeta{
+		Images:    []string{"registry.k8s.io/pause:3.9"},
+		Files:     []string{rel},
+		Checksums: checksums,
+	})
+	if err != nil {
+		t.Fatalf("marshal legacy metadata: %v", err)
+	}
+	if err := os.WriteFile(imageMetaFileAbs(bundle, "images"), raw, 0o644); err != nil {
+		t.Fatalf("write legacy metadata: %v", err)
+	}
+
+	fetches := 0
+	imageOps := imageDownloadOps{
+		parseReference: func(v string) (name.Reference, error) {
+			return name.ParseReference(v, name.WeakValidation)
+		},
+		fetchImage: func(_ name.Reference, _ *v1.Platform, _ ...remote.Option) (v1.Image, error) {
+			fetches++
+			return empty.Image, nil
+		},
+		writeArchive: func(path string, _ name.Reference, _ v1.Image, _ ...tarball.WriteOption) error {
+			return os.WriteFile(path, []byte(filepath.Base(path)), 0o644)
+		},
+	}
+	files, err := runDownloadImage(context.Background(), nil, bundle, map[string]any{"images": []any{"registry.k8s.io/pause:3.9"}}, RunOptions{imageDownloadOps: imageOps})
+	if err != nil {
+		t.Fatalf("runDownloadImage failed: %v", err)
+	}
+
+	if fetches != 0 {
+		t.Fatalf("expected legacy image metadata to be reused, got %d fetches", fetches)
+	}
+	if len(files) != 1 || files[0] != rel {
+		t.Fatalf("unexpected reused files: %#v", files)
+	}
+}
+
+func TestRunDownloadImagePartiallyReusesLegacyGroupedArtifactMeta(t *testing.T) {
+	bundle := t.TempDir()
+	rels := []string{
+		"images/registry.k8s.io_pause_3.9.tar",
+		"images/registry.k8s.io_coredns_coredns_v1.11.1.tar",
+	}
+	for _, rel := range rels {
+		path := filepath.Join(bundle, filepath.FromSlash(rel))
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatalf("mkdir image dir: %v", err)
+		}
+		if err := os.WriteFile(path, []byte(filepath.Base(path)), 0o644); err != nil {
+			t.Fatalf("write image archive: %v", err)
+		}
+	}
+	checksums, err := computeArtifactChecksums(bundle, rels)
+	if err != nil {
+		t.Fatalf("computeArtifactChecksums: %v", err)
+	}
+	raw, err := json.Marshal(imageArtifactMeta{
+		Images:    []string{"registry.k8s.io/pause:3.9", "registry.k8s.io/coredns/coredns:v1.11.1"},
+		Files:     rels,
+		Checksums: checksums,
+	})
+	if err != nil {
+		t.Fatalf("marshal legacy metadata: %v", err)
+	}
+	if err := os.WriteFile(imageMetaFileAbs(bundle, "images"), raw, 0o644); err != nil {
+		t.Fatalf("write legacy metadata: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(bundle, filepath.FromSlash(rels[0])), []byte("corrupted"), 0o644); err != nil {
+		t.Fatalf("corrupt image archive: %v", err)
+	}
+
+	fetches := 0
+	imageOps := imageDownloadOps{
+		parseReference: func(v string) (name.Reference, error) {
+			return name.ParseReference(v, name.WeakValidation)
+		},
+		fetchImage: func(_ name.Reference, _ *v1.Platform, _ ...remote.Option) (v1.Image, error) {
+			fetches++
+			return empty.Image, nil
+		},
+		writeArchive: func(path string, _ name.Reference, _ v1.Image, _ ...tarball.WriteOption) error {
+			return os.WriteFile(path, []byte(filepath.Base(path)), 0o644)
+		},
+	}
+	spec := map[string]any{"images": []any{"registry.k8s.io/pause:3.9", "registry.k8s.io/coredns/coredns:v1.11.1"}}
+	if _, err := runDownloadImage(context.Background(), nil, bundle, spec, RunOptions{imageDownloadOps: imageOps}); err != nil {
+		t.Fatalf("runDownloadImage failed: %v", err)
+	}
+
+	if fetches != 1 {
+		t.Fatalf("expected only corrupted legacy grouped image to be fetched, got %d fetches", fetches)
+	}
+}
+
+func TestRunDownloadImageUsesFreshPerImageMetaAfterStaleGroupedMeta(t *testing.T) {
+	bundle := t.TempDir()
+	rels := []string{
+		"images/registry.k8s.io_pause_3.9.tar",
+		"images/registry.k8s.io_coredns_coredns_v1.11.1.tar",
+	}
+	for _, rel := range rels {
+		path := filepath.Join(bundle, filepath.FromSlash(rel))
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatalf("mkdir image dir: %v", err)
+		}
+		if err := os.WriteFile(path, []byte(filepath.Base(path)), 0o644); err != nil {
+			t.Fatalf("write image archive: %v", err)
+		}
+	}
+	staleChecksums, err := computeArtifactChecksums(bundle, rels)
+	if err != nil {
+		t.Fatalf("compute stale checksums: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(bundle, filepath.FromSlash(rels[0])), []byte("fresh-pause"), 0o644); err != nil {
+		t.Fatalf("write fresh pause archive: %v", err)
+	}
+	freshChecksums, err := computeArtifactChecksums(bundle, []string{rels[0]})
+	if err != nil {
+		t.Fatalf("compute fresh checksums: %v", err)
+	}
+	raw, err := json.Marshal(imageArtifactMetaFile{Artifacts: []imageArtifactMeta{
+		{
+			Images:    []string{"registry.k8s.io/pause:3.9", "registry.k8s.io/coredns/coredns:v1.11.1"},
+			Files:     rels,
+			Checksums: staleChecksums,
+		},
+		{
+			Images:    []string{"registry.k8s.io/pause:3.9"},
+			Files:     []string{rels[0]},
+			Checksums: freshChecksums,
+		},
+	}})
+	if err != nil {
+		t.Fatalf("marshal metadata: %v", err)
+	}
+	if err := os.WriteFile(imageMetaFileAbs(bundle, "images"), raw, 0o644); err != nil {
+		t.Fatalf("write metadata: %v", err)
+	}
+
+	fetches := 0
+	imageOps := imageDownloadOps{
+		parseReference: func(v string) (name.Reference, error) {
+			return name.ParseReference(v, name.WeakValidation)
+		},
+		fetchImage: func(_ name.Reference, _ *v1.Platform, _ ...remote.Option) (v1.Image, error) {
+			fetches++
+			return empty.Image, nil
+		},
+		writeArchive: func(path string, _ name.Reference, _ v1.Image, _ ...tarball.WriteOption) error {
+			return os.WriteFile(path, []byte(filepath.Base(path)), 0o644)
+		},
+	}
+	files, err := runDownloadImage(context.Background(), nil, bundle, map[string]any{"images": []any{"registry.k8s.io/pause:3.9"}}, RunOptions{imageDownloadOps: imageOps})
+	if err != nil {
+		t.Fatalf("runDownloadImage failed: %v", err)
+	}
+
+	if fetches != 0 {
+		t.Fatalf("expected fresh per-image metadata to be reused after stale grouped metadata, got %d fetches", fetches)
+	}
+	if len(files) != 1 || files[0] != rels[0] {
+		t.Fatalf("unexpected reused files: %#v", files)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Reuse DownloadImage artifacts per image instead of refetching an entire step when one archive is invalid.
- Preserve multiple image/platform metadata entries per output directory while continuing to read legacy metadata.
- Document image reuse metadata requirements and add regression coverage for partial reuse cases.

## Tests
- make test && make lint