### PR TITLE
Reduce launcher utility dependencies

### DIFF
--- a/internal/preparecli/launcher.go
+++ b/internal/preparecli/launcher.go
@@ -13,8 +13,7 @@ log_error() {
 	shift
 	printf 'level=%s component=%s event=%s' "$level" "$component" "$event" >&2
 	while [ "$#" -gt 1 ]; do
-		escaped_value=$(printf '%s' "$2" | tr '\r\n' '  ' | sed 's/["\\]/\\&/g')
-		printf ' %s="%s"' "$1" "$escaped_value" >&2
+		printf ' %s="%s"' "$1" "$2" >&2
 		shift 2
 	done
 	printf '\n' >&2
@@ -41,7 +40,17 @@ case "$arch_name" in
 		;;
 esac
 
-script_dir=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+script_path=$0
+case "$script_path" in
+	*/*)
+		script_dir_part=${script_path%/*}
+		if [ -z "$script_dir_part" ]; then
+			script_dir_part=/
+		fi
+		;;
+	*) script_dir_part=. ;;
+esac
+script_dir=$(CDPATH= cd "$script_dir_part" && pwd)
 runtime_bin="$script_dir/outputs/bin/$deck_os/$deck_arch/deck"
 
 if [ ! -x "$runtime_bin" ]; then

--- a/internal/preparecli/launcher.go
+++ b/internal/preparecli/launcher.go
@@ -13,6 +13,8 @@ log_error() {
 	shift
 	printf 'level=%s component=%s event=%s' "$level" "$component" "$event" >&2
 	while [ "$#" -gt 1 ]; do
+		# Values passed here are fixed launcher paths or uname output. Avoid external
+		# escaping utilities so the launcher works in minimal rescue environments.
 		printf ' %s="%s"' "$1" "$2" >&2
 		shift 2
 	done
@@ -49,6 +51,9 @@ case "$script_path" in
 		fi
 		;;
 	*) script_dir_part=. ;;
+esac
+case "$script_dir_part" in
+	-*) script_dir_part=./$script_dir_part ;;
 esac
 script_dir=$(CDPATH= cd "$script_dir_part" && pwd)
 runtime_bin="$script_dir/outputs/bin/$deck_os/$deck_arch/deck"

--- a/internal/preparecli/launcher_test.go
+++ b/internal/preparecli/launcher_test.go
@@ -1,6 +1,9 @@
 package preparecli
 
 import (
+	"os"
+	"os/exec"
+	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -9,15 +12,63 @@ func TestRenderLauncherScriptUsesStructuredErrors(t *testing.T) {
 	script := renderLauncherScript()
 	for _, want := range []string{
 		`component="launcher"`,
-		`tr '\r\n' '  ' | sed 's/["\\]/\\&/g'`,
-		`printf ' %s="%s"' "$1" "$escaped_value" >&2`,
+		`printf ' %s="%s"' "$1" "$2" >&2`,
 		`log_error unsupported_os os "$os_name"`,
 		`log_error unsupported_arch architecture "$arch_name"`,
 		`log_error runtime_binary_not_executable path "outputs/bin/$deck_os/$deck_arch/deck"`,
 		`log_error runtime_binary_missing os "$deck_os" architecture "$deck_arch" path "outputs/bin/$deck_os/$deck_arch/deck"`,
+		`script_dir_part=${script_path%/*}`,
 	} {
 		if !strings.Contains(script, want) {
 			t.Fatalf("expected %q in launcher script", want)
 		}
+	}
+	for _, forbidden := range []string{` tr `, ` sed `, `dirname`} {
+		if strings.Contains(script, forbidden) {
+			t.Fatalf("launcher script must not require %q: %s", forbidden, script)
+		}
+	}
+}
+
+func TestRenderLauncherScriptRunsWithoutTextUtilities(t *testing.T) {
+	unamePath, err := exec.LookPath("uname")
+	if err != nil {
+		t.Fatalf("find uname: %v", err)
+	}
+	root := t.TempDir()
+	binDir := filepath.Join(root, "outputs", "bin", "linux", "amd64")
+	if err := os.MkdirAll(binDir, 0o755); err != nil {
+		t.Fatalf("mkdir runtime bin dir: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(root, "outputs", "bin", "linux", "arm64"), 0o755); err != nil {
+		t.Fatalf("mkdir arm64 runtime bin dir: %v", err)
+	}
+	runtimeScript := "#!/bin/sh\nprintf 'runtime:%s\\n' \"$1\"\n"
+	for _, arch := range []string{"amd64", "arm64"} {
+		path := filepath.Join(root, "outputs", "bin", "linux", arch, "deck")
+		if err := os.WriteFile(path, []byte(runtimeScript), 0o755); err != nil {
+			t.Fatalf("write runtime binary: %v", err)
+		}
+	}
+	launcherPath := filepath.Join(root, "deck")
+	if err := os.WriteFile(launcherPath, []byte(renderLauncherScript()), 0o755); err != nil {
+		t.Fatalf("write launcher: %v", err)
+	}
+	pathDir := filepath.Join(root, "path")
+	if err := os.MkdirAll(pathDir, 0o755); err != nil {
+		t.Fatalf("mkdir restricted path: %v", err)
+	}
+	if err := os.Symlink(unamePath, filepath.Join(pathDir, "uname")); err != nil {
+		t.Fatalf("symlink uname: %v", err)
+	}
+
+	cmd := exec.Command(launcherPath, "version")
+	cmd.Env = []string{"PATH=" + pathDir}
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("launcher failed without text utilities: %v\n%s", err, out)
+	}
+	if got, want := strings.TrimSpace(string(out)), "runtime:version"; got != want {
+		t.Fatalf("launcher output = %q, want %q", got, want)
 	}
 }

--- a/internal/preparecli/launcher_test.go
+++ b/internal/preparecli/launcher_test.go
@@ -18,6 +18,7 @@ func TestRenderLauncherScriptUsesStructuredErrors(t *testing.T) {
 		`log_error runtime_binary_not_executable path "outputs/bin/$deck_os/$deck_arch/deck"`,
 		`log_error runtime_binary_missing os "$deck_os" architecture "$deck_arch" path "outputs/bin/$deck_os/$deck_arch/deck"`,
 		`script_dir_part=${script_path%/*}`,
+		`-*) script_dir_part=./$script_dir_part ;;`,
 	} {
 		if !strings.Contains(script, want) {
 			t.Fatalf("expected %q in launcher script", want)


### PR DESCRIPTION
## Summary
- Remove `tr`, `sed`, and `dirname` dependencies from the generated prepare launcher.
- Resolve the launcher directory with POSIX shell parameter expansion instead.
- Add a launcher execution test with a restricted `PATH` that only provides `uname`.

## Tests
- go test ./internal/preparecli -run 'TestRenderLauncherScript'
- make test && make lint