### PR TITLE
Improve CLI diagnostic verbosity UX

### DIFF
--- a/cmd/deck/apply_cli_test.go
+++ b/cmd/deck/apply_cli_test.go
@@ -13,6 +13,7 @@ import (
 	"testing"
 
 	"github.com/Airgap-Castaways/deck/internal/applycli"
+	"github.com/Airgap-Castaways/deck/internal/buildinfo"
 	"github.com/Airgap-Castaways/deck/internal/config"
 )
 
@@ -675,9 +676,13 @@ func TestPlan(t *testing.T) {
 	wfPath := filepath.Join(t.TempDir(), "apply.yaml")
 	writeWorkflowYAML(t, wfPath, "version: v1alpha1\nphases:\n  - name: install\n    steps:\n      - id: step-1\n        apiVersion: deck/v1alpha1\n        kind: Command\n        spec:\n          command: [\"true\"]\n")
 
-	before, err := runWithCapturedStdout([]string{"plan", "--workflow", wfPath})
-	if err != nil {
-		t.Fatalf("expected success, got %v", err)
+	planRes := execute([]string{"plan", "--workflow", wfPath})
+	if planRes.err != nil {
+		t.Fatalf("expected success, got %v", planRes.err)
+	}
+	before := planRes.stdout
+	if !strings.Contains(planRes.stderr, buildinfo.Summary()+" plan started") {
+		t.Fatalf("expected plan startup line on stderr, got %q", planRes.stderr)
 	}
 	if !strings.Contains(before, "SUMMARY steps=1 run=1 skip=0") {
 		t.Fatalf("expected summary in plan output, got %q", before)
@@ -858,6 +863,9 @@ func TestApplyDefaultShowsProgressLogs(t *testing.T) {
 	}
 	if res.stdout != "apply: ok\n" {
 		t.Fatalf("unexpected stdout: %q", res.stdout)
+	}
+	if !strings.Contains(res.stderr, buildinfo.Summary()+" apply started") {
+		t.Fatalf("expected apply startup line on stderr, got %q", res.stderr)
 	}
 	for _, want := range []string{"component=apply event=phase_started", "phase=install", "component=apply event=batch_started", "component=apply event=step_started", "step=progress-step", "component=apply event=step_succeeded", "component=apply event=batch_succeeded", "component=apply event=phase_succeeded"} {
 		if !strings.Contains(res.stderr, want) {

--- a/cmd/deck/apply_cli_test.go
+++ b/cmd/deck/apply_cli_test.go
@@ -816,14 +816,33 @@ func TestApplyVerboseDiagnostics(t *testing.T) {
 	if res.stdout != "apply: ok\n" {
 		t.Fatalf("unexpected stdout: %q", res.stdout)
 	}
-	for _, want := range []string{"component=apply event=run_requested", "workflow=" + wfPath, "component=apply event=runlog_created", "runlog=", "component=apply event=batch_started batch=install", "component=apply event=step_started", "step=verbose-step", "component=apply event=step_succeeded", "duration_ms=", "component=apply event=batch_succeeded batch=install"} {
+	for _, want := range []string{"component=apply event=run_requested", "workflow=" + wfPath, "component=apply event=execution_plan", "phases=1", "batches=1", "steps=1", "component=apply event=state_snapshot", "component=apply event=phase_plan", "phase=install", "component=apply event=batch_plan", "component=apply event=step_plan", "kind=Command", "component=apply event=runlog_created", "runlog=", "component=apply event=batch_started", "batch=install", "component=apply event=step_started", "step=verbose-step", "component=apply event=step_succeeded", "duration_ms=", "component=apply event=batch_succeeded", "component=apply event=run_completed", "status=ok"} {
+		if !strings.Contains(res.stderr, want) {
+			t.Fatalf("expected %q in stderr, got %q", want, res.stderr)
+		}
+	}
+	if strings.Contains(res.stderr, "component=apply event=step_contract") || strings.Contains(res.stderr, "component=apply event=execution_context") {
+		t.Fatalf("expected --v=2 to exclude v3 apply traces, got %q", res.stderr)
+	}
+}
+
+func TestApplyTraceDiagnostics(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	wfPath := filepath.Join(t.TempDir(), "apply-trace.yaml")
+	writeWorkflowYAML(t, wfPath, "version: v1alpha1\nvars:\n  mode: test\nphases:\n  - name: install\n    steps:\n      - id: trace-step\n        kind: Command\n        metadata:\n          owner: test\n        when: vars.mode == \"test\"\n        spec:\n          command: [\"true\"]\n")
+
+	res := execute([]string{"apply", "--workflow", wfPath, "--v=3"})
+	if res.err != nil {
+		t.Fatalf("expected success, got %v", res.err)
+	}
+	for _, want := range []string{"component=apply event=execution_context", "workflow_sha256=", "state_key=", "component=apply event=context_keys", "component=apply event=workflow_vars", "keys=mode", "component=apply event=state_runtime", "component=apply event=step_contract", "api_version=-", "metadata_keys=owner", "spec_keys=command"} {
 		if !strings.Contains(res.stderr, want) {
 			t.Fatalf("expected %q in stderr, got %q", want, res.stderr)
 		}
 	}
 }
 
-func TestApplyDefaultProgressLogs(t *testing.T) {
+func TestApplyDefaultSuppressesProgressLogs(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 	wfPath := filepath.Join(t.TempDir(), "apply-default-progress.yaml")
 	writeWorkflowYAML(t, wfPath, "version: v1alpha1\nphases:\n  - name: install\n    steps:\n      - id: progress-step\n        kind: Command\n        spec:\n          command: [\"true\"]\n")
@@ -837,11 +856,11 @@ func TestApplyDefaultProgressLogs(t *testing.T) {
 	if res.err != nil {
 		t.Fatalf("expected success, got %v", res.err)
 	}
-	if !strings.Contains(res.stderr, "component=apply event=step_started") || !strings.Contains(res.stderr, "step=progress-step") || !strings.Contains(res.stderr, "batch=install") {
-		t.Fatalf("expected started progress log, got %q", res.stderr)
+	if res.stdout != "apply: ok\n" {
+		t.Fatalf("unexpected stdout: %q", res.stdout)
 	}
-	if !strings.Contains(res.stderr, "component=apply event=batch_succeeded batch=install") || !strings.Contains(res.stderr, "duration_ms=") {
-		t.Fatalf("expected completion progress log with duration, got %q", res.stderr)
+	if strings.Contains(res.stderr, "component=apply event=step_started") || strings.Contains(res.stderr, "component=apply event=batch_succeeded") {
+		t.Fatalf("expected default verbosity to suppress progress logs, got %q", res.stderr)
 	}
 }
 
@@ -855,19 +874,20 @@ func TestApplyParallelBatchProgressLogs(t *testing.T) {
 	}
 	createValidBundleManifest(t, bundle)
 
-	res := execute([]string{"apply", "--workflow", wfPath, bundle})
+	res := execute([]string{"--v=1", "apply", "--workflow", wfPath, bundle})
 	if res.err != nil {
 		t.Fatalf("expected success, got %v", res.err)
 	}
 	for _, want := range []string{
-		"component=apply event=batch_started batch=install:downloads",
+		"component=apply event=batch_started",
+		"batch=install:downloads",
 		"parallel_group=downloads",
 		"batch_size=2",
 		"max_parallelism=2",
 		"component=apply event=step_started",
 		"step=first",
 		"step=second",
-		"component=apply event=batch_succeeded batch=install:downloads",
+		"component=apply event=batch_succeeded",
 		"duration_ms=",
 	} {
 		if !strings.Contains(res.stderr, want) {

--- a/cmd/deck/apply_cli_test.go
+++ b/cmd/deck/apply_cli_test.go
@@ -842,7 +842,7 @@ func TestApplyTraceDiagnostics(t *testing.T) {
 	}
 }
 
-func TestApplyDefaultSuppressesProgressLogs(t *testing.T) {
+func TestApplyDefaultShowsProgressLogs(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 	wfPath := filepath.Join(t.TempDir(), "apply-default-progress.yaml")
 	writeWorkflowYAML(t, wfPath, "version: v1alpha1\nphases:\n  - name: install\n    steps:\n      - id: progress-step\n        kind: Command\n        spec:\n          command: [\"true\"]\n")
@@ -859,8 +859,15 @@ func TestApplyDefaultSuppressesProgressLogs(t *testing.T) {
 	if res.stdout != "apply: ok\n" {
 		t.Fatalf("unexpected stdout: %q", res.stdout)
 	}
-	if strings.Contains(res.stderr, "component=apply event=step_started") || strings.Contains(res.stderr, "component=apply event=batch_succeeded") {
-		t.Fatalf("expected default verbosity to suppress progress logs, got %q", res.stderr)
+	for _, want := range []string{"component=apply event=batch_started", "component=apply event=step_started", "step=progress-step", "component=apply event=step_succeeded", "component=apply event=batch_succeeded"} {
+		if !strings.Contains(res.stderr, want) {
+			t.Fatalf("expected default verbosity to show progress log %q, got %q", want, res.stderr)
+		}
+	}
+	for _, hidden := range []string{"component=apply event=run_requested", "component=apply event=run_completed", "component=apply event=execution_plan"} {
+		if strings.Contains(res.stderr, hidden) {
+			t.Fatalf("expected default verbosity to suppress diagnostic log %q, got %q", hidden, res.stderr)
+		}
 	}
 }
 

--- a/cmd/deck/apply_cli_test.go
+++ b/cmd/deck/apply_cli_test.go
@@ -859,7 +859,7 @@ func TestApplyDefaultShowsProgressLogs(t *testing.T) {
 	if res.stdout != "apply: ok\n" {
 		t.Fatalf("unexpected stdout: %q", res.stdout)
 	}
-	for _, want := range []string{"component=apply event=batch_started", "component=apply event=step_started", "step=progress-step", "component=apply event=step_succeeded", "component=apply event=batch_succeeded"} {
+	for _, want := range []string{"component=apply event=phase_started", "phase=install", "component=apply event=batch_started", "component=apply event=step_started", "step=progress-step", "component=apply event=step_succeeded", "component=apply event=batch_succeeded", "component=apply event=phase_succeeded"} {
 		if !strings.Contains(res.stderr, want) {
 			t.Fatalf("expected default verbosity to show progress log %q, got %q", want, res.stderr)
 		}
@@ -867,6 +867,40 @@ func TestApplyDefaultShowsProgressLogs(t *testing.T) {
 	for _, hidden := range []string{"component=apply event=run_requested", "component=apply event=run_completed", "component=apply event=execution_plan"} {
 		if strings.Contains(res.stderr, hidden) {
 			t.Fatalf("expected default verbosity to suppress diagnostic log %q, got %q", hidden, res.stderr)
+		}
+	}
+
+	res = execute([]string{"apply", "--workflow", wfPath, bundle})
+	if res.err != nil {
+		t.Fatalf("expected second apply success, got %v", res.err)
+	}
+	if res.stdout != "apply: ok\n" {
+		t.Fatalf("unexpected second stdout: %q", res.stdout)
+	}
+	for _, want := range []string{"component=apply event=phase_skipped", "phase=install", "reason=completed", "component=apply event=step_skipped", "step=progress-step"} {
+		if !strings.Contains(res.stderr, want) {
+			t.Fatalf("expected default verbosity to show completed skip log %q, got %q", want, res.stderr)
+		}
+	}
+}
+
+func TestApplyDefaultShowsFailureProgressLogs(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	wfPath := filepath.Join(t.TempDir(), "apply-default-failure-progress.yaml")
+	writeWorkflowYAML(t, wfPath, "version: v1alpha1\nphases:\n  - name: install\n    steps:\n      - id: fail-step\n        kind: Command\n        spec:\n          command: [\"false\"]\n")
+	bundle := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(bundle, "workflows"), 0o755); err != nil {
+		t.Fatalf("mkdir bundle workflows: %v", err)
+	}
+	createValidBundleManifest(t, bundle)
+
+	res := execute([]string{"apply", "--workflow", wfPath, bundle})
+	if res.err == nil {
+		t.Fatalf("expected apply failure")
+	}
+	for _, want := range []string{"component=apply event=phase_started", "phase=install", "component=apply event=step_started", "step=fail-step", "component=apply event=step_failed", "status=failed", "component=apply event=batch_failed", "component=apply event=phase_failed"} {
+		if !strings.Contains(res.stderr, want) {
+			t.Fatalf("expected default verbosity to show failure progress log %q, got %q", want, res.stderr)
 		}
 	}
 }

--- a/cmd/deck/apply_cli_test.go
+++ b/cmd/deck/apply_cli_test.go
@@ -915,7 +915,7 @@ func TestApplyParallelBatchProgressLogs(t *testing.T) {
 	}
 	createValidBundleManifest(t, bundle)
 
-	res := execute([]string{"--v=1", "apply", "--workflow", wfPath, bundle})
+	res := execute([]string{"--v=2", "apply", "--workflow", wfPath, bundle})
 	if res.err != nil {
 		t.Fatalf("expected success, got %v", res.err)
 	}

--- a/cmd/deck/ask_ai_test.go
+++ b/cmd/deck/ask_ai_test.go
@@ -148,7 +148,7 @@ func synthesizeClassification(prompt string) string {
 
 func TestAskConfigCommands(t *testing.T) {
 	t.Setenv("XDG_CONFIG_HOME", filepath.Join(t.TempDir(), "config"))
-	out, err := runWithCapturedStdout([]string{"ask", "config", "set", "--provider", "openrouter", "--model", "anthropic/claude-3.5-sonnet", "--endpoint", "https://openrouter.ai/api/v1", "--api-key", "secret-token", "--oauth-token", "oauth-token", "--log-level", "debug"})
+	out, err := runWithCapturedStdout([]string{"ask", "config", "set", "--provider", "openrouter", "--model", "anthropic/claude-3.5-sonnet", "--endpoint", "https://openrouter.ai/api/v1", "--api-key", "secret-token", "--oauth-token", "oauth-token"})
 	if err != nil {
 		t.Fatalf("config set: %v", err)
 	}
@@ -159,7 +159,7 @@ func TestAskConfigCommands(t *testing.T) {
 	if err != nil {
 		t.Fatalf("config show: %v", err)
 	}
-	for _, want := range []string{"provider=openrouter", "model=anthropic/claude-3.5-sonnet", "endpoint=https://openrouter.ai/api/v1", "endpointSource=config", "logLevel=debug", "mcpEnabled=false", "apiKey=secr****oken", "apiKeySource=config", "oauthToken=oaut***oken", "oauthTokenSource=config", "authStatus="} {
+	for _, want := range []string{"provider=openrouter", "model=anthropic/claude-3.5-sonnet", "endpoint=https://openrouter.ai/api/v1", "endpointSource=config", "mcpEnabled=false", "apiKey=secr****oken", "apiKeySource=config", "oauthToken=oaut***oken", "oauthTokenSource=config", "authStatus="} {
 		if !strings.Contains(out, want) {
 			t.Fatalf("expected %q in config show output, got %q", want, out)
 		}
@@ -170,6 +170,81 @@ func TestAskConfigCommands(t *testing.T) {
 	}
 	if !strings.Contains(out, "ask config cleared") {
 		t.Fatalf("unexpected config unset output: %q", out)
+	}
+}
+
+func TestAskVerbosityOverridesStoredTraceLogLevel(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(t.TempDir(), "config"))
+	configPath, err := askconfig.ConfigPath()
+	if err != nil {
+		t.Fatalf("config path: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(configPath), 0o700); err != nil {
+		t.Fatalf("mkdir ask config: %v", err)
+	}
+	legacyConfig := []byte(`{"ask":{"provider":"openai","model":"gpt-5.4","logLevel":"trace"}}`)
+	if err := os.WriteFile(configPath, legacyConfig, 0o600); err != nil {
+		t.Fatalf("write legacy ask config: %v", err)
+	}
+	root := t.TempDir()
+	oldWD, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	if err := os.Chdir(root); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(oldWD) })
+
+	res := execute([]string{"ask", "--review", "review workspace"})
+	if res.err != nil {
+		t.Fatalf("ask review: %v", res.err)
+	}
+	if strings.Contains(res.stderr, "log_level=") {
+		t.Fatalf("expected default --v=0 to suppress ask logs, got %q", res.stderr)
+	}
+	if strings.Contains(res.stdout, "ask status:") || strings.Contains(res.stderr, "ask status:") {
+		t.Fatalf("expected default --v=0 to suppress ask progress, got stdout=%q stderr=%q", res.stdout, res.stderr)
+	}
+	for _, hidden := range []string{"event=command", "event=request content="} {
+		if strings.Contains(res.stderr, hidden) {
+			t.Fatalf("expected %s to stay hidden at default verbosity, got %q", hidden, res.stderr)
+		}
+	}
+
+	res = execute([]string{"--v=1", "ask", "--review", "review workspace"})
+	if res.err != nil {
+		t.Fatalf("ask review --v=1: %v", res.err)
+	}
+	if !strings.Contains(res.stderr, "log_level=basic") {
+		t.Fatalf("expected --v=1 to enable basic ask logs, got %q", res.stderr)
+	}
+	if strings.Contains(res.stdout, "ask status:") {
+		t.Fatalf("expected ask progress on stderr, not stdout, got stdout=%q", res.stdout)
+	}
+	for _, hidden := range []string{"event=command", "event=request content="} {
+		if strings.Contains(res.stderr, hidden) {
+			t.Fatalf("expected %s to stay hidden at --v=1, got %q", hidden, res.stderr)
+		}
+	}
+
+	res = execute([]string{"--v=2", "ask", "--review", "review workspace"})
+	if res.err != nil {
+		t.Fatalf("ask review --v=2: %v", res.err)
+	}
+	if !strings.Contains(res.stderr, "log_level=debug") || !strings.Contains(res.stderr, "event=command") {
+		t.Fatalf("expected --v=2 to enable debug ask logs, got %q", res.stderr)
+	}
+	if strings.Contains(res.stderr, "event=request content=") {
+		t.Fatalf("expected trace request log to stay hidden at --v=2, got %q", res.stderr)
+	}
+
+	res = execute([]string{"--v=3", "ask", "--review", "review workspace"})
+	if res.err != nil {
+		t.Fatalf("ask review --v=3: %v", res.err)
+	}
+	if !strings.Contains(res.stderr, "log_level=trace") || !strings.Contains(res.stderr, "event=request content=") {
+		t.Fatalf("expected --v=3 to enable trace ask logs, got %q", res.stderr)
 	}
 }
 
@@ -238,7 +313,6 @@ func TestAskConfigShowIncludesStoredMCPSettings(t *testing.T) {
 		Model:      "gpt-5.4",
 		APIKey:     testAPIKey(),
 		OAuthToken: testOAuthToken(),
-		LogLevel:   "trace",
 		MCP:        askconfig.MCP{Enabled: true, Servers: []askconfig.MCPServer{{Name: "context7", RunCommand: "context7-mcp"}}},
 	}); err != nil {
 		t.Fatalf("save stored config: %v", err)
@@ -247,7 +321,7 @@ func TestAskConfigShowIncludesStoredMCPSettings(t *testing.T) {
 	if err != nil {
 		t.Fatalf("config show: %v", err)
 	}
-	for _, want := range []string{"logLevel=trace", "mcpEnabled=true", "mcpProviderCount=1", "mcpProvider[0].name=context7", "mcpProvider[0].id=context7", "mcpProvider[0].transport=context7-mcp", "mcpProvider[0].transportSource=config-override", "mcpProvider[0].capabilities=entity-resolve,doc-fetch,official-doc-search"} {
+	for _, want := range []string{"mcpEnabled=true", "mcpProviderCount=1", "mcpProvider[0].name=context7", "mcpProvider[0].id=context7", "mcpProvider[0].transport=context7-mcp", "mcpProvider[0].transportSource=config-override", "mcpProvider[0].capabilities=entity-resolve,doc-fetch,official-doc-search"} {
 		if !strings.Contains(out, want) {
 			t.Fatalf("expected %q in config show output, got %q", want, out)
 		}

--- a/cmd/deck/cmd_apply.go
+++ b/cmd/deck/cmd_apply.go
@@ -320,6 +320,7 @@ func runApplyWithOptions(env *cliEnv, ctx context.Context, opts applyOptions) er
 	if err != nil {
 		return err
 	}
+	invocationID := newInvocationID("apply")
 	return applycli.RunApplyCommand(ctx, applycli.ApplyCommandOptions{
 		WorkflowPath:   workflowPath,
 		BundleRoot:     bundleRoot,
@@ -334,7 +335,8 @@ func runApplyWithOptions(env *cliEnv, ctx context.Context, opts applyOptions) er
 		Verbosef:       env.verbosef,
 		StdoutPrintf:   env.stdoutPrintf,
 		StdoutPrintln:  env.stdoutPrintln,
-		AdditionalSink: verboseApplyStepSink(env),
+		InvocationID:   invocationID,
+		AdditionalSink: verboseApplyStepSink(env, invocationID),
 		NewRunLogger: func(workflowPath, workflowSource, scenario, bundleRoot, selectedPhase string) (applycli.RunLogger, error) {
 			return newApplyRunLogger(env, workflowPath, workflowSource, scenario, bundleRoot, selectedPhase)
 		},

--- a/cmd/deck/cmd_apply.go
+++ b/cmd/deck/cmd_apply.go
@@ -197,6 +197,9 @@ func runPlanVarsWithOptions(env *cliEnv, ctx context.Context, opts planVarsOptio
 }
 
 func runDiffWithOptions(env *cliEnv, ctx context.Context, opts diffOptions) error {
+	if err := env.commandStarted("plan"); err != nil {
+		return err
+	}
 	workflowPath, err := resolvePlanWorkflowPath(ctx, strings.TrimSpace(opts.workflowPath), strings.TrimSpace(opts.scenario), strings.TrimSpace(opts.source))
 	if err != nil {
 		return err
@@ -314,6 +317,9 @@ func runApplyWithOptions(env *cliEnv, ctx context.Context, opts applyOptions) er
 	positionalArgs := make([]string, 0, len(opts.positional))
 	for _, arg := range opts.positional {
 		positionalArgs = append(positionalArgs, strings.TrimSpace(arg))
+	}
+	if err := env.commandStarted("apply"); err != nil {
+		return err
 	}
 
 	workflowPath, bundleRoot, err := resolveApplyWorkflowAndBundle(ctx, opts, positionalArgs)

--- a/cmd/deck/cmd_apply_events.go
+++ b/cmd/deck/cmd_apply_events.go
@@ -15,7 +15,7 @@ func verboseApplyStepSink(env *cliEnv, invocationID string) install.StepEventSin
 	}
 	return func(event install.StepEvent) {
 		event.InvocationID = invocationID
-		_ = env.stderrPrintf("%s\n", formatWorkflowEventLine("apply", event))
+		_ = env.stderrPrintf("%s\n", formatWorkflowEventLine("apply", event, env.verbosity, env.logFormat))
 	}
 }
 

--- a/cmd/deck/cmd_apply_events.go
+++ b/cmd/deck/cmd_apply_events.go
@@ -9,8 +9,12 @@ import (
 	"github.com/Airgap-Castaways/deck/internal/lintcli"
 )
 
-func verboseApplyStepSink(env *cliEnv) install.StepEventSink {
+func verboseApplyStepSink(env *cliEnv, invocationID string) install.StepEventSink {
+	if env == nil || env.verbosity < 1 {
+		return nil
+	}
 	return func(event install.StepEvent) {
+		event.InvocationID = invocationID
 		_ = env.stderrPrintf("%s\n", formatWorkflowEventLine("apply", event))
 	}
 }

--- a/cmd/deck/cmd_apply_events.go
+++ b/cmd/deck/cmd_apply_events.go
@@ -10,7 +10,7 @@ import (
 )
 
 func verboseApplyStepSink(env *cliEnv, invocationID string) install.StepEventSink {
-	if env == nil || env.verbosity < 1 {
+	if env == nil {
 		return nil
 	}
 	return func(event install.StepEvent) {

--- a/cmd/deck/cmd_cache.go
+++ b/cmd/deck/cmd_cache.go
@@ -19,7 +19,16 @@ type cacheEntry struct {
 	ModTime   string `json:"mod_time"`
 }
 
-func executeCacheList(env *cliEnv, output string) error {
+func executeCacheList(env *cliEnv, output string) (err error) {
+	started := time.Now().UTC()
+	entryCount := 0
+	defer func() {
+		status := "ok"
+		if err != nil {
+			status = "failed"
+		}
+		_ = env.verboseCLIEvent(1, ctrllogs.CLIEvent{Component: "cache", Event: "list_completed", Attrs: map[string]any{"status": status, "duration_ms": time.Since(started).Milliseconds(), "entries": entryCount}})
+	}()
 	resolvedOutput, err := resolveOutputFormat(output)
 	if err != nil {
 		return err
@@ -36,8 +45,17 @@ func executeCacheList(env *cliEnv, output string) error {
 	if err != nil {
 		return err
 	}
+	entryCount = len(entries)
 	if err := env.verboseCLIEvent(1, ctrllogs.CLIEvent{Component: "cache", Event: "list_loaded", Attrs: map[string]any{"entries": len(entries)}}); err != nil {
 		return err
+	}
+	if err := env.verboseCLIEvent(2, ctrllogs.CLIEvent{Level: "debug", Component: "cache", Event: "list_summary", Attrs: cacheEntriesSummary(entries)}); err != nil {
+		return err
+	}
+	for idx, entry := range entries {
+		if err := env.verboseCLIEvent(3, ctrllogs.CLIEvent{Level: "debug", Component: "cache", Event: "list_entry", Attrs: map[string]any{"entry_index": idx + 1, "entry_count": len(entries), "path": entry.Path, "size_bytes": entry.SizeBytes, "mod_time": entry.ModTime}}); err != nil {
+			return err
+		}
 	}
 	if resolvedOutput == "json" {
 		enc := env.stdoutJSONEncoder()
@@ -51,7 +69,17 @@ func executeCacheList(env *cliEnv, output string) error {
 	return nil
 }
 
-func executeCacheClean(env *cliEnv, olderThan string, dryRun bool) error {
+func executeCacheClean(env *cliEnv, olderThan string, dryRun bool) (err error) {
+	started := time.Now().UTC()
+	matchCount := 0
+	deletedCount := 0
+	defer func() {
+		status := "ok"
+		if err != nil {
+			status = "failed"
+		}
+		_ = env.verboseCLIEvent(1, ctrllogs.CLIEvent{Component: "cache", Event: "clean_completed", Attrs: map[string]any{"status": status, "duration_ms": time.Since(started).Milliseconds(), "matches": matchCount, "deleted": deletedCount, "dry_run": dryRun}})
+	}()
 	root, err := defaultDeckCacheRoot()
 	if err != nil {
 		return err
@@ -61,18 +89,28 @@ func executeCacheClean(env *cliEnv, olderThan string, dryRun bool) error {
 	}
 	cutoff, hasCutoff, err := parseOlderThan(olderThan)
 	if err != nil {
+		_ = env.verboseCLIEvent(1, ctrllogs.CLIEvent{Level: "error", Component: "cache", Event: "clean_parse_failed", Attrs: map[string]any{"older_than": strings.TrimSpace(olderThan), "error": err, "suggestion": "use a duration such as 24h, 7d, or 30d"}})
 		return err
 	}
 	plan, err := computeCacheCleanPlan(root, cutoff, hasCutoff)
 	if err != nil {
 		return err
 	}
+	matchCount = len(plan)
 	if err := env.verboseCLIEvent(1, ctrllogs.CLIEvent{Component: "cache", Event: "clean_planned", Attrs: map[string]any{"matches": len(plan)}}); err != nil {
+		return err
+	}
+	if err := env.verboseCLIEvent(2, ctrllogs.CLIEvent{Level: "debug", Component: "cache", Event: "clean_cutoff", Attrs: map[string]any{"has_cutoff": hasCutoff, "cutoff": formatCacheCutoff(cutoff)}}); err != nil {
 		return err
 	}
 	for _, p := range plan {
 		if err := env.verboseCLIEvent(2, ctrllogs.CLIEvent{Component: "cache", Event: "clean_match", Attrs: map[string]any{"path": p}}); err != nil {
 			return err
+		}
+		if info, statErr := os.Stat(p); statErr == nil {
+			if err := env.verboseCLIEvent(3, ctrllogs.CLIEvent{Level: "debug", Component: "cache", Event: "clean_match_stat", Attrs: map[string]any{"path": p, "is_dir": info.IsDir(), "size_bytes": info.Size(), "mod_time": info.ModTime().UTC().Format(time.RFC3339)}}); err != nil {
+				return err
+			}
 		}
 		if err := env.stdoutPrintln(p); err != nil {
 			return err
@@ -85,8 +123,32 @@ func executeCacheClean(env *cliEnv, olderThan string, dryRun bool) error {
 		if err := os.RemoveAll(p); err != nil {
 			return fmt.Errorf("delete %s: %w", p, err)
 		}
+		deletedCount++
 	}
 	return nil
+}
+
+func cacheEntriesSummary(entries []cacheEntry) map[string]any {
+	totalBytes := int64(0)
+	oldest := ""
+	newest := ""
+	for _, entry := range entries {
+		totalBytes += entry.SizeBytes
+		if oldest == "" || entry.ModTime < oldest {
+			oldest = entry.ModTime
+		}
+		if newest == "" || entry.ModTime > newest {
+			newest = entry.ModTime
+		}
+	}
+	return map[string]any{"entries": len(entries), "total_bytes": totalBytes, "oldest": displayValueOrDash(oldest), "newest": displayValueOrDash(newest)}
+}
+
+func formatCacheCutoff(cutoff time.Time) string {
+	if cutoff.IsZero() {
+		return "-"
+	}
+	return cutoff.UTC().Format(time.RFC3339)
 }
 
 func defaultDeckCacheRoot() (string, error) {

--- a/cmd/deck/cmd_prepare.go
+++ b/cmd/deck/cmd_prepare.go
@@ -90,7 +90,8 @@ func newPrepareCommand(env *cliEnv) *cobra.Command {
 }
 
 func runPrepareWithOptions(env *cliEnv, cmd *cobra.Command, opts prepareOptions) error {
-	if err := env.verboseCLIEvent(1, ctrllogs.CLIEvent{Component: "prepare", Event: "run_requested", Attrs: map[string]any{"root": opts.preparedRoot, "dry_run": opts.dryRun, "refresh": opts.refresh, "clean": opts.clean}}); err != nil {
+	invocationID := newInvocationID("prepare")
+	if err := env.verboseCLIEvent(1, ctrllogs.CLIEvent{Component: "prepare", Event: "run_requested", Attrs: map[string]any{"invocation_id": invocationID, "root": opts.preparedRoot, "dry_run": opts.dryRun, "refresh": opts.refresh, "clean": opts.clean}}); err != nil {
 		return err
 	}
 	return preparecli.Run(cmd.Context(), preparecli.Options{
@@ -107,6 +108,7 @@ func runPrepareWithOptions(env *cliEnv, cmd *cobra.Command, opts prepareOptions)
 		VarsFiles:      append([]string(nil), opts.varsFiles...),
 		Stdout:         env.stdoutWriter(),
 		Diagnosticf:    env.verbosef,
-		EventSink:      verbosePrepareStepSink(env),
+		InvocationID:   invocationID,
+		EventSink:      verbosePrepareStepSink(env, invocationID),
 	})
 }

--- a/cmd/deck/cmd_prepare_events.go
+++ b/cmd/deck/cmd_prepare_events.go
@@ -4,8 +4,12 @@ import (
 	"github.com/Airgap-Castaways/deck/internal/prepare"
 )
 
-func verbosePrepareStepSink(env *cliEnv) prepare.StepEventSink {
+func verbosePrepareStepSink(env *cliEnv, invocationID string) prepare.StepEventSink {
+	if env == nil || env.verbosity < 1 {
+		return nil
+	}
 	return func(event prepare.StepEvent) {
+		event.InvocationID = invocationID
 		_ = env.stderrPrintf("%s\n", formatWorkflowEventLine("prepare", event))
 	}
 }

--- a/cmd/deck/cmd_prepare_events.go
+++ b/cmd/deck/cmd_prepare_events.go
@@ -10,6 +10,6 @@ func verbosePrepareStepSink(env *cliEnv, invocationID string) prepare.StepEventS
 	}
 	return func(event prepare.StepEvent) {
 		event.InvocationID = invocationID
-		_ = env.stderrPrintf("%s\n", formatWorkflowEventLine("prepare", event))
+		_ = env.stderrPrintf("%s\n", formatWorkflowEventLine("prepare", event, env.verbosity, env.logFormat))
 	}
 }

--- a/cmd/deck/cmd_prepare_events.go
+++ b/cmd/deck/cmd_prepare_events.go
@@ -5,7 +5,7 @@ import (
 )
 
 func verbosePrepareStepSink(env *cliEnv, invocationID string) prepare.StepEventSink {
-	if env == nil || env.verbosity < 1 {
+	if env == nil {
 		return nil
 	}
 	return func(event prepare.StepEvent) {

--- a/cmd/deck/cmd_serve.go
+++ b/cmd/deck/cmd_serve.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"os/signal"
 	"path/filepath"
+	"slices"
 	"strconv"
 	"strings"
 	"syscall"
@@ -158,6 +159,7 @@ func executeHealth(env *cliEnv, ctx context.Context, server string, output strin
 	}
 	resolvedServer, _, err := resolveRequiredSourceURL(server)
 	if err != nil {
+		_ = env.verboseCLIEvent(1, ctrllogs.CLIEvent{TS: time.Now().UTC(), Level: "error", Component: "server", Event: "health_check_failed", Attrs: map[string]any{"error": err, "suggestion": "set a remote with `deck server remote set <url>` or pass --server"}})
 		return err
 	}
 	if err := env.verboseCLIEvent(1, ctrllogs.CLIEvent{TS: time.Now().UTC(), Level: "info", Component: "server", Event: "health_check", Attrs: map[string]any{"server": resolvedServer}}); err != nil {
@@ -169,18 +171,24 @@ func executeHealth(env *cliEnv, ctx context.Context, server string, output strin
 	if err := env.verboseCLIEvent(2, ctrllogs.CLIEvent{TS: time.Now().UTC(), Level: "debug", Component: "server", Event: "health_check", Attrs: map[string]any{"server": resolvedServer, "url": healthURL}}); err != nil {
 		return err
 	}
+	if err := env.verboseCLIEvent(3, ctrllogs.CLIEvent{TS: time.Now().UTC(), Level: "debug", Component: "server", Event: "health_request", Attrs: map[string]any{"method": http.MethodGet, "url": healthURL, "timeout_ms": 5000}}); err != nil {
+		return err
+	}
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, healthURL, nil)
 	if err != nil {
 		return fmt.Errorf("health: build request: %w", err)
 	}
+	started := time.Now().UTC()
 	resp, err := client.Do(req)
+	durationMS := time.Since(started).Milliseconds()
 	if err != nil {
-		_ = env.verboseCLIEvent(2, ctrllogs.CLIEvent{TS: time.Now().UTC(), Level: "error", Component: "server", Event: "health_check_failed", Attrs: map[string]any{"server": resolvedServer, "url": healthURL, "error": err}})
+		_ = env.verboseCLIEvent(2, ctrllogs.CLIEvent{TS: time.Now().UTC(), Level: "error", Component: "server", Event: "health_check_failed", Attrs: map[string]any{"server": resolvedServer, "url": healthURL, "error": err, "suggestion": "check `deck server up`, the remote URL, and network/firewall access"}})
 		return fmt.Errorf("health: request failed: %w", err)
 	}
 	defer closeSilently(resp.Body)
+	_ = env.verboseCLIEvent(3, ctrllogs.CLIEvent{TS: time.Now().UTC(), Level: "debug", Component: "server", Event: "health_response", Attrs: map[string]any{"status": resp.StatusCode, "duration_ms": durationMS, "content_length": resp.ContentLength, "header_keys": strings.Join(sortedHeaderKeys(resp.Header), ",")}})
 	if resp.StatusCode != http.StatusOK {
-		_ = env.verboseCLIEvent(2, ctrllogs.CLIEvent{TS: time.Now().UTC(), Level: "warn", Component: "server", Event: "health_check", Attrs: map[string]any{"server": resolvedServer, "url": healthURL, "http_status": resp.StatusCode}})
+		_ = env.verboseCLIEvent(2, ctrllogs.CLIEvent{TS: time.Now().UTC(), Level: "warn", Component: "server", Event: "health_check", Attrs: map[string]any{"server": resolvedServer, "url": healthURL, "http_status": resp.StatusCode, "suggestion": "inspect server logs and confirm the bundle server is healthy"}})
 		return fmt.Errorf("health: unexpected status %d", resp.StatusCode)
 	}
 	if err := env.verboseCLIEvent(2, ctrllogs.CLIEvent{TS: time.Now().UTC(), Level: "info", Component: "server", Event: "health_check", Attrs: map[string]any{"server": resolvedServer, "url": healthURL, "http_status": resp.StatusCode}}); err != nil {
@@ -250,6 +258,12 @@ func executeLogs(env *cliEnv, ctx context.Context, root string, source string, p
 	if err := env.verboseCLIEvent(1, ctrllogs.CLIEvent{TS: time.Now().UTC(), Level: "info", Component: "server", Event: "logs_loaded", Attrs: map[string]any{"records": len(records)}}); err != nil {
 		return err
 	}
+	if err := env.verboseCLIEvent(2, ctrllogs.CLIEvent{TS: time.Now().UTC(), Level: "debug", Component: "server", Event: "logs_summary", Attrs: summarizeLogRecords(records)}); err != nil {
+		return err
+	}
+	if err := env.verboseCLIEvent(3, ctrllogs.CLIEvent{TS: time.Now().UTC(), Level: "debug", Component: "server", Event: "logs_window", Attrs: logRecordWindow(records)}); err != nil {
+		return err
+	}
 
 	if resolvedOutput == "json" {
 		enc := env.stdoutJSONEncoder()
@@ -261,6 +275,55 @@ func executeLogs(env *cliEnv, ctx context.Context, root string, source string, p
 		}
 	}
 	return nil
+}
+
+func sortedHeaderKeys(header http.Header) []string {
+	if len(header) == 0 {
+		return nil
+	}
+	keys := make([]string, 0, len(header))
+	for key := range header {
+		keys = append(keys, key)
+	}
+	slices.Sort(keys)
+	return keys
+}
+
+func summarizeLogRecords(records []ctrllogs.LogRecord) map[string]any {
+	levels := map[string]int{}
+	sources := map[string]int{}
+	for _, record := range records {
+		levels[displayValueOrDash(record.Level)]++
+		sources[displayValueOrDash(record.Source)]++
+	}
+	return map[string]any{"records": len(records), "levels": compactCounts(levels), "sources": compactCounts(sources)}
+}
+
+func logRecordWindow(records []ctrllogs.LogRecord) map[string]any {
+	if len(records) == 0 {
+		return map[string]any{"first_ts": "-", "last_ts": "-", "event_types": "-"}
+	}
+	events := map[string]int{}
+	for _, record := range records {
+		events[displayValueOrDash(record.EventType)]++
+	}
+	return map[string]any{"first_ts": displayValueOrDash(records[0].TS), "last_ts": displayValueOrDash(records[len(records)-1].TS), "event_types": compactCounts(events)}
+}
+
+func compactCounts(counts map[string]int) string {
+	if len(counts) == 0 {
+		return "-"
+	}
+	keys := make([]string, 0, len(counts))
+	for key := range counts {
+		keys = append(keys, key)
+	}
+	slices.Sort(keys)
+	parts := make([]string, 0, len(keys))
+	for _, key := range keys {
+		parts = append(parts, fmt.Sprintf("%s:%d", key, counts[key]))
+	}
+	return strings.Join(parts, ",")
 }
 
 func resolveLogsFilePath(root string, path string) (string, error) {

--- a/cmd/deck/cobra_ask_ai.go
+++ b/cmd/deck/cobra_ask_ai.go
@@ -65,6 +65,7 @@ func newAskCommand(env *cliEnv) *cobra.Command {
 				Provider:      provider,
 				Model:         model,
 				Endpoint:      endpoint,
+				LogLevel:      askLogLevelForVerbosity(env.verbosity),
 				Stdin:         cmd.InOrStdin(),
 				Stdout:        cmd.OutOrStdout(),
 				Stderr:        cmd.ErrOrStderr(),
@@ -83,14 +84,14 @@ func newAskCommand(env *cliEnv) *cobra.Command {
 	cmd.Flags().StringVar(&planName, "plan-name", "", "optional plan artifact name used by ask plan")
 	cmd.Flags().StringVar(&planDir, "plan-dir", ".deck/plan", "directory for ask plan artifacts")
 
-	cmd.AddCommand(newAskPlanCommand())
+	cmd.AddCommand(newAskPlanCommand(env))
 	cmd.AddCommand(newAskConfigCommand(env))
 	cmd.AddCommand(newAskMCPCommand())
 	cmd.AddCommand(newAskLoginCommand(env), newAskLogoutCommand(env), newAskStatusCommand(env))
 	return cmd
 }
 
-func newAskPlanCommand() *cobra.Command {
+func newAskPlanCommand(env *cliEnv) *cobra.Command {
 	var fromPath string
 	var answers []string
 	var planName string
@@ -121,6 +122,7 @@ func newAskPlanCommand() *cobra.Command {
 				Provider: provider,
 				Model:    model,
 				Endpoint: endpoint,
+				LogLevel: askLogLevelForVerbosity(env.verbosity),
 				Stdin:    cmd.InOrStdin(),
 				Stdout:   cmd.OutOrStdout(),
 				Stderr:   cmd.ErrOrStderr(),
@@ -135,6 +137,19 @@ func newAskPlanCommand() *cobra.Command {
 	cmd.Flags().StringVar(&model, "model", "", "override the configured ask model for this run")
 	cmd.Flags().StringVar(&endpoint, "endpoint", "", "override the configured ask provider endpoint for this run")
 	return cmd
+}
+
+func askLogLevelForVerbosity(level int) string {
+	switch {
+	case level >= 3:
+		return "trace"
+	case level >= 2:
+		return "debug"
+	case level >= 1:
+		return "basic"
+	default:
+		return "off"
+	}
 }
 
 func newAskConfigCommand(env *cliEnv) *cobra.Command {
@@ -156,7 +171,6 @@ func newAskConfigSetCommand(env *cliEnv) *cobra.Command {
 	var provider string
 	var model string
 	var endpoint string
-	var logLevel string
 	cmd := &cobra.Command{
 		Use:   "set",
 		Short: "Save ask config defaults and api key",
@@ -182,17 +196,13 @@ func newAskConfigSetCommand(env *cliEnv) *cobra.Command {
 			if value := strings.TrimSpace(endpoint); value != "" {
 				updated.Endpoint = value
 			}
-			if value := strings.TrimSpace(logLevel); value != "" {
-				updated.LogLevel = value
-			}
 			changed := settings.Provider != updated.Provider ||
 				settings.Model != updated.Model ||
 				settings.APIKey != updated.APIKey ||
 				settings.OAuthToken != updated.OAuthToken ||
-				settings.Endpoint != updated.Endpoint ||
-				settings.LogLevel != updated.LogLevel
+				settings.Endpoint != updated.Endpoint
 			if !changed {
-				return fmt.Errorf("ask config set requires at least one of --api-key, --oauth-token, --provider, --model, --endpoint, or --log-level")
+				return fmt.Errorf("ask config set requires at least one of --api-key, --oauth-token, --provider, --model, or --endpoint")
 			}
 			if err := askconfig.SaveStored(updated); err != nil {
 				return err
@@ -205,7 +215,6 @@ func newAskConfigSetCommand(env *cliEnv) *cobra.Command {
 	cmd.Flags().StringVar(&provider, "provider", "", "save the default ask provider")
 	cmd.Flags().StringVar(&model, "model", "", "save the default ask model")
 	cmd.Flags().StringVar(&endpoint, "endpoint", "", "save the default ask provider endpoint")
-	cmd.Flags().StringVar(&logLevel, "log-level", "", "save the ask terminal log level (basic, debug, trace)")
 	return cmd
 }
 
@@ -235,9 +244,6 @@ func newAskConfigShowCommand(env *cliEnv) *cobra.Command {
 				return err
 			}
 			if err := env.stdoutPrintf("endpointSource=%s\n", effective.EndpointSource); err != nil {
-				return err
-			}
-			if err := env.stdoutPrintf("logLevel=%s\n", effective.LogLevel); err != nil {
 				return err
 			}
 			if err := env.stdoutPrintf("mcpEnabled=%t\n", effective.MCP.Enabled); err != nil {

--- a/cmd/deck/cobra_completion.go
+++ b/cmd/deck/cobra_completion.go
@@ -8,8 +8,19 @@ import (
 
 func newCompletionCommand() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:                   "completion <bash|zsh|fish|powershell>",
-		Short:                 "Generate shell completion scripts",
+		Use:   "completion <bash|zsh|fish|powershell>",
+		Short: "Generate shell completion scripts",
+		Long: `Generate shell completion scripts.
+
+Immediate sourcing:
+  bash: source <(deck completion bash)
+  zsh:  source <(deck completion zsh)
+  fish: deck completion fish | source
+
+Persistent setup:
+  bash: add 'source <(deck completion bash)' to ~/.bashrc
+  zsh:  add 'source <(deck completion zsh)' to ~/.zshrc
+  fish: deck completion fish > ~/.config/fish/completions/deck.fish`,
 		Args:                  cobra.ExactArgs(1),
 		DisableFlagsInUseLine: true,
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/cmd/deck/cobra_server.go
+++ b/cmd/deck/cobra_server.go
@@ -4,9 +4,11 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/spf13/cobra"
 
@@ -233,7 +235,15 @@ func newServerRemoteUnsetCommand(env *cliEnv) *cobra.Command {
 	return cmd
 }
 
-func executeServerRemoteSet(env *cliEnv, rawURL string) error {
+func executeServerRemoteSet(env *cliEnv, rawURL string) (err error) {
+	started := time.Now().UTC()
+	defer func() {
+		status := "ok"
+		if err != nil {
+			status = "failed"
+		}
+		_ = env.verboseCLIEvent(1, ctrllogs.CLIEvent{Component: "server", Event: "remote_completed", Attrs: map[string]any{"operation": "set", "status": status, "duration_ms": time.Since(started).Milliseconds()}})
+	}()
 	resolved := strings.TrimRight(strings.TrimSpace(rawURL), "/")
 	if err := validateSourceURL(resolved); err != nil {
 		return err
@@ -242,7 +252,10 @@ func executeServerRemoteSet(env *cliEnv, rawURL string) error {
 	if err != nil {
 		return err
 	}
-	if err := env.verboseCLIEvent(1, ctrllogs.CLIEvent{Component: "server", Event: "remote_set", Attrs: map[string]any{"url": resolved, "config": configPath}}); err != nil {
+	if err := env.verboseCLIEvent(1, ctrllogs.CLIEvent{Component: "server", Event: "remote_set", Attrs: map[string]any{"url": redactDiagnosticURLString(resolved), "config": configPath}}); err != nil {
+		return err
+	}
+	if err := emitRemoteTargetDetails(env, "remote_set_target", resolved); err != nil {
 		return err
 	}
 	if err := saveSourceDefaults(sourceDefaults{URL: resolved}); err != nil {
@@ -251,7 +264,15 @@ func executeServerRemoteSet(env *cliEnv, rawURL string) error {
 	return env.stdoutPrintf("server remote set: %s\n", resolved)
 }
 
-func executeServerRemoteShow(env *cliEnv) error {
+func executeServerRemoteShow(env *cliEnv) (err error) {
+	started := time.Now().UTC()
+	defer func() {
+		status := "ok"
+		if err != nil {
+			status = "failed"
+		}
+		_ = env.verboseCLIEvent(1, ctrllogs.CLIEvent{Component: "server", Event: "remote_completed", Attrs: map[string]any{"operation": "show", "status": status, "duration_ms": time.Since(started).Milliseconds()}})
+	}()
 	configPath, err := sourceDefaultsPath()
 	if err != nil {
 		return err
@@ -260,7 +281,10 @@ func executeServerRemoteShow(env *cliEnv) error {
 	if err != nil {
 		return err
 	}
-	if err := env.verboseCLIEvent(1, ctrllogs.CLIEvent{Component: "server", Event: "remote_show", Attrs: map[string]any{"config": configPath, "resolved": displayValueOrDash(resolved), "origin": displayValueOrDash(source)}}); err != nil {
+	if err := env.verboseCLIEvent(1, ctrllogs.CLIEvent{Component: "server", Event: "remote_show", Attrs: map[string]any{"config": configPath, "resolved": displayValueOrDash(redactDiagnosticURLString(resolved)), "origin": displayValueOrDash(source)}}); err != nil {
+		return err
+	}
+	if err := emitRemoteTargetDetails(env, "remote_show_target", resolved); err != nil {
 		return err
 	}
 	if resolved == "" {
@@ -275,7 +299,15 @@ func executeServerRemoteShow(env *cliEnv) error {
 	return env.stdoutPrintf("origin=%s\n", source)
 }
 
-func executeServerRemoteUnset(env *cliEnv) error {
+func executeServerRemoteUnset(env *cliEnv) (err error) {
+	started := time.Now().UTC()
+	defer func() {
+		status := "ok"
+		if err != nil {
+			status = "failed"
+		}
+		_ = env.verboseCLIEvent(1, ctrllogs.CLIEvent{Component: "server", Event: "remote_completed", Attrs: map[string]any{"operation": "unset", "status": status, "duration_ms": time.Since(started).Milliseconds()}})
+	}()
 	configPath, err := sourceDefaultsPath()
 	if err != nil {
 		return err
@@ -283,10 +315,53 @@ func executeServerRemoteUnset(env *cliEnv) error {
 	if err := env.verboseCLIEvent(1, ctrllogs.CLIEvent{Component: "server", Event: "remote_unset", Attrs: map[string]any{"config": configPath}}); err != nil {
 		return err
 	}
+	if err := env.verboseCLIEvent(2, ctrllogs.CLIEvent{Level: "debug", Component: "server", Event: "remote_config", Attrs: map[string]any{"config": configPath}}); err != nil {
+		return err
+	}
 	if err := clearSourceDefaults(); err != nil {
 		return err
 	}
 	return env.stdoutPrintln("server remote cleared")
+}
+
+func emitRemoteTargetDetails(env *cliEnv, event string, raw string) error {
+	trimmed := strings.TrimSpace(raw)
+	if trimmed == "" {
+		return env.verboseCLIEvent(2, ctrllogs.CLIEvent{Level: "debug", Component: "server", Event: event, Attrs: map[string]any{"configured": false}})
+	}
+	parsed, err := url.Parse(trimmed)
+	if err != nil {
+		return env.verboseCLIEvent(2, ctrllogs.CLIEvent{Level: "debug", Component: "server", Event: event, Attrs: map[string]any{"configured": true, "parse_error": err.Error()}})
+	}
+	if err := env.verboseCLIEvent(2, ctrllogs.CLIEvent{Level: "debug", Component: "server", Event: event, Attrs: map[string]any{"configured": true, "scheme": parsed.Scheme, "host": parsed.Host, "path": displayValueOrDash(parsed.Path)}}); err != nil {
+		return err
+	}
+	return env.verboseCLIEvent(3, ctrllogs.CLIEvent{Level: "debug", Component: "server", Event: event + "_trace", Attrs: map[string]any{"url": redactDiagnosticURL(parsed), "has_userinfo": parsed.User != nil, "has_query": parsed.RawQuery != "", "has_fragment": parsed.Fragment != ""}})
+}
+
+func redactDiagnosticURL(parsed *url.URL) string {
+	if parsed == nil {
+		return ""
+	}
+	redacted := *parsed
+	if redacted.User != nil {
+		redacted.User = url.User("redacted")
+	}
+	redacted.RawQuery = ""
+	redacted.Fragment = ""
+	return strings.TrimRight(redacted.String(), "?")
+}
+
+func redactDiagnosticURLString(raw string) string {
+	trimmed := strings.TrimSpace(raw)
+	if trimmed == "" {
+		return ""
+	}
+	parsed, err := url.Parse(trimmed)
+	if err != nil {
+		return trimmed
+	}
+	return redactDiagnosticURL(parsed)
 }
 
 type serverUpOptions struct {

--- a/cmd/deck/command_helpers.go
+++ b/cmd/deck/command_helpers.go
@@ -1,12 +1,15 @@
 package main
 
 import (
+	"crypto/rand"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
 	"os"
 	"strings"
+	"time"
 
 	ctrllogs "github.com/Airgap-Castaways/deck/internal/logs"
 )
@@ -133,6 +136,21 @@ func resolveCLILogFormat(format string) (string, error) {
 		return "", errors.New("--log-format must be text or json")
 	}
 	return resolved, nil
+}
+
+func resolveCLIVerbosity(level int) (int, error) {
+	if level < 0 || level > 3 {
+		return 0, errors.New("--v must be between 0 and 3")
+	}
+	return level, nil
+}
+
+func newInvocationID(prefix string) string {
+	var raw [4]byte
+	if _, err := rand.Read(raw[:]); err == nil {
+		return strings.TrimSpace(prefix) + "-" + hex.EncodeToString(raw[:])
+	}
+	return strings.TrimSpace(prefix) + "-" + fmt.Sprintf("%x", time.Now().UTC().UnixNano())
 }
 
 func (e *cliEnv) setWriters(stdout io.Writer, stderr io.Writer) {

--- a/cmd/deck/command_helpers.go
+++ b/cmd/deck/command_helpers.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/Airgap-Castaways/deck/internal/buildinfo"
 	ctrllogs "github.com/Airgap-Castaways/deck/internal/logs"
 )
 
@@ -229,6 +230,18 @@ func (e *cliEnv) verboseCLIEvent(level int, event ctrllogs.CLIEvent) error {
 		return nil
 	}
 	return e.stderrCLIEvent(event)
+}
+
+func (e *cliEnv) commandStarted(command string) error {
+	trimmed := strings.TrimSpace(command)
+	if trimmed == "" {
+		trimmed = "command"
+	}
+	if e != nil && strings.TrimSpace(e.logFormat) == "json" {
+		info := buildinfo.Current()
+		return e.stderrCLIEvent(ctrllogs.CLIEvent{Component: trimmed, Event: "command_started", Attrs: map[string]any{"status": "started", "version": info.Version}})
+	}
+	return e.stderrPrintf("%s %s started\n", buildinfo.Summary(), trimmed)
 }
 
 func (e *cliEnv) verbosef(level int, format string, args ...any) error {

--- a/cmd/deck/help_completion_test.go
+++ b/cmd/deck/help_completion_test.go
@@ -52,6 +52,18 @@ func TestRunUsageShowsTopLevelAxes(t *testing.T) {
 	}
 }
 
+func TestRejectsInvalidVerbosity(t *testing.T) {
+	for _, args := range [][]string{{"--v=-1", "version"}, {"--v=4", "version"}} {
+		res := execute(args)
+		if res.err == nil {
+			t.Fatalf("expected invalid verbosity error for %v", args)
+		}
+		if !strings.Contains(res.stderr, "--v must be between 0 and 3") {
+			t.Fatalf("expected verbosity range error for %v, got %q", args, res.stderr)
+		}
+	}
+}
+
 func TestCompletionHelp(t *testing.T) {
 	out, err := runWithCapturedStdout([]string{"help", "completion"})
 	if err != nil {

--- a/cmd/deck/help_completion_test.go
+++ b/cmd/deck/help_completion_test.go
@@ -72,6 +72,11 @@ func TestCompletionHelp(t *testing.T) {
 	if !strings.Contains(out, "deck completion <bash|zsh|fish|powershell>") {
 		t.Fatalf("unexpected output: %q", out)
 	}
+	for _, want := range []string{"source <(deck completion bash)", "source <(deck completion zsh)", "deck completion fish | source", "~/.config/fish/completions/deck.fish"} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("expected completion help to include %q, got %q", want, out)
+		}
+	}
 }
 
 func TestCompletionCommands(t *testing.T) {

--- a/cmd/deck/prepare_cli_test.go
+++ b/cmd/deck/prepare_cli_test.go
@@ -215,6 +215,16 @@ func TestRunPrepareVerboseDiagnostics(t *testing.T) {
 			t.Fatalf("expected %q in stderr, got %q", want, res.stderr)
 		}
 	}
+
+	res = execute([]string{"prepare", "--dry-run", "--v=3", "--bundle-binary-source", "local"})
+	if res.err != nil {
+		t.Fatalf("expected success, got %v", res.err)
+	}
+	for _, want := range []string{"event=workflow_trace", "phases=1", "steps=1", "var_keys=x", "event=phase_trace", "event=step_trace", "step=seed", "spec_keys=fetch,outputPath,source"} {
+		if !strings.Contains(res.stderr, want) {
+			t.Fatalf("expected %q in stderr, got %q", want, res.stderr)
+		}
+	}
 }
 
 func TestRunPrepareVerboseStepDiagnostics(t *testing.T) {
@@ -251,7 +261,7 @@ func TestRunPrepareVerboseStepDiagnostics(t *testing.T) {
 		"batch=prepare",
 		"component=prepare event=step_succeeded",
 		"duration_ms=",
-		"component=prepare event=batch_succeeded batch=prepare",
+		"component=prepare event=batch_succeeded",
 	} {
 		if !strings.Contains(res.stderr, want) {
 			t.Fatalf("expected %q in stderr, got %q", want, res.stderr)
@@ -259,7 +269,7 @@ func TestRunPrepareVerboseStepDiagnostics(t *testing.T) {
 	}
 }
 
-func TestRunPrepareEmitsDefaultProgressLog(t *testing.T) {
+func TestRunPrepareDefaultSuppressesProgressLog(t *testing.T) {
 	root := t.TempDir()
 	workflowsDir := filepath.Join(root, "workflows")
 	if err := os.MkdirAll(filepath.Join(workflowsDir, "scenarios"), 0o755); err != nil {
@@ -283,11 +293,11 @@ func TestRunPrepareEmitsDefaultProgressLog(t *testing.T) {
 	if res.err != nil {
 		t.Fatalf("expected success, got %v", res.err)
 	}
-	if !strings.Contains(res.stderr, "component=prepare event=step_started") || !strings.Contains(res.stderr, "step=seed") || !strings.Contains(res.stderr, "batch=prepare") {
-		t.Fatalf("expected default step progress on stderr, got %q", res.stderr)
+	if !strings.Contains(res.stdout, "prepare: ok") {
+		t.Fatalf("unexpected stdout: %q", res.stdout)
 	}
-	if !strings.Contains(res.stderr, "component=prepare event=batch_succeeded batch=prepare") || !strings.Contains(res.stderr, "duration_ms=") {
-		t.Fatalf("expected completion progress with duration, got %q", res.stderr)
+	if strings.Contains(res.stderr, "component=prepare event=step_started") || strings.Contains(res.stderr, "component=prepare event=batch_succeeded") {
+		t.Fatalf("expected default verbosity to suppress progress logs, got %q", res.stderr)
 	}
 }
 
@@ -311,7 +321,7 @@ func TestRunPrepareSupportsJSONLogFormat(t *testing.T) {
 	}
 	t.Cleanup(func() { _ = os.Chdir(originalCWD) })
 
-	res := execute([]string{"prepare", "--root", filepath.Join(root, "outputs"), "--bundle-binary-source", "local", "--log-format=json"})
+	res := execute([]string{"--v=1", "--log-format=json", "prepare", "--root", filepath.Join(root, "outputs"), "--bundle-binary-source", "local"})
 	if res.err != nil {
 		t.Fatalf("expected success, got %v", res.err)
 	}

--- a/cmd/deck/prepare_cli_test.go
+++ b/cmd/deck/prepare_cli_test.go
@@ -255,6 +255,8 @@ func TestRunPrepareVerboseStepDiagnostics(t *testing.T) {
 		t.Fatalf("unexpected stdout: %q", res.stdout)
 	}
 	for _, want := range []string{
+		"component=prepare event=phase_started",
+		"phase=prepare",
 		"component=prepare event=batch_started",
 		"component=prepare event=step_started",
 		"step=seed",
@@ -262,6 +264,7 @@ func TestRunPrepareVerboseStepDiagnostics(t *testing.T) {
 		"component=prepare event=step_succeeded",
 		"duration_ms=",
 		"component=prepare event=batch_succeeded",
+		"component=prepare event=phase_succeeded",
 	} {
 		if !strings.Contains(res.stderr, want) {
 			t.Fatalf("expected %q in stderr, got %q", want, res.stderr)
@@ -269,7 +272,7 @@ func TestRunPrepareVerboseStepDiagnostics(t *testing.T) {
 	}
 }
 
-func TestRunPrepareDefaultSuppressesProgressLog(t *testing.T) {
+func TestRunPrepareDefaultShowsProgressLog(t *testing.T) {
 	root := t.TempDir()
 	workflowsDir := filepath.Join(root, "workflows")
 	if err := os.MkdirAll(filepath.Join(workflowsDir, "scenarios"), 0o755); err != nil {
@@ -296,8 +299,15 @@ func TestRunPrepareDefaultSuppressesProgressLog(t *testing.T) {
 	if !strings.Contains(res.stdout, "prepare: ok") {
 		t.Fatalf("unexpected stdout: %q", res.stdout)
 	}
-	if strings.Contains(res.stderr, "component=prepare event=step_started") || strings.Contains(res.stderr, "component=prepare event=batch_succeeded") {
-		t.Fatalf("expected default verbosity to suppress progress logs, got %q", res.stderr)
+	for _, want := range []string{"component=prepare event=phase_started", "phase=prepare", "component=prepare event=batch_started", "component=prepare event=step_started", "step=seed", "component=prepare event=step_succeeded", "component=prepare event=batch_succeeded", "component=prepare event=phase_succeeded"} {
+		if !strings.Contains(res.stderr, want) {
+			t.Fatalf("expected default verbosity to show progress log %q, got %q", want, res.stderr)
+		}
+	}
+	for _, hidden := range []string{"component=prepare event=run_requested", "component=prepare event=prepare_completed", "component=prepare event=workflow_trace"} {
+		if strings.Contains(res.stderr, hidden) {
+			t.Fatalf("expected default verbosity to suppress diagnostic log %q, got %q", hidden, res.stderr)
+		}
 	}
 }
 

--- a/cmd/deck/prepare_cli_test.go
+++ b/cmd/deck/prepare_cli_test.go
@@ -260,7 +260,6 @@ func TestRunPrepareVerboseStepDiagnostics(t *testing.T) {
 		"component=prepare event=batch_started",
 		"component=prepare event=step_started",
 		"step=seed",
-		"batch=prepare",
 		"component=prepare event=step_succeeded",
 		"duration_ms=",
 		"component=prepare event=batch_succeeded",

--- a/cmd/deck/root_cobra.go
+++ b/cmd/deck/root_cobra.go
@@ -23,12 +23,16 @@ func newRootCommand(env *cliEnv) *cobra.Command {
 		SilenceUsage:       true,
 		DisableSuggestions: true,
 		PersistentPreRunE: func(_ *cobra.Command, _ []string) error {
+			verbosity, err := resolveCLIVerbosity(env.verbosity)
+			if err != nil {
+				return err
+			}
 			resolved, err := resolveCLILogFormat(env.logFormat)
 			if err != nil {
 				return err
 			}
 			env.setLogFormat(resolved)
-			env.setVerbosity(env.verbosity)
+			env.setVerbosity(verbosity)
 			return nil
 		},
 	}

--- a/cmd/deck/scenario_cli.go
+++ b/cmd/deck/scenario_cli.go
@@ -56,7 +56,16 @@ func newListCommand(env *cliEnv) *cobra.Command {
 	return cmd
 }
 
-func executeList(env *cliEnv, ctx context.Context, source, output string) error {
+func executeList(env *cliEnv, ctx context.Context, source, output string) (err error) {
+	started := time.Now().UTC()
+	entries := []scenarioEntry{}
+	defer func() {
+		status := "ok"
+		if err != nil {
+			status = "failed"
+		}
+		_ = env.verboseCLIEvent(1, ctrllogs.CLIEvent{Component: "list", Event: "list_completed", Attrs: map[string]any{"status": status, "duration_ms": time.Since(started).Milliseconds(), "entries": len(entries), "local_entries": countScenarioSource(entries, scenarioSourceLocal), "server_entries": countScenarioSource(entries, scenarioSourceServer)}})
+	}()
 	if ctx == nil {
 		return fmt.Errorf("context is nil")
 	}
@@ -72,11 +81,14 @@ func executeList(env *cliEnv, ctx context.Context, source, output string) error 
 		return err
 	}
 
-	entries, err := discoverScenarioEntries(env, ctx, resolvedSource)
+	entries, err = discoverScenarioEntries(env, ctx, resolvedSource)
 	if err != nil {
 		return err
 	}
 	if err := env.verboseCLIEvent(1, ctrllogs.CLIEvent{Component: "list", Event: "list_loaded", Attrs: map[string]any{"entries": len(entries)}}); err != nil {
+		return err
+	}
+	if err := logScenarioEntries(env, entries); err != nil {
 		return err
 	}
 
@@ -105,6 +117,7 @@ func discoverScenarioEntries(env *cliEnv, ctx context.Context, source string) ([
 			}
 			_ = env.verboseCLIEvent(2, ctrllogs.CLIEvent{Level: "debug", Component: "list", Event: "local_skipped", Attrs: map[string]any{"error": err}})
 		} else {
+			_ = env.verboseCLIEvent(2, ctrllogs.CLIEvent{Level: "debug", Component: "list", Event: "local_loaded", Attrs: map[string]any{"entries": len(localEntries)}})
 			entries = append(entries, localEntries...)
 		}
 	}
@@ -125,6 +138,7 @@ func discoverScenarioEntries(env *cliEnv, ctx context.Context, source string) ([
 				}
 				_ = env.verboseCLIEvent(2, ctrllogs.CLIEvent{Level: "debug", Component: "list", Event: "server_lookup_failed", Attrs: map[string]any{"server": serverURL, "error": err}})
 			} else {
+				_ = env.verboseCLIEvent(2, ctrllogs.CLIEvent{Level: "debug", Component: "list", Event: "server_loaded", Attrs: map[string]any{"server": serverURL, "entries": len(serverEntries)}})
 				entries = append(entries, serverEntries...)
 			}
 		case source == scenarioSourceAll:
@@ -144,6 +158,26 @@ func discoverScenarioEntries(env *cliEnv, ctx context.Context, source string) ([
 		return entries[i].Workflow < entries[j].Workflow
 	})
 	return entries, nil
+}
+
+func logScenarioEntries(env *cliEnv, entries []scenarioEntry) error {
+	entryCount := len(entries)
+	for idx, entry := range entries {
+		if err := env.verboseCLIEvent(3, ctrllogs.CLIEvent{Level: "debug", Component: "list", Event: "scenario_entry", Attrs: map[string]any{"entry_index": idx + 1, "entry_count": entryCount, "source": entry.Source, "name": entry.Name, "workflow": entry.Workflow}}); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func countScenarioSource(entries []scenarioEntry, source string) int {
+	count := 0
+	for _, entry := range entries {
+		if entry.Source == source {
+			count++
+		}
+	}
+	return count
 }
 
 func discoverLocalScenarioEntries(root string) ([]scenarioEntry, error) {

--- a/cmd/deck/scenario_cli_test.go
+++ b/cmd/deck/scenario_cli_test.go
@@ -131,11 +131,11 @@ func TestListVerboseDiagnosticsDoNotPolluteJSON(t *testing.T) {
 	}
 	defer func() { _ = os.Chdir(oldWD) }()
 
-	res := execute([]string{"list", "--source", "local", "-o", "json", "--v=1"})
+	res := execute([]string{"list", "--source", "local", "-o", "json", "--v=3"})
 	if res.err != nil {
 		t.Fatalf("expected success, got %v", res.err)
 	}
-	if !strings.Contains(res.stderr, "component=list") || !strings.Contains(res.stderr, "event=list_requested") || !strings.Contains(res.stderr, "source=local") || !strings.Contains(res.stderr, "output=json") {
+	if !strings.Contains(res.stderr, "component=list") || !strings.Contains(res.stderr, "event=list_requested") || !strings.Contains(res.stderr, "source=local") || !strings.Contains(res.stderr, "output=json") || !strings.Contains(res.stderr, "event=local_loaded") || !strings.Contains(res.stderr, "event=scenario_entry") || !strings.Contains(res.stderr, "name=apply") {
 		t.Fatalf("expected diagnostics on stderr, got %q", res.stderr)
 	}
 	var entries []scenarioEntry

--- a/cmd/deck/server_misc_cli_test.go
+++ b/cmd/deck/server_misc_cli_test.go
@@ -71,6 +71,15 @@ func TestHealth(t *testing.T) {
 		if !strings.Contains(res.stderr, "component=server") || !strings.Contains(res.stderr, "url="+srv.URL+"/healthz") || !strings.Contains(res.stderr, "http_status=200") {
 			t.Fatalf("expected v2 diagnostics on stderr, got %q", res.stderr)
 		}
+		res = execute([]string{"server", "health", "--server", srv.URL, "-o", "json", "--v=3"})
+		if res.err != nil {
+			t.Fatalf("expected success, got %v", res.err)
+		}
+		for _, want := range []string{"event=health_request", "method=GET", "timeout_ms=5000", "event=health_response", "status=200", "duration_ms="} {
+			if !strings.Contains(res.stderr, want) {
+				t.Fatalf("expected %q in stderr, got %q", want, res.stderr)
+			}
+		}
 		res = execute([]string{"server", "health", "--server", srv.URL, "-o", "json", "--v=2", "--log-format=json"})
 		if res.err != nil {
 			t.Fatalf("expected success, got %v", res.err)
@@ -161,26 +170,41 @@ func TestServerRemoteCommands(t *testing.T) {
 		t.Fatalf("expected config file removal, got %v", statErr)
 	}
 
-	res := execute([]string{"server", "remote", "set", "http://127.0.0.1:9090", "--v=1"})
+	res := execute([]string{"server", "remote", "set", "http://127.0.0.1:9090", "--v=3"})
 	if res.err != nil {
 		t.Fatalf("server remote verbose set failed: %v", res.err)
 	}
-	if !strings.Contains(res.stderr, "component=server") || !strings.Contains(res.stderr, "event=remote_set") || !strings.Contains(res.stderr, "url=http://127.0.0.1:9090") || !strings.Contains(res.stderr, "config=") {
+	if !strings.Contains(res.stderr, "component=server") || !strings.Contains(res.stderr, "event=remote_set") || !strings.Contains(res.stderr, "url=http://127.0.0.1:9090") || !strings.Contains(res.stderr, "config=") || !strings.Contains(res.stderr, "event=remote_set_target") || !strings.Contains(res.stderr, "scheme=http") || !strings.Contains(res.stderr, "host=127.0.0.1:9090") || !strings.Contains(res.stderr, "event=remote_set_target_trace") || !strings.Contains(res.stderr, "event=remote_completed") || !strings.Contains(res.stderr, "operation=set") {
 		t.Fatalf("unexpected verbose set stderr: %q", res.stderr)
 	}
-	res = execute([]string{"server", "remote", "show", "--v=1"})
+	res = execute([]string{"server", "remote", "show", "--v=3"})
 	if res.err != nil {
 		t.Fatalf("server remote verbose show failed: %v", res.err)
 	}
-	if !strings.Contains(res.stderr, "component=server") || !strings.Contains(res.stderr, "event=remote_show") || !strings.Contains(res.stderr, "config=") || !strings.Contains(res.stderr, "origin=config") {
+	if !strings.Contains(res.stderr, "component=server") || !strings.Contains(res.stderr, "event=remote_show") || !strings.Contains(res.stderr, "config=") || !strings.Contains(res.stderr, "origin=config") || !strings.Contains(res.stderr, "event=remote_show_target") || !strings.Contains(res.stderr, "event=remote_completed") || !strings.Contains(res.stderr, "operation=show") {
 		t.Fatalf("unexpected verbose show stderr: %q", res.stderr)
 	}
-	res = execute([]string{"server", "remote", "unset", "--v=1"})
+	res = execute([]string{"server", "remote", "unset", "--v=2"})
 	if res.err != nil {
 		t.Fatalf("server remote verbose unset failed: %v", res.err)
 	}
-	if !strings.Contains(res.stderr, "component=server") || !strings.Contains(res.stderr, "event=remote_unset") || !strings.Contains(res.stderr, "config=") {
+	if !strings.Contains(res.stderr, "component=server") || !strings.Contains(res.stderr, "event=remote_unset") || !strings.Contains(res.stderr, "config=") || !strings.Contains(res.stderr, "event=remote_config") || !strings.Contains(res.stderr, "event=remote_completed") || !strings.Contains(res.stderr, "operation=unset") {
 		t.Fatalf("unexpected verbose unset stderr: %q", res.stderr)
+	}
+
+	res = execute([]string{"server", "remote", "set", "https://user:secret@example.invalid/help?token=x#fragment-secret", "--v=3"})
+	if res.err != nil {
+		t.Fatalf("server remote redaction set failed: %v", res.err)
+	}
+	for _, leaked := range []string{"secret", "token=x", "fragment-secret"} {
+		if strings.Contains(res.stderr, leaked) {
+			t.Fatalf("expected stderr URL diagnostics to redact %q, got %q", leaked, res.stderr)
+		}
+	}
+	for _, want := range []string{"url=https://redacted@example.invalid/help", "has_userinfo=true", "has_query=true", "has_fragment=true"} {
+		if !strings.Contains(res.stderr, want) {
+			t.Fatalf("expected redacted URL diagnostic %q, got %q", want, res.stderr)
+		}
 	}
 }
 
@@ -369,11 +393,11 @@ func TestCache(t *testing.T) {
 	})
 
 	t.Run("list json keeps diagnostics on stderr", func(t *testing.T) {
-		res := execute([]string{"cache", "list", "-o", "json", "--v=1"})
+		res := execute([]string{"cache", "list", "-o", "json", "--v=3"})
 		if res.err != nil {
 			t.Fatalf("expected success, got %v", res.err)
 		}
-		if !strings.Contains(res.stderr, "component=cache") || !strings.Contains(res.stderr, "event=list_requested") || !strings.Contains(res.stderr, "root=") || !strings.Contains(res.stderr, "event=list_loaded") || !strings.Contains(res.stderr, "entries=") {
+		if !strings.Contains(res.stderr, "component=cache") || !strings.Contains(res.stderr, "event=list_requested") || !strings.Contains(res.stderr, "root=") || !strings.Contains(res.stderr, "event=list_loaded") || !strings.Contains(res.stderr, "entries=") || !strings.Contains(res.stderr, "event=list_summary") || !strings.Contains(res.stderr, "total_bytes=") || !strings.Contains(res.stderr, "event=list_entry") || !strings.Contains(res.stderr, "path=packages/p.deb") {
 			t.Fatalf("expected diagnostics on stderr, got %q", res.stderr)
 		}
 		var entries []struct {
@@ -407,14 +431,14 @@ func TestCache(t *testing.T) {
 	})
 
 	t.Run("clean dry-run diagnostics", func(t *testing.T) {
-		res := execute([]string{"cache", "clean", "--older-than", "1h", "--dry-run", "--v=2"})
+		res := execute([]string{"cache", "clean", "--older-than", "1h", "--dry-run", "--v=3"})
 		if res.err != nil {
 			t.Fatalf("expected success, got %v", res.err)
 		}
 		if !strings.Contains(res.stdout, packagesDir) {
 			t.Fatalf("expected packages dir in plan, got %q", res.stdout)
 		}
-		for _, want := range []string{"component=cache", "event=clean_requested", "event=clean_planned", "matches=1", "event=clean_match", "path="} {
+		for _, want := range []string{"component=cache", "event=clean_requested", "event=clean_planned", "matches=1", "event=clean_cutoff", "has_cutoff=true", "event=clean_match", "path=", "event=clean_match_stat", "is_dir=true"} {
 			if !strings.Contains(res.stderr, want) {
 				t.Fatalf("expected %q in stderr, got %q", want, res.stderr)
 			}
@@ -798,6 +822,13 @@ func TestRunWorkflowBundleVerifyJSON(t *testing.T) {
 	if !strings.Contains(res.stderr, "component=bundle") || !strings.Contains(res.stderr, "event=verify_manifest") || !strings.Contains(res.stderr, "manifest_entries=1") || !strings.Contains(res.stderr, "files=1") || !strings.Contains(res.stderr, "images=0") || !strings.Contains(res.stderr, "packages=0") || !strings.Contains(res.stderr, "other=0") {
 		t.Fatalf("expected manifest count diagnostic, got %q", res.stderr)
 	}
+	res = execute([]string{"bundle", "verify", "--file", bundleDir, "-o", "json", "--v=3"})
+	if res.err != nil {
+		t.Fatalf("expected success, got %v", res.err)
+	}
+	if !strings.Contains(res.stderr, "event=verify_manifest_entry") || !strings.Contains(res.stderr, "category=file") || !strings.Contains(res.stderr, "sha256_prefix=") {
+		t.Fatalf("expected v3 manifest entry diagnostic, got %q", res.stderr)
+	}
 }
 
 func TestRunWorkflowBundleBuildSuccess(t *testing.T) {
@@ -817,11 +848,11 @@ func TestRunWorkflowBundleBuildSuccess(t *testing.T) {
 		t.Fatalf("expected archive file, got %v", err)
 	}
 
-	res := execute([]string{"bundle", "build", "--root", bundleDir, "--out", archivePath, "--v=2"})
+	res := execute([]string{"bundle", "build", "--root", bundleDir, "--out", archivePath, "--v=3"})
 	if res.err != nil {
 		t.Fatalf("expected build success, got %v", res.err)
 	}
-	for _, want := range []string{"component=bundle", "event=manifest_loaded", "entries=1", "event=manifest_summary", "files=1", "images=0", "packages=0", "other=0", "event=archive_written", "archive_size="} {
+	for _, want := range []string{"component=bundle", "event=manifest_loaded", "entries=1", "event=manifest_summary", "files=1", "images=0", "packages=0", "other=0", "event=build_manifest_entry", "category=file", "event=archive_written", "archive_size="} {
 		if !strings.Contains(res.stderr, want) {
 			t.Fatalf("expected %q in stderr, got %q", want, res.stderr)
 		}

--- a/cmd/deck/step_progress.go
+++ b/cmd/deck/step_progress.go
@@ -8,7 +8,21 @@ import (
 	"github.com/Airgap-Castaways/deck/internal/logs"
 )
 
-func formatWorkflowEventLine(command string, event install.StepEvent) string {
+func formatWorkflowEventLine(command string, event install.StepEvent, verbosity int, logFormat string) string {
+	attrs := workflowEventAttrs(event)
+	if strings.TrimSpace(logFormat) != "json" {
+		attrs = filterWorkflowEventAttrs(attrs, verbosity)
+	}
+	return formatCLIEvent(logs.CLIEvent{
+		TS:        eventTimestamp(event),
+		Level:     eventLevel(event),
+		Component: command,
+		Event:     eventName(event),
+		Attrs:     attrs,
+	})
+}
+
+func workflowEventAttrs(event install.StepEvent) map[string]any {
 	attrs := map[string]any{
 		"phase":  displayValueOrDash(event.Phase),
 		"status": displayValueOrDash(event.Status),
@@ -52,13 +66,27 @@ func formatWorkflowEventLine(command string, event install.StepEvent) string {
 	if durationMS := formatEventDurationMS(event.StartedAt, event.EndedAt); durationMS >= 0 {
 		attrs["duration_ms"] = durationMS
 	}
-	return formatCLIEvent(logs.CLIEvent{
-		TS:        eventTimestamp(event),
-		Level:     eventLevel(event),
-		Component: command,
-		Event:     eventName(event),
-		Attrs:     attrs,
-	})
+	return attrs
+}
+
+func filterWorkflowEventAttrs(attrs map[string]any, verbosity int) map[string]any {
+	if verbosity >= 2 {
+		return attrs
+	}
+	allowed := map[string]bool{"phase": true, "step": true, "status": true, "reason": true}
+	if verbosity >= 1 {
+		allowed["kind"] = true
+		allowed["duration_ms"] = true
+		allowed["failed_step"] = true
+		allowed["error"] = true
+	}
+	filtered := make(map[string]any, len(allowed))
+	for key, value := range attrs {
+		if allowed[key] {
+			filtered[key] = value
+		}
+	}
+	return filtered
 }
 
 func formatEventDurationMS(startedAt, endedAt string) int64 {

--- a/cmd/deck/step_progress.go
+++ b/cmd/deck/step_progress.go
@@ -13,6 +13,9 @@ func formatWorkflowEventLine(command string, event install.StepEvent) string {
 		"phase":  displayValueOrDash(event.Phase),
 		"status": displayValueOrDash(event.Status),
 	}
+	if event.InvocationID != "" {
+		attrs["invocation_id"] = event.InvocationID
+	}
 	if event.StepID != "" {
 		attrs["step"] = event.StepID
 	}

--- a/cmd/deck/step_progress_test.go
+++ b/cmd/deck/step_progress_test.go
@@ -1,0 +1,75 @@
+package main
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/Airgap-Castaways/deck/internal/install"
+	ctrllogs "github.com/Airgap-Castaways/deck/internal/logs"
+)
+
+func TestFormatWorkflowEventLineFiltersTextFieldsByVerbosity(t *testing.T) {
+	ctrllogs.SetCLIFormat("text")
+	ctrllogs.SetCLIColorEnabled(false)
+	event := install.StepEvent{
+		InvocationID:   "apply-1234",
+		Event:          "step_skipped",
+		StepID:         "join-worker",
+		Kind:           "Command",
+		Phase:          "install",
+		Status:         "skipped",
+		Reason:         "completed",
+		Attempt:        1,
+		StartedAt:      "2026-04-02T09:20:00Z",
+		EndedAt:        "2026-04-02T09:20:01Z",
+		BatchID:        "install:workers",
+		ParallelGroup:  "workers",
+		Parallel:       true,
+		BatchSize:      2,
+		MaxParallelism: 2,
+	}
+
+	line := formatWorkflowEventLine("apply", event, 0, "text")
+	for _, want := range []string{"phase=install", "step=join-worker", "status=skipped", "reason=completed"} {
+		if !strings.Contains(line, want) {
+			t.Fatalf("expected compact line to include %q, got %q", want, line)
+		}
+	}
+	for _, hidden := range []string{"kind=Command", "duration_ms=", "batch=install:workers", "invocation_id=apply-1234", "parallel_group=workers"} {
+		if strings.Contains(line, hidden) {
+			t.Fatalf("expected compact line to hide %q, got %q", hidden, line)
+		}
+	}
+
+	line = formatWorkflowEventLine("apply", event, 1, "text")
+	for _, want := range []string{"kind=Command", "duration_ms=1000"} {
+		if !strings.Contains(line, want) {
+			t.Fatalf("expected level 1 line to include %q, got %q", want, line)
+		}
+	}
+	for _, hidden := range []string{"batch=install:workers", "invocation_id=apply-1234", "parallel_group=workers"} {
+		if strings.Contains(line, hidden) {
+			t.Fatalf("expected level 1 line to hide %q, got %q", hidden, line)
+		}
+	}
+
+	line = formatWorkflowEventLine("apply", event, 2, "text")
+	for _, want := range []string{"batch=install:workers", "parallel_group=workers", "batch_size=2", "max_parallelism=2", "invocation_id=apply-1234"} {
+		if !strings.Contains(line, want) {
+			t.Fatalf("expected level 2 line to include %q, got %q", want, line)
+		}
+	}
+}
+
+func TestFormatWorkflowEventLineKeepsJSONFields(t *testing.T) {
+	ctrllogs.SetCLIFormat("json")
+	t.Cleanup(func() { ctrllogs.SetCLIFormat("text") })
+	event := install.StepEvent{InvocationID: "apply-1234", Event: "step_started", StepID: "install", Kind: "Command", Phase: "bootstrap", Status: "started", Attempt: 1, BatchID: "bootstrap"}
+
+	line := formatWorkflowEventLine("apply", event, 0, "json")
+	for _, want := range []string{"\"invocation_id\":\"apply-1234\"", "\"batch\":\"bootstrap\"", "\"attempt\":1", "\"kind\":\"Command\""} {
+		if !strings.Contains(line, want) {
+			t.Fatalf("expected JSON line to keep %q, got %q", want, line)
+		}
+	}
+}

--- a/docs/guides/ask.md
+++ b/docs/guides/ask.md
@@ -296,19 +296,18 @@ When the request still has blockers or unresolved clarifications, `deck ask` may
 
 ## Diagnostics and troubleshooting
 
-`ask.logLevel` controls terminal diagnostics on stderr:
+Global `--v=<n>` controls terminal diagnostics on stderr:
 
-- `basic`: route and provider summary
-- `debug`: `basic` plus the user command and MCP events
-- `trace`: `debug` plus classifier and route prompt text
+- `--v=0`: no ask diagnostics
+- `--v=1`: route, provider, and progress summary on stderr
+- `--v=2`: route/provider summary plus the user command and MCP events
+- `--v=3`: debug logs plus classifier and route prompt text
 
-Set it with:
+Use trace-level diagnostics when you need to inspect route selection, clarification behavior, or external evidence setup:
 
 ```bash
-deck ask config set --log-level trace
+deck ask --v=3 "review this workspace"
 ```
-
-Use `trace` when you need to inspect route selection, clarification behavior, or external evidence setup.
 
 For external evidence setup, `deck ask config health` is the quickest way to distinguish:
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -56,13 +56,14 @@ OpenAI-compatible provider support currently targets:
 
 You can override `provider`, `model`, and `endpoint` per run, or save defaults with `ask config set`.
 
-`ask.logLevel` controls terminal diagnostics on stderr:
+Global `--v=<n>` controls `deck ask` terminal diagnostics on stderr:
 
-- `basic`: route and provider summary
-- `debug`: `basic` plus the user command and MCP events
-- `trace`: `debug` plus classifier/route system prompts and user prompts
+- `--v=0`: no ask diagnostics
+- `--v=1`: route, provider, and progress summary on stderr
+- `--v=2`: route/provider summary plus the user command and MCP events
+- `--v=3`: debug logs plus classifier/route system prompts and user prompts
 
-At `trace`, `ask` also writes prompt and response payload artifacts under `.deck/ask/runs/<run-id>/` and logs their paths on stderr. Prompt and response bodies stay hidden outside `trace`.
+At `--v=3`, `ask` also writes prompt and response payload artifacts under `.deck/ask/runs/<run-id>/` and logs their paths on stderr. Prompt and response bodies stay hidden below `--v=3`.
 
 `ask.mcp.servers[]` keeps the same config shape, but it now selects built-in external-docs providers rather than arbitrary first-class MCP semantics. Current built-in provider ids are:
 
@@ -96,15 +97,21 @@ Use [Server Audit Log](server-audit-log.md) for the current emitted record shape
 Global `--v=<n>` writes diagnostics to stderr without changing stdout result contracts. Supported levels are 0-3:
 
 - `--v=0`: result only
-- `--v=1`: workflow/source/path decisions and high-level execution context
-- `--v=2`: per-step apply diagnostics, plan evaluation details, and deeper bundle/prepare/health inspection counts
-- `--v=3`: contract notes, lint finding hints, and the most detailed plan/lint traces
+- `--v=1`: workflow/source/path decisions, progress events, and high-level execution context
+- `--v=2`: apply execution plan/state/step metadata, ask debug logs, plan evaluation details, and deeper bundle/prepare/health inspection counts
+- `--v=3`: key-level traces for apply/prepare/bundle/list/server/cache, ask trace artifacts, contract notes, lint finding hints, and the most detailed plan/lint traces
 
 In practice:
 
 - `deck plan --v=3` adds workflow/runtime var traces and per-step evaluation details
+- `deck apply --v=2` adds execution plan, state snapshot, phase/batch plan, and per-step metadata
+- `deck apply --v=3` adds workflow hash/state key, context keys, workflow var keys, runtime state keys, and step contract keys without logging spec values
 - `deck prepare --v=2` adds artifact group and cache reuse/fetch diagnostics
-- `deck bundle build --v=2` and `deck bundle verify --v=2` add manifest entry breakdowns
+- `deck prepare --v=3` adds workflow, phase, step, and runtime-binary key traces without logging spec values
+- `deck bundle build --v=3` and `deck bundle verify --v=3` add per-manifest-entry path/category/size/hash-prefix traces
+- `deck list --v=3`, `deck cache ... --v=3`, and `deck server ... --v=3` add per-entry or request/response/window traces where applicable
+
+Some commands have no additional detail above their highest implemented level. At `--v=0`, `ask`, `prepare`, and `apply` suppress progress diagnostics and keep stdout focused on command results.
 
 Global `--log-format=text|json` controls how migrated diagnostic logs are rendered on stderr.
 
@@ -112,6 +119,20 @@ Global `--log-format=text|json` controls how migrated diagnostic logs are render
 - `--log-format=json`: JSON Lines on stderr with the same event schema for machine processing
 
 Current migrated command families include `ask`, `prepare`, `apply`, `server`, `list`, and `cache`.
+
+Text diagnostics prioritize high-signal fields such as `invocation_id`, `phase`, `batch`, `step`, `kind`, `status`, `action`, `reason`, `duration_ms`, and path/location fields before lower-priority attributes. JSON diagnostics retain the same field names for machine processing.
+
+Event naming follows these conventions for new diagnostics:
+
+- `*_requested`: command intent received
+- `*_selected` or `*_resolved`: input path, source, or config resolution
+- `*_planned`: work plan computed
+- `*_started`, `*_succeeded`, `*_failed`: unit-level execution progress
+- `*_completed`: command-level completion summary with `status` and `duration_ms`
+- `*_summary`: aggregate counts
+- `*_trace`: key-level details intended for `--v=3`
+
+New fields use `duration_ms` for durations, `*_bytes` for byte sizes, `*_count` for new count fields, and `has_*` booleans for presence checks. URL diagnostics redact userinfo, query values, and fragments.
 
 Example text diagnostics:
 
@@ -291,7 +312,6 @@ Optional ask augmentation config example:
   "ask": {
     "provider": "openai",
     "model": "gpt-5.4",
-    "logLevel": "trace",
     "mcp": {
       "enabled": true,
       "servers": [
@@ -343,7 +363,7 @@ Optional transport override example:
 - `deck ask plan` writes plan artifacts under `./.deck/plan/` by default (`<timestamp>-<slug>.md`, `<timestamp>-<slug>.json`, `latest.md`, `latest.json`).
 - `deck ask --from .deck/plan/<name>.md "implement this plan"` prefers the same-basename `.json` artifact when present.
 - complex one-shot authoring requests may stop after planning or clarification if blockers remain; in that case `deck ask` prints the saved plan paths and follow-up commands instead of writing weak output.
-- `ask config set --log-level trace` is the quickest way to see the effective `deck ask` command, MCP events, and prompt text in terminal logs.
+- `deck ask --v=3 ...` is the quickest way to see the effective `deck ask` command, MCP events, and prompt text in terminal logs.
 - optional augmentation config can be defined under `ask.mcp` in the same config file.
 - `ask config show` includes the configured built-in MCP provider ids, effective transport commands, and capability lists.
 - `ask config health` checks whether configured built-in MCP providers can start, initialize, list tools, and satisfy their required capabilities.

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -120,7 +120,7 @@ Global `--log-format=text|json` controls how migrated diagnostic logs are render
 
 Current migrated command families include `ask`, `prepare`, `apply`, `server`, `list`, and `cache`.
 
-Text diagnostics prioritize high-signal fields such as `invocation_id`, `phase`, `batch`, `step`, `kind`, `status`, `action`, `reason`, `duration_ms`, and path/location fields before lower-priority attributes. JSON diagnostics retain the same field names for machine processing.
+Text diagnostics prioritize high-signal fields such as `phase`, `step`, `status`, `reason`, `kind`, `duration_ms`, `batch`, `invocation_id`, and path/location fields before lower-priority attributes. For `apply` and `prepare` progress logs, text output expands fields by verbosity: `--v=0` shows core progress fields, `--v=1` adds kind/duration/failure details, and `--v>=2` includes batch, parallelism, attempt, and invocation correlation fields. JSON diagnostics retain the full event fields for machine processing.
 
 Event naming follows these conventions for new diagnostics:
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -96,7 +96,7 @@ Use [Server Audit Log](server-audit-log.md) for the current emitted record shape
 
 Global `--v=<n>` writes diagnostics to stderr without changing stdout result contracts. Supported levels are 0-3:
 
-- `--v=0`: result only
+- `--v=0`: result-focused output; long-running `apply` runs still show step progress on stderr
 - `--v=1`: workflow/source/path decisions, progress events, and high-level execution context
 - `--v=2`: apply execution plan/state/step metadata, ask debug logs, plan evaluation details, and deeper bundle/prepare/health inspection counts
 - `--v=3`: key-level traces for apply/prepare/bundle/list/server/cache, ask trace artifacts, contract notes, lint finding hints, and the most detailed plan/lint traces
@@ -111,7 +111,7 @@ In practice:
 - `deck bundle build --v=3` and `deck bundle verify --v=3` add per-manifest-entry path/category/size/hash-prefix traces
 - `deck list --v=3`, `deck cache ... --v=3`, and `deck server ... --v=3` add per-entry or request/response/window traces where applicable
 
-Some commands have no additional detail above their highest implemented level. At `--v=0`, `ask`, `prepare`, and `apply` suppress progress diagnostics and keep stdout focused on command results.
+Some commands have no additional detail above their highest implemented level. At `--v=0`, `ask` and `prepare` suppress progress diagnostics, while `apply` keeps human step progress visible on stderr and stdout focused on the final command result.
 
 Global `--log-format=text|json` controls how migrated diagnostic logs are rendered on stderr.
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -96,7 +96,7 @@ Use [Server Audit Log](server-audit-log.md) for the current emitted record shape
 
 Global `--v=<n>` writes diagnostics to stderr without changing stdout result contracts. Supported levels are 0-3:
 
-- `--v=0`: result-focused output; long-running `apply` runs still show step progress on stderr
+- `--v=0`: result-focused output; long-running `apply` and `prepare` runs still show phase and step progress on stderr
 - `--v=1`: workflow/source/path decisions, progress events, and high-level execution context
 - `--v=2`: apply execution plan/state/step metadata, ask debug logs, plan evaluation details, and deeper bundle/prepare/health inspection counts
 - `--v=3`: key-level traces for apply/prepare/bundle/list/server/cache, ask trace artifacts, contract notes, lint finding hints, and the most detailed plan/lint traces
@@ -111,7 +111,7 @@ In practice:
 - `deck bundle build --v=3` and `deck bundle verify --v=3` add per-manifest-entry path/category/size/hash-prefix traces
 - `deck list --v=3`, `deck cache ... --v=3`, and `deck server ... --v=3` add per-entry or request/response/window traces where applicable
 
-Some commands have no additional detail above their highest implemented level. At `--v=0`, `ask` and `prepare` suppress progress diagnostics, while `apply` keeps phase and step progress visible on stderr, including completed-state skips, and stdout focused on the final command result.
+Some commands have no additional detail above their highest implemented level. At `--v=0`, `ask` suppresses progress diagnostics, while `apply` and `prepare` keep phase and step progress visible on stderr. `apply` also reports completed-state skips. Stdout remains focused on the final command result.
 
 Global `--log-format=text|json` controls how migrated diagnostic logs are rendered on stderr.
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -111,7 +111,7 @@ In practice:
 - `deck bundle build --v=3` and `deck bundle verify --v=3` add per-manifest-entry path/category/size/hash-prefix traces
 - `deck list --v=3`, `deck cache ... --v=3`, and `deck server ... --v=3` add per-entry or request/response/window traces where applicable
 
-Some commands have no additional detail above their highest implemented level. At `--v=0`, `ask` and `prepare` suppress progress diagnostics, while `apply` keeps human step progress visible on stderr and stdout focused on the final command result.
+Some commands have no additional detail above their highest implemented level. At `--v=0`, `ask` and `prepare` suppress progress diagnostics, while `apply` keeps phase and step progress visible on stderr, including completed-state skips, and stdout focused on the final command result.
 
 Global `--log-format=text|json` controls how migrated diagnostic logs are rendered on stderr.
 

--- a/internal/applycli/command.go
+++ b/internal/applycli/command.go
@@ -45,6 +45,7 @@ type ApplyCommandOptions struct {
 	Verbosef       func(level int, format string, args ...any) error
 	StdoutPrintf   func(format string, args ...any) error
 	StdoutPrintln  func(args ...any) error
+	InvocationID   string
 	AdditionalSink install.StepEventSink
 	NewRunLogger   func(workflowPath, workflowSource, scenario, bundleRoot, selectedPhase string) (RunLogger, error)
 }
@@ -138,6 +139,7 @@ func RunApplyCommand(ctx context.Context, opts ApplyCommandOptions) error {
 		Verbosef:       opts.Verbosef,
 		StdoutPrintf:   opts.StdoutPrintf,
 		StdoutPrintln:  opts.StdoutPrintln,
+		InvocationID:   strings.TrimSpace(opts.InvocationID),
 		AdditionalSink: opts.AdditionalSink,
 		NewRunLogger:   opts.NewRunLogger,
 	})

--- a/internal/applycli/service.go
+++ b/internal/applycli/service.go
@@ -4,11 +4,15 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"slices"
 	"strings"
+	"time"
 
+	"github.com/Airgap-Castaways/deck/internal/config"
 	"github.com/Airgap-Castaways/deck/internal/install"
 	"github.com/Airgap-Castaways/deck/internal/logs"
 	"github.com/Airgap-Castaways/deck/internal/workflowcontext"
+	"github.com/Airgap-Castaways/deck/internal/workflowexec"
 )
 
 type RunLogger interface {
@@ -28,6 +32,7 @@ type ExecuteOptions struct {
 	Verbosef       func(level int, format string, args ...any) error
 	StdoutPrintf   func(format string, args ...any) error
 	StdoutPrintln  func(args ...any) error
+	InvocationID   string
 	AdditionalSink install.StepEventSink
 	NewRunLogger   func(workflowPath, workflowSource, scenario, bundleRoot, selectedPhase string) (RunLogger, error)
 }
@@ -43,7 +48,21 @@ func Execute(ctx context.Context, opts ExecuteOptions) (err error) {
 	if request.ExecutionWorkflow == nil {
 		return fmt.Errorf("execution workflow is nil")
 	}
-	if err := verboseEvent(opts.Verbosef, 1, logs.CLIEvent{Component: "apply", Event: "run_requested", Attrs: map[string]any{"workflow": request.WorkflowPath, "phase": request.SelectedPhase, "state": request.StatePath, "bundle": strings.TrimSpace(opts.BundleRoot), "dry_run": opts.DryRun, "fresh": request.Fresh}}); err != nil {
+	started := time.Now().UTC()
+	defer func() {
+		status := "ok"
+		if err != nil {
+			status = "failed"
+		}
+		_ = emitApplyDiagnostic(opts, 1, logs.CLIEvent{Component: "apply", Event: "run_completed", Attrs: map[string]any{"status": status, "duration_ms": time.Since(started).Milliseconds()}})
+	}()
+	if err := emitApplyDiagnostic(opts, 1, logs.CLIEvent{Component: "apply", Event: "run_requested", Attrs: map[string]any{"workflow": request.WorkflowPath, "phase": request.SelectedPhase, "state": request.StatePath, "bundle": strings.TrimSpace(opts.BundleRoot), "dry_run": opts.DryRun, "fresh": request.Fresh}}); err != nil {
+		return err
+	}
+	if err := logApplyExecutionPlan(opts, request); err != nil {
+		return err
+	}
+	if err := logApplyContext(opts, request); err != nil {
 		return err
 	}
 	if opts.DryRun {
@@ -56,7 +75,7 @@ func Execute(ctx context.Context, opts ExecuteOptions) (err error) {
 	if err != nil {
 		return err
 	}
-	if err := verboseEvent(opts.Verbosef, 1, logs.CLIEvent{Component: "apply", Event: "runlog_created", Attrs: map[string]any{"runlog": runLogger.Dir()}}); err != nil {
+	if err := emitApplyDiagnostic(opts, 1, logs.CLIEvent{Component: "apply", Event: "runlog_created", Attrs: map[string]any{"runlog": runLogger.Dir()}}); err != nil {
 		return err
 	}
 	eventSink := combineStepEventSinks(runLogger.EventSink(), opts.AdditionalSink)
@@ -153,6 +172,130 @@ func combineStepEventSinks(sinks ...install.StepEventSink) install.StepEventSink
 			sink(event)
 		}
 	}
+}
+
+func logApplyExecutionPlan(opts ExecuteOptions, request ExecutionRequest) error {
+	wf := request.ExecutionWorkflow
+	if wf == nil {
+		return nil
+	}
+	phases := config.NormalizedPhases(wf)
+	phaseCount, batchCount, stepCount, parallelBatchCount := summarizeApplyWorkflow(phases)
+	if err := emitApplyDiagnostic(opts, 2, logs.CLIEvent{Level: "debug", Component: "apply", Event: "execution_plan", Attrs: map[string]any{"phases": phaseCount, "batches": batchCount, "steps": stepCount, "parallel_batches": parallelBatchCount}}); err != nil {
+		return err
+	}
+	state, stateErr := LoadInstallDryRunState(request)
+	if stateErr != nil {
+		if err := emitApplyDiagnostic(opts, 2, logs.CLIEvent{Level: "debug", Component: "apply", Event: "state_snapshot_failed", Attrs: map[string]any{"state": request.StatePath, "error": stateErr}}); err != nil {
+			return err
+		}
+	} else {
+		if err := emitApplyDiagnostic(opts, 2, logs.CLIEvent{Level: "debug", Component: "apply", Event: "state_snapshot", Attrs: map[string]any{"state": request.StatePath, "completed_phases": len(state.CompletedPhases), "runtime_vars": len(state.RuntimeVars), "runtime_secrets": len(state.RuntimeSecrets)}}); err != nil {
+			return err
+		}
+		if err := emitApplyDiagnostic(opts, 3, logs.CLIEvent{Level: "debug", Component: "apply", Event: "state_runtime", Attrs: map[string]any{"completed_phases": joinOrDash(cloneStrings(state.CompletedPhases)), "runtime_vars": joinOrDash(sortedAnyKeys(state.RuntimeVars)), "runtime_secrets": len(state.RuntimeSecrets)}}); err != nil {
+			return err
+		}
+	}
+	for _, phase := range phases {
+		batches := workflowexec.BuildPhaseBatches(phase)
+		if err := emitApplyDiagnostic(opts, 2, logs.CLIEvent{Level: "debug", Component: "apply", Event: "phase_plan", Attrs: map[string]any{"phase": phase.Name, "steps": len(phase.Steps), "batches": len(batches), "max_parallelism": phase.MaxParallelism}}); err != nil {
+			return err
+		}
+		for _, batch := range batches {
+			if err := emitApplyDiagnostic(opts, 2, logs.CLIEvent{Level: "debug", Component: "apply", Event: "batch_plan", Attrs: map[string]any{"phase": batch.PhaseName, "parallel_group": displayValueOrDash(batch.ParallelGroup), "parallel": batch.Parallel(), "steps": len(batch.Steps), "max_parallelism": batch.MaxParallelism}}); err != nil {
+				return err
+			}
+			for _, step := range batch.Steps {
+				if err := emitApplyDiagnostic(opts, 2, logs.CLIEvent{Level: "debug", Component: "apply", Event: "step_plan", Attrs: map[string]any{"phase": batch.PhaseName, "step": step.ID, "kind": step.Kind, "parallel_group": displayValueOrDash(step.ParallelGroup), "when": displayValueOrDash(step.When), "retry": step.Retry, "timeout": displayValueOrDash(step.Timeout), "register": len(step.Register)}}); err != nil {
+					return err
+				}
+				if err := emitApplyDiagnostic(opts, 3, logs.CLIEvent{Level: "debug", Component: "apply", Event: "step_contract", Attrs: map[string]any{"phase": batch.PhaseName, "step": step.ID, "api_version": displayValueOrDash(step.APIVersion), "metadata_keys": joinOrDash(sortedAnyKeys(step.Metadata)), "register_keys": joinOrDash(sortedRegisterKeys(step.Register)), "spec_keys": joinOrDash(sortedAnyKeys(step.Spec))}}); err != nil {
+					return err
+				}
+			}
+		}
+	}
+	return nil
+}
+
+func logApplyContext(opts ExecuteOptions, request ExecutionRequest) error {
+	wf := request.Workflow
+	if wf == nil {
+		wf = request.ExecutionWorkflow
+	}
+	attrs := map[string]any{
+		"workflow":        request.WorkflowPath,
+		"workflow_source": displayValueOrDash(opts.WorkflowSource),
+		"scenario":        displayValueOrDash(opts.Scenario),
+		"selected_phase":  displayValueOrDash(request.SelectedPhase),
+		"bundle":          displayValueOrDash(strings.TrimSpace(opts.BundleRoot)),
+		"state":           displayValueOrDash(request.StatePath),
+		"non_interactive": opts.NonInteractive,
+	}
+	if wf != nil {
+		attrs["state_key"] = displayValueOrDash(wf.StateKey)
+		attrs["workflow_sha256"] = displayValueOrDash(wf.WorkflowSHA256)
+		attrs["vars"] = len(wf.Vars)
+	}
+	if err := emitApplyDiagnostic(opts, 3, logs.CLIEvent{Level: "debug", Component: "apply", Event: "execution_context", Attrs: attrs}); err != nil {
+		return err
+	}
+	contextMap := opts.Context.RenderMap()
+	if err := emitApplyDiagnostic(opts, 3, logs.CLIEvent{Level: "debug", Component: "apply", Event: "context_keys", Attrs: map[string]any{"keys": joinOrDash(sortedAnyKeys(contextMap))}}); err != nil {
+		return err
+	}
+	if wf != nil {
+		return emitApplyDiagnostic(opts, 3, logs.CLIEvent{Level: "debug", Component: "apply", Event: "workflow_vars", Attrs: map[string]any{"keys": joinOrDash(sortedAnyKeys(wf.Vars))}})
+	}
+	return nil
+}
+
+func summarizeApplyWorkflow(phases []config.Phase) (phaseCount int, batchCount int, stepCount int, parallelBatchCount int) {
+	for _, phase := range phases {
+		phaseCount++
+		stepCount += len(phase.Steps)
+		for _, batch := range workflowexec.BuildPhaseBatches(phase) {
+			batchCount++
+			if batch.Parallel() {
+				parallelBatchCount++
+			}
+		}
+	}
+	return phaseCount, batchCount, stepCount, parallelBatchCount
+}
+
+func sortedAnyKeys(values map[string]any) []string {
+	if len(values) == 0 {
+		return nil
+	}
+	keys := make([]string, 0, len(values))
+	for key := range values {
+		keys = append(keys, key)
+	}
+	slices.Sort(keys)
+	return keys
+}
+
+func cloneStrings(values []string) []string {
+	if len(values) == 0 {
+		return nil
+	}
+	cloned := append([]string(nil), values...)
+	slices.Sort(cloned)
+	return cloned
+}
+
+func emitApplyDiagnostic(opts ExecuteOptions, level int, event logs.CLIEvent) error {
+	if strings.TrimSpace(opts.InvocationID) != "" {
+		attrs := make(map[string]any, len(event.Attrs)+1)
+		for key, value := range event.Attrs {
+			attrs[key] = value
+		}
+		attrs["invocation_id"] = strings.TrimSpace(opts.InvocationID)
+		event.Attrs = attrs
+	}
+	return verboseEvent(opts.Verbosef, level, event)
 }
 
 func verboseEvent(fn func(level int, format string, args ...any) error, level int, event logs.CLIEvent) error {

--- a/internal/askcli/progress.go
+++ b/internal/askcli/progress.go
@@ -11,8 +11,8 @@ type askProgress struct {
 	enabled bool
 }
 
-func newAskProgress(writer io.Writer) askProgress {
-	return askProgress{writer: writer, enabled: writer != nil && writer != io.Discard}
+func newAskProgress(writer io.Writer, logLevel string) askProgress {
+	return askProgress{writer: writer, enabled: writer != nil && writer != io.Discard && shouldLogAsk(logLevel, "basic")}
 }
 
 func (p askProgress) status(format string, args ...any) {

--- a/internal/askcli/progress_test.go
+++ b/internal/askcli/progress_test.go
@@ -7,12 +7,21 @@ import (
 
 func TestAskProgressFlushesStatus(t *testing.T) {
 	writer := &flushCapture{}
-	progress := askProgress{writer: writer, enabled: true}
+	progress := newAskProgress(writer, "basic")
 	progress.status("planning authoring workflow")
 	if writer.flushes == 0 {
 		t.Fatalf("expected progress status to flush output")
 	}
 	if !strings.Contains(writer.String(), "ask status: planning authoring workflow") {
 		t.Fatalf("expected progress output, got %q", writer.String())
+	}
+}
+
+func TestAskProgressDisabledWhenOff(t *testing.T) {
+	writer := &flushCapture{}
+	progress := newAskProgress(writer, "off")
+	progress.status("planning authoring workflow")
+	if writer.String() != "" || writer.flushes != 0 {
+		t.Fatalf("expected no progress output, got %q with %d flushes", writer.String(), writer.flushes)
 	}
 }

--- a/internal/askcli/render.go
+++ b/internal/askcli/render.go
@@ -198,7 +198,7 @@ func render(stdout io.Writer, stderr io.Writer, result runResult) error {
 }
 
 func shouldLogAsk(current string, required string) bool {
-	levels := map[string]int{"basic": 1, "debug": 2, "trace": 3}
+	levels := map[string]int{"off": 0, "basic": 1, "debug": 2, "trace": 3}
 	current = askconfigLogLevel(current)
 	required = askconfigLogLevel(required)
 	return levels[current] >= levels[required]
@@ -206,11 +206,15 @@ func shouldLogAsk(current string, required string) bool {
 
 func askconfigLogLevel(level string) string {
 	switch strings.ToLower(strings.TrimSpace(level)) {
+	case "off", "none", "quiet":
+		return "off"
 	case "debug":
 		return "debug"
 	case "trace":
 		return "trace"
-	default:
+	case "basic":
 		return "basic"
+	default:
+		return "off"
 	}
 }

--- a/internal/askcli/service.go
+++ b/internal/askcli/service.go
@@ -32,7 +32,7 @@ func Execute(ctx context.Context, opts Options, client askprovider.Client) error
 	if opts.Stdin == nil {
 		opts.Stdin = os.Stdin
 	}
-	progress := newAskProgress(opts.Stdout)
+	progress := newAskProgress(opts.Stderr, opts.LogLevel)
 	resolvedRoot, err := filepath.Abs(strings.TrimSpace(opts.Root))
 	if err != nil {
 		return fmt.Errorf("resolve workspace root: %w", err)
@@ -88,6 +88,7 @@ func Execute(ctx context.Context, opts Options, client askprovider.Client) error
 	if err != nil {
 		return err
 	}
+	effective.LogLevel = askconfigLogLevel(opts.LogLevel)
 	if effective.OAuthTokenSource == "session" || effective.OAuthTokenSource == "session-expired" {
 		session, source, status, err := askconfig.ResolveRuntimeSessionWithContext(ctx, effective.Provider)
 		if err != nil {

--- a/internal/askcli/types.go
+++ b/internal/askcli/types.go
@@ -33,6 +33,7 @@ type Options struct {
 	Provider      string
 	Model         string
 	Endpoint      string
+	LogLevel      string
 	Stdin         io.Reader
 	Stdout        io.Writer
 	Stderr        io.Writer

--- a/internal/askconfig/config.go
+++ b/internal/askconfig/config.go
@@ -30,7 +30,6 @@ type Settings struct {
 	APIKey     string `json:"apiKey,omitempty"`
 	OAuthToken string `json:"oauthToken,omitempty"`
 	Endpoint   string `json:"endpoint,omitempty"`
-	LogLevel   string `json:"logLevel,omitempty"`
 	MCP        MCP    `json:"mcp,omitempty"`
 }
 
@@ -58,6 +57,7 @@ type EffectiveSettings struct {
 	ModelSource      string
 	AuthStatus       string
 	AccountID        string
+	LogLevel         string
 }
 
 func ConfigPath() (string, error) {
@@ -139,7 +139,6 @@ func ResolveEffective(cli Settings) (EffectiveSettings, error) {
 			APIKey:     "",
 			OAuthToken: "",
 			Endpoint:   "",
-			LogLevel:   "basic",
 			MCP:        stored.MCP,
 		},
 		ProviderSource:   "default",
@@ -147,6 +146,7 @@ func ResolveEffective(cli Settings) (EffectiveSettings, error) {
 		APIKeySource:     "unset",
 		OAuthTokenSource: "unset",
 		EndpointSource:   "unset",
+		LogLevel:         "off",
 	}
 	if stored.Provider != "" {
 		effective.Provider = stored.Provider
@@ -167,9 +167,6 @@ func ResolveEffective(cli Settings) (EffectiveSettings, error) {
 	if stored.Endpoint != "" {
 		effective.Endpoint = stored.Endpoint
 		effective.EndpointSource = "config"
-	}
-	if stored.LogLevel != "" {
-		effective.LogLevel = stored.LogLevel
 	}
 	if value := strings.TrimSpace(os.Getenv(envServiceEndpoint)); value != "" {
 		effective.Endpoint = value
@@ -342,7 +339,6 @@ func normalize(settings Settings) Settings {
 	settings.APIKey = strings.TrimSpace(settings.APIKey)
 	settings.OAuthToken = strings.TrimSpace(settings.OAuthToken)
 	settings.Endpoint = strings.TrimSpace(settings.Endpoint)
-	settings.LogLevel = normalizeLogLevel(settings.LogLevel)
 	for i := range settings.MCP.Servers {
 		settings.MCP.Servers[i].Name = NormalizeMCPProviderName(settings.MCP.Servers[i].Name)
 		settings.MCP.Servers[i].RunCommand = strings.TrimSpace(settings.MCP.Servers[i].RunCommand)
@@ -355,19 +351,6 @@ func normalize(settings Settings) Settings {
 		settings.MCP.Servers[i].Args = trimmed
 	}
 	return settings
-}
-
-func normalizeLogLevel(level string) string {
-	switch strings.ToLower(strings.TrimSpace(level)) {
-	case "", "basic":
-		return "basic"
-	case "debug":
-		return "debug"
-	case "trace":
-		return "trace"
-	default:
-		return "basic"
-	}
 }
 
 func normalizeProvider(provider string) string {

--- a/internal/askconfig/config_test.go
+++ b/internal/askconfig/config_test.go
@@ -17,7 +17,7 @@ import (
 
 func TestSaveStoredAndLoadStored(t *testing.T) {
 	t.Setenv("XDG_CONFIG_HOME", filepath.Join(t.TempDir(), "config"))
-	settings := Settings{Provider: "openrouter", Model: "anthropic/claude-3.5-sonnet", APIKey: "stored-api-value", OAuthToken: "stored-session-value", Endpoint: "https://example.invalid/v1", LogLevel: "trace", MCP: MCP{Enabled: true, Servers: []MCPServer{{Name: "web-search", RunCommand: "node", Args: []string{"mcp.js"}}}}}
+	settings := Settings{Provider: "openrouter", Model: "anthropic/claude-3.5-sonnet", APIKey: "stored-api-value", OAuthToken: "stored-session-value", Endpoint: "https://example.invalid/v1", MCP: MCP{Enabled: true, Servers: []MCPServer{{Name: "web-search", RunCommand: "node", Args: []string{"mcp.js"}}}}}
 	if err := SaveStored(settings); err != nil {
 		t.Fatalf("save stored: %v", err)
 	}
@@ -80,8 +80,8 @@ func TestResolveEffectivePrecedence(t *testing.T) {
 	if !effective.MCP.Enabled || len(effective.MCP.Servers) != 1 {
 		t.Fatalf("expected stored mcp config in effective settings: %#v", effective)
 	}
-	if effective.LogLevel != "basic" {
-		t.Fatalf("expected default log level to be basic, got %#v", effective)
+	if effective.LogLevel != "off" {
+		t.Fatalf("expected default log level to be off, got %#v", effective)
 	}
 }
 
@@ -224,14 +224,6 @@ func TestResolveRuntimeSessionRefreshesExpiredOpenAISession(t *testing.T) {
 	}
 	if session.AccessToken != "fresh-access-value" || source != "session" || status != "valid" {
 		t.Fatalf("unexpected refreshed runtime session: %#v %q %q", session, source, status)
-	}
-}
-
-func TestNormalizeLogLevel(t *testing.T) {
-	for input, want := range map[string]string{"": "basic", "basic": "basic", "DEBUG": "debug", "trace": "trace", "loud": "basic"} {
-		if got := normalizeLogLevel(input); got != want {
-			t.Fatalf("normalizeLogLevel(%q) = %q, want %q", input, got, want)
-		}
 	}
 }
 

--- a/internal/bundlecli/service.go
+++ b/internal/bundlecli/service.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/Airgap-Castaways/deck/internal/bundle"
 	"github.com/Airgap-Castaways/deck/internal/logs"
@@ -40,8 +41,18 @@ type manifestSummary struct {
 	Other    int
 }
 
-func Verify(opts VerifyOptions) error {
-	resolvedPath, err := resolveBundlePathArg(opts.FilePath, opts.PositionalArgs, "bundle verify accepts a single <path>")
+func Verify(opts VerifyOptions) (err error) {
+	started := time.Now().UTC()
+	resolvedPath := ""
+	manifestEntries := 0
+	defer func() {
+		status := "ok"
+		if err != nil {
+			status = "failed"
+		}
+		_ = verboseEvent(opts.Verbosef, 1, logs.CLIEvent{Component: "bundle", Event: "verify_completed", Attrs: map[string]any{"status": status, "duration_ms": time.Since(started).Milliseconds(), "path": resolvedPath, "manifest_entries": manifestEntries}})
+	}()
+	resolvedPath, err = resolveBundlePathArg(opts.FilePath, opts.PositionalArgs, "bundle verify accepts a single <path>")
 	if err != nil {
 		return err
 	}
@@ -49,7 +60,7 @@ func Verify(opts VerifyOptions) error {
 		return err
 	}
 	if err := bundle.VerifyManifest(resolvedPath); err != nil {
-		_ = verboseEvent(opts.Verbosef, 2, logs.CLIEvent{Level: "debug", Component: "bundle", Event: "verify_failed", Attrs: map[string]any{"error": err}})
+		_ = verboseEvent(opts.Verbosef, 2, logs.CLIEvent{Level: "debug", Component: "bundle", Event: "verify_failed", Attrs: map[string]any{"error": err, "suggestion": "rerun `deck prepare` and rebuild the bundle with `deck bundle build`"}})
 		return err
 	}
 	entries, err := bundle.InspectManifest(resolvedPath)
@@ -57,7 +68,11 @@ func Verify(opts VerifyOptions) error {
 		return err
 	}
 	summary := summarizeBundleManifest(entries)
+	manifestEntries = summary.Entries
 	if err := verboseEvent(opts.Verbosef, 2, logs.CLIEvent{Level: "debug", Component: "bundle", Event: "verify_manifest", Attrs: map[string]any{"manifest_entries": summary.Entries, "files": summary.Files, "images": summary.Images, "packages": summary.Packages, "other": summary.Other}}); err != nil {
+		return err
+	}
+	if err := logManifestEntries(opts.Verbosef, "verify_manifest_entry", entries); err != nil {
 		return err
 	}
 	report := verifyReport{Status: "ok", Path: resolvedPath}
@@ -73,7 +88,17 @@ func Verify(opts VerifyOptions) error {
 	return opts.StdoutPrintf("bundle verify: ok (%s)\n", report.Path)
 }
 
-func Build(opts BuildOptions) error {
+func Build(opts BuildOptions) (err error) {
+	started := time.Now().UTC()
+	archiveSize := int64(0)
+	manifestEntries := 0
+	defer func() {
+		status := "ok"
+		if err != nil {
+			status = "failed"
+		}
+		_ = verboseEvent(opts.Verbosef, 1, logs.CLIEvent{Component: "bundle", Event: "build_completed", Attrs: map[string]any{"status": status, "duration_ms": time.Since(started).Milliseconds(), "archive": strings.TrimSpace(opts.Out), "archive_size": archiveSize, "manifest_entries": manifestEntries}})
+	}()
 	resolvedRoot := strings.TrimSpace(opts.Root)
 	if resolvedRoot == "" {
 		resolvedRoot = "."
@@ -92,10 +117,14 @@ func Build(opts BuildOptions) error {
 		}
 	} else {
 		summary := summarizeBundleManifest(entries)
+		manifestEntries = summary.Entries
 		if err := verboseEvent(opts.Verbosef, 1, logs.CLIEvent{Component: "bundle", Event: "manifest_loaded", Attrs: map[string]any{"manifest": manifestPath, "entries": summary.Entries}}); err != nil {
 			return err
 		}
 		if err := verboseEvent(opts.Verbosef, 2, logs.CLIEvent{Level: "debug", Component: "bundle", Event: "manifest_summary", Attrs: map[string]any{"files": summary.Files, "images": summary.Images, "packages": summary.Packages, "other": summary.Other}}); err != nil {
+			return err
+		}
+		if err := logManifestEntries(opts.Verbosef, "build_manifest_entry", entries); err != nil {
 			return err
 		}
 	}
@@ -103,6 +132,7 @@ func Build(opts BuildOptions) error {
 		return err
 	}
 	if info, err := os.Stat(opts.Out); err == nil {
+		archiveSize = info.Size()
 		if err := verboseEvent(opts.Verbosef, 2, logs.CLIEvent{Level: "debug", Component: "bundle", Event: "archive_written", Attrs: map[string]any{"archive_size": info.Size()}}); err != nil {
 			return err
 		}
@@ -143,6 +173,38 @@ func summarizeBundleManifest(entries []bundle.ManifestEntry) manifestSummary {
 		}
 	}
 	return summary
+}
+
+func logManifestEntries(verbose func(level int, format string, args ...any) error, event string, entries []bundle.ManifestEntry) error {
+	entryCount := len(entries)
+	for idx, entry := range entries {
+		if err := verboseEvent(verbose, 3, logs.CLIEvent{Level: "debug", Component: "bundle", Event: event, Attrs: map[string]any{"entry_index": idx + 1, "entry_count": entryCount, "path": entry.Path, "category": manifestEntryCategory(entry.Path), "size": entry.Size, "sha256_prefix": shaPrefix(entry.SHA256)}}); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func manifestEntryCategory(path string) string {
+	trimmed := strings.TrimSpace(path)
+	switch {
+	case workspacepaths.IsPreparedFilePath(trimmed):
+		return "file"
+	case workspacepaths.IsPreparedImagePath(trimmed):
+		return "image"
+	case workspacepaths.IsPreparedPackagePath(trimmed):
+		return "package"
+	default:
+		return "other"
+	}
+}
+
+func shaPrefix(value string) string {
+	trimmed := strings.TrimSpace(value)
+	if len(trimmed) <= 12 {
+		return trimmed
+	}
+	return trimmed[:12]
 }
 
 func verboseEvent(fn func(level int, format string, args ...any) error, level int, event logs.CLIEvent) error {

--- a/internal/install/events.go
+++ b/internal/install/events.go
@@ -1,6 +1,7 @@
 package install
 
 type StepEvent struct {
+	InvocationID   string
 	Event          string
 	StepID         string
 	Kind           string

--- a/internal/install/runner.go
+++ b/internal/install/runner.go
@@ -153,12 +153,16 @@ func Run(ctx context.Context, wf *config.Workflow, opts RunOptions) error {
 	for _, phase := range phases {
 		st.Phase = phase.Name
 		if completed[phase.Name] {
+			emitPhaseEvent(opts.EventSink, phase.Name, "skipped", "completed", "")
+			emitCompletedPhaseStepSkipped(opts.EventSink, phase)
 			continue
 		}
+		emitPhaseEvent(opts.EventSink, phase.Name, "started", "", "")
 		for _, batch := range workflowexec.BuildPhaseBatches(phase) {
 			if err := executeInstallBatch(ctx, wf, runtimeVars, runtimeSecrets, ctxData, execCtx, batch, opts.EventSink); err != nil {
 				st.FailedPhase = phase.Name
 				st.Error = maskSecrets(err.Error(), runtimeSecretValues(runtimeVars, runtimeSecrets))
+				emitPhaseEvent(opts.EventSink, phase.Name, "failed", "", "")
 				if saveErr := SaveState(statePath, sanitizedState(st, runtimeVars, runtimeSecrets, false)); saveErr != nil {
 					return errors.Join(err, fmt.Errorf("save failed apply state: %w", saveErr))
 				}
@@ -169,6 +173,7 @@ func Run(ctx context.Context, wf *config.Workflow, opts RunOptions) error {
 		completed[phase.Name] = true
 		st.FailedPhase = ""
 		st.Error = ""
+		emitPhaseEvent(opts.EventSink, phase.Name, "succeeded", "", "")
 		if err := SaveState(statePath, sanitizedState(st, runtimeVars, runtimeSecrets, false)); err != nil {
 			return err
 		}
@@ -224,6 +229,32 @@ func executeInstallBatch(ctx context.Context, wf *config.Workflow, runtimeVars m
 	}
 	emitBatchEvent(sink, batchCtx, batch.PhaseName, "succeeded", "")
 	return nil
+}
+
+func emitPhaseEvent(sink StepEventSink, phaseName string, status string, reason string, failedStep string) {
+	if sink == nil {
+		return
+	}
+	event := StepEvent{Event: "phase_" + strings.TrimSpace(status), Phase: phaseName, Status: status, Reason: strings.TrimSpace(reason), FailedStep: strings.TrimSpace(failedStep)}
+	now := time.Now().UTC().Format(time.RFC3339Nano)
+	if status == "started" {
+		event.StartedAt = now
+	} else {
+		event.EndedAt = now
+	}
+	emitStepEvent(sink, event)
+}
+
+func emitCompletedPhaseStepSkipped(sink StepEventSink, phase config.Phase) {
+	if sink == nil {
+		return
+	}
+	for _, batch := range workflowexec.BuildPhaseBatches(phase) {
+		batchCtx := batchrun.NewEventContext(batch)
+		for _, step := range batch.Steps {
+			emitStepEvent(sink, withBatchContext(batchCtx, StepEvent{Event: "step_skipped", StepID: step.ID, Kind: step.Kind, Phase: phase.Name, Status: "skipped", Reason: "completed"}))
+		}
+	}
 }
 
 func executeInstallStep(ctx context.Context, wf *config.Workflow, runtimeSnapshot map[string]any, ctxData map[string]any, execCtx ExecutionContext, phaseName string, batchCtx batchEventContext, step config.Step, sink StepEventSink) (installBatchResult, error) {

--- a/internal/logs/cli_event.go
+++ b/internal/logs/cli_event.go
@@ -50,16 +50,49 @@ func FormatCLIText(event CLIEvent) string {
 		messageKeyCode, messageValueCode := cliFieldCodes("message", normalized.Message)
 		parts = append(parts, colorizeCLIField("message", normalized.Message, messageKeyCode, messageValueCode))
 	}
-	keys := make([]string, 0, len(normalized.Attrs))
-	for key := range normalized.Attrs {
-		keys = append(keys, key)
-	}
-	sort.Strings(keys)
+	keys := orderedCLIAttrKeys(normalized.Attrs)
 	for _, key := range keys {
 		keyCode, valueCode := cliFieldCodes(key, normalized.Attrs[key])
 		parts = append(parts, colorizeCLIField(key, normalized.Attrs[key], keyCode, valueCode))
 	}
 	return strings.Join(parts, " ")
+}
+
+func orderedCLIAttrKeys(attrs map[string]any) []string {
+	if len(attrs) == 0 {
+		return nil
+	}
+	keys := make([]string, 0, len(attrs))
+	for key := range attrs {
+		keys = append(keys, key)
+	}
+	sort.SliceStable(keys, func(i, j int) bool {
+		leftRank, leftKnown := cliAttrRank(keys[i])
+		rightRank, rightKnown := cliAttrRank(keys[j])
+		if leftKnown != rightKnown {
+			return leftKnown
+		}
+		if leftKnown && leftRank != rightRank {
+			return leftRank < rightRank
+		}
+		return keys[i] < keys[j]
+	})
+	return keys
+}
+
+func cliAttrRank(key string) (int, bool) {
+	for idx, ranked := range []string{
+		"invocation_id", "run_id", "runlog",
+		"phase", "batch", "step", "kind",
+		"status", "action", "reason", "attempt", "duration_ms",
+		"workflow", "scenario", "source", "path", "state", "bundle", "root", "url",
+		"steps", "phases", "batches", "entries", "records", "matches",
+	} {
+		if key == ranked {
+			return idx, true
+		}
+	}
+	return 0, false
 }
 
 func FormatCLIJSON(event CLIEvent) ([]byte, error) {

--- a/internal/logs/cli_event.go
+++ b/internal/logs/cli_event.go
@@ -82,9 +82,10 @@ func orderedCLIAttrKeys(attrs map[string]any) []string {
 
 func cliAttrRank(key string) (int, bool) {
 	for idx, ranked := range []string{
+		"phase", "step", "status", "reason",
+		"kind", "duration_ms", "failed_step", "error",
+		"action", "attempt", "batch", "parallel_group", "parallel", "batch_size", "max_parallelism",
 		"invocation_id", "run_id", "runlog",
-		"phase", "batch", "step", "kind",
-		"status", "action", "reason", "attempt", "duration_ms",
 		"workflow", "scenario", "source", "path", "state", "bundle", "root", "url",
 		"steps", "phases", "batches", "entries", "records", "matches",
 	} {

--- a/internal/logs/cli_event_test.go
+++ b/internal/logs/cli_event_test.go
@@ -46,24 +46,30 @@ func TestFormatCLITextUsesPreferredFieldOrder(t *testing.T) {
 		Component: "apply",
 		Event:     "step_succeeded",
 		Attrs: map[string]any{
-			"zeta":        "last",
-			"status":      "succeeded",
-			"workflow":    "workflows/scenarios/apply.yaml",
-			"step":        "install",
-			"duration_ms": 12,
-			"phase":       "bootstrap",
+			"batch":         "bootstrap",
+			"invocation_id": "apply-1234",
+			"zeta":          "last",
+			"status":        "succeeded",
+			"workflow":      "workflows/scenarios/apply.yaml",
+			"step":          "install",
+			"duration_ms":   12,
+			"reason":        "completed",
+			"phase":         "bootstrap",
 		},
 	})
 	phaseIdx := strings.Index(line, "phase=bootstrap")
 	stepIdx := strings.Index(line, "step=install")
 	statusIdx := strings.Index(line, "status=succeeded")
+	reasonIdx := strings.Index(line, "reason=completed")
 	durationIdx := strings.Index(line, "duration_ms=12")
+	batchIdx := strings.Index(line, "batch=bootstrap")
+	invocationIdx := strings.Index(line, "invocation_id=apply-1234")
 	workflowIdx := strings.Index(line, "workflow=workflows/scenarios/apply.yaml")
 	zetaIdx := strings.Index(line, "zeta=last")
-	if phaseIdx < 0 || stepIdx < 0 || statusIdx < 0 || durationIdx < 0 || workflowIdx < 0 || zetaIdx < 0 {
+	if phaseIdx < 0 || stepIdx < 0 || statusIdx < 0 || reasonIdx < 0 || durationIdx < 0 || batchIdx < 0 || invocationIdx < 0 || workflowIdx < 0 || zetaIdx < 0 {
 		t.Fatalf("expected all fields in %q", line)
 	}
-	if phaseIdx >= stepIdx || stepIdx >= statusIdx || statusIdx >= durationIdx || durationIdx >= workflowIdx || workflowIdx >= zetaIdx {
+	if phaseIdx >= stepIdx || stepIdx >= statusIdx || statusIdx >= reasonIdx || reasonIdx >= durationIdx || durationIdx >= batchIdx || batchIdx >= invocationIdx || invocationIdx >= workflowIdx || workflowIdx >= zetaIdx {
 		t.Fatalf("unexpected field order: %q", line)
 	}
 }

--- a/internal/logs/cli_event_test.go
+++ b/internal/logs/cli_event_test.go
@@ -38,6 +38,36 @@ func TestFormatCLIText(t *testing.T) {
 	}
 }
 
+func TestFormatCLITextUsesPreferredFieldOrder(t *testing.T) {
+	SetCLIColorEnabled(false)
+	line := FormatCLIText(CLIEvent{
+		TS:        time.Date(2026, time.April, 2, 9, 20, 0, 0, time.UTC),
+		Level:     "info",
+		Component: "apply",
+		Event:     "step_succeeded",
+		Attrs: map[string]any{
+			"zeta":        "last",
+			"status":      "succeeded",
+			"workflow":    "workflows/scenarios/apply.yaml",
+			"step":        "install",
+			"duration_ms": 12,
+			"phase":       "bootstrap",
+		},
+	})
+	phaseIdx := strings.Index(line, "phase=bootstrap")
+	stepIdx := strings.Index(line, "step=install")
+	statusIdx := strings.Index(line, "status=succeeded")
+	durationIdx := strings.Index(line, "duration_ms=12")
+	workflowIdx := strings.Index(line, "workflow=workflows/scenarios/apply.yaml")
+	zetaIdx := strings.Index(line, "zeta=last")
+	if phaseIdx < 0 || stepIdx < 0 || statusIdx < 0 || durationIdx < 0 || workflowIdx < 0 || zetaIdx < 0 {
+		t.Fatalf("expected all fields in %q", line)
+	}
+	if phaseIdx >= stepIdx || stepIdx >= statusIdx || statusIdx >= durationIdx || durationIdx >= workflowIdx || workflowIdx >= zetaIdx {
+		t.Fatalf("unexpected field order: %q", line)
+	}
+}
+
 func TestFormatCLITextWithColors(t *testing.T) {
 	SetCLIColorEnabled(true)
 	t.Cleanup(func() {

--- a/internal/prepare/execution_runtime_test.go
+++ b/internal/prepare/execution_runtime_test.go
@@ -172,10 +172,22 @@ func TestRun_EmitsStepEvents(t *testing.T) {
 	}
 
 	stepEvents := make([]StepEvent, 0, len(events))
+	phaseEvents := make([]StepEvent, 0, len(events))
 	for _, event := range events {
 		if event.StepID != "" {
 			stepEvents = append(stepEvents, event)
+		} else if strings.HasPrefix(event.Event, "phase_") {
+			phaseEvents = append(phaseEvents, event)
 		}
+	}
+	if len(phaseEvents) != 2 {
+		t.Fatalf("expected 2 phase events, got %#v", events)
+	}
+	if phaseEvents[0].Event != "phase_started" || phaseEvents[0].Status != "started" || phaseEvents[0].Phase != "prepare" {
+		t.Fatalf("unexpected first phase event: %+v", phaseEvents[0])
+	}
+	if phaseEvents[1].Event != "phase_succeeded" || phaseEvents[1].Status != "succeeded" || phaseEvents[1].Phase != "prepare" {
+		t.Fatalf("unexpected second phase event: %+v", phaseEvents[1])
 	}
 	if len(stepEvents) != 3 {
 		t.Fatalf("expected 3 step events, got %#v", events)
@@ -244,14 +256,34 @@ func TestRun_RetrySemantics(t *testing.T) {
 			}},
 		}
 
-		err := Run(context.Background(), wf, RunOptions{BundleRoot: bundle})
+		var (
+			events []StepEvent
+			mu     sync.Mutex
+		)
+		err := Run(context.Background(), wf, RunOptions{BundleRoot: bundle, EventSink: func(event StepEvent) {
+			mu.Lock()
+			events = append(events, event)
+			mu.Unlock()
+		}})
 		if err == nil {
 			t.Fatalf("expected failure after retry exhaustion")
 		}
 		if !strings.Contains(err.Error(), "E_PREPARE_SOURCE_NOT_FOUND") {
 			t.Fatalf("expected E_PREPARE_SOURCE_NOT_FOUND, got %v", err)
 		}
+		if !hasPrepareEvent(events, "phase_failed", "prepare", "failed") {
+			t.Fatalf("expected phase_failed event, got %#v", events)
+		}
 	})
+}
+
+func hasPrepareEvent(events []StepEvent, eventName string, phase string, status string) bool {
+	for _, event := range events {
+		if event.Event == eventName && event.Phase == phase && event.Status == status {
+			return true
+		}
+	}
+	return false
 }
 
 func TestRun_WhenInvalidExpression(t *testing.T) {

--- a/internal/prepare/runner.go
+++ b/internal/prepare/runner.go
@@ -137,9 +137,11 @@ func Run(ctx context.Context, wf *config.Workflow, opts RunOptions) error {
 	}
 
 	for _, phase := range phases {
+		emitPhaseEvent(opts.EventSink, phase.Name, "started")
 		for _, batch := range workflowexec.BuildPhaseBatches(phase) {
 			batchFiles, err := executePrepareBatch(ctx, runner, bundleRoot, wf, runtimeVars, ctxData, batch, opts)
 			if err != nil {
+				emitPhaseEvent(opts.EventSink, phase.Name, "failed")
 				return err
 			}
 			for _, f := range batchFiles {
@@ -150,6 +152,7 @@ func Run(ctx context.Context, wf *config.Workflow, opts RunOptions) error {
 				entries = append(entries, entry)
 			}
 		}
+		emitPhaseEvent(opts.EventSink, phase.Name, "succeeded")
 	}
 
 	sort.Slice(entries, func(i, j int) bool { return entries[i].Path < entries[j].Path })
@@ -217,6 +220,20 @@ func executePrepareBatch(ctx context.Context, runner CommandRunner, bundleRoot s
 	}
 	emitBatchEvent(opts.EventSink, batchCtx, batch.PhaseName, "succeeded", "")
 	return files, nil
+}
+
+func emitPhaseEvent(sink StepEventSink, phaseName string, status string) {
+	if sink == nil {
+		return
+	}
+	event := StepEvent{Event: "phase_" + strings.TrimSpace(status), Phase: phaseName, Status: status}
+	now := time.Now().UTC().Format(time.RFC3339Nano)
+	if status == "started" {
+		event.StartedAt = now
+	} else {
+		event.EndedAt = now
+	}
+	emitStepEvent(sink, event)
 }
 
 func executePrepareStep(ctx context.Context, runner CommandRunner, bundleRoot string, wf *config.Workflow, runtimeSnapshot map[string]any, ctxData map[string]any, phaseName string, batchCtx batchEventContext, step config.Step, opts RunOptions) (prepareBatchResult, error) {

--- a/internal/preparecli/runtime_binaries.go
+++ b/internal/preparecli/runtime_binaries.go
@@ -85,6 +85,9 @@ func stageRuntimeBinariesWithContext(ctx context.Context, preparedRootAbs string
 	if err != nil {
 		return err
 	}
+	if err := emitDiagnosticEvent(opts, 3, logs.CLIEvent{Level: "debug", Component: "prepare", Event: "runtime_binary_plan", Attrs: map[string]any{"source": source, "release_version": displayValueOrDash(releaseVersion), "targets": len(targets), "target_keys": joinOrDash(runtimeBinaryTargetKeys(targets))}}); err != nil {
+		return err
+	}
 	for _, target := range targets {
 		raw, err := loadRuntimeBinary(ctx, opts, deps, source, releaseVersion, target)
 		if err != nil {
@@ -99,6 +102,17 @@ func stageRuntimeBinariesWithContext(ctx context.Context, preparedRootAbs string
 		}
 	}
 	return nil
+}
+
+func runtimeBinaryTargetKeys(targets []runtimeBinaryTarget) []string {
+	if len(targets) == 0 {
+		return nil
+	}
+	keys := make([]string, 0, len(targets))
+	for _, target := range targets {
+		keys = append(keys, target.OS+"/"+target.Arch)
+	}
+	return keys
 }
 
 func dryRunRuntimeBinaryWrites(preparedRootAbs string, opts Options) ([]string, error) {

--- a/internal/preparecli/service.go
+++ b/internal/preparecli/service.go
@@ -6,7 +6,9 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
+	"time"
 
 	"github.com/Airgap-Castaways/deck/internal/config"
 	"github.com/Airgap-Castaways/deck/internal/filemode"
@@ -32,6 +34,7 @@ type Options struct {
 	VarsFiles         []string
 	Stdout            io.Writer
 	Diagnosticf       func(level int, format string, args ...any) error
+	InvocationID      string
 	EventSink         prepare.StepEventSink
 	runtimeBinaryDeps runtimeBinaryDeps
 }
@@ -46,7 +49,17 @@ type preparedManifestEntry struct {
 	Size   int64  `json:"size"`
 }
 
-func Run(ctx context.Context, opts Options) error {
+func Run(ctx context.Context, opts Options) (err error) {
+	started := time.Now().UTC()
+	preparedRootForLog := ""
+	manifestEntries := 0
+	defer func() {
+		status := "ok"
+		if err != nil {
+			status = "failed"
+		}
+		_ = emitDiagnosticEvent(opts, 1, logs.CLIEvent{Component: "prepare", Event: "prepare_completed", Attrs: map[string]any{"status": status, "duration_ms": time.Since(started).Milliseconds(), "prepared_root": preparedRootForLog, "manifest_entries": manifestEntries}})
+	}()
 	if ctx == nil {
 		return fmt.Errorf("context is nil")
 	}
@@ -87,6 +100,7 @@ func Run(ctx context.Context, opts Options) error {
 	if err := emitDiagnosticEvent(opts, 1, logs.CLIEvent{Component: "prepare", Event: "prepared_root", Attrs: map[string]any{"prepared_root": filepath.ToSlash(resolvedPreparedRootAbs)}}); err != nil {
 		return err
 	}
+	preparedRootForLog = filepath.ToSlash(resolvedPreparedRootAbs)
 	preparedRoot, err := fsutil.NewPreparedRoot(resolvedPreparedRootAbs)
 	if err != nil {
 		return err
@@ -105,6 +119,9 @@ func Run(ctx context.Context, opts Options) error {
 	}
 	prepareWorkflow, err := config.LoadWithOptions(ctx, prepareWorkflowPath, config.LoadOptions{VarOverrides: opts.VarOverrides, VarsFiles: opts.VarsFiles, NodeScopedVars: true})
 	if err != nil {
+		return err
+	}
+	if err := logPrepareWorkflowTrace(opts, prepareWorkflow); err != nil {
 		return err
 	}
 	if err := emitDiagnosticEvent(opts, 1, logs.CLIEvent{Component: "prepare", Event: "run_config", Attrs: map[string]any{"refresh": opts.Refresh, "clean": opts.Clean}}); err != nil {
@@ -207,6 +224,7 @@ func Run(ctx context.Context, opts Options) error {
 	if err != nil {
 		return err
 	}
+	manifestEntries = len(manifest.Entries)
 	if err := writePreparedManifest(filepath.Join(preparedWorkspaceRoot, ".deck", "manifest.json"), manifest); err != nil {
 		return err
 	}
@@ -221,6 +239,14 @@ func Run(ctx context.Context, opts Options) error {
 }
 
 func emitDiagnosticEvent(opts Options, level int, event logs.CLIEvent) error {
+	if strings.TrimSpace(opts.InvocationID) != "" {
+		attrs := make(map[string]any, len(event.Attrs)+1)
+		for key, value := range event.Attrs {
+			attrs[key] = value
+		}
+		attrs["invocation_id"] = strings.TrimSpace(opts.InvocationID)
+		event.Attrs = attrs
+	}
 	return logs.EmitCLIEventf(opts.Diagnosticf, level, event)
 }
 
@@ -233,6 +259,70 @@ func workflowIncludeCount(prepareWorkflowPath, varsWorkflowPath, applyWorkflowPa
 		count++
 	}
 	return count
+}
+
+func logPrepareWorkflowTrace(opts Options, wf *config.Workflow) error {
+	if wf == nil {
+		return nil
+	}
+	phases := config.NormalizedPhases(wf)
+	stepCount := 0
+	for _, phase := range phases {
+		stepCount += len(phase.Steps)
+	}
+	if err := emitDiagnosticEvent(opts, 3, logs.CLIEvent{Level: "debug", Component: "prepare", Event: "workflow_trace", Attrs: map[string]any{"version": wf.Version, "state_key": displayValueOrDash(wf.StateKey), "workflow_sha256": displayValueOrDash(wf.WorkflowSHA256), "phases": len(phases), "steps": stepCount, "vars": len(wf.Vars), "var_keys": joinOrDash(sortedAnyKeys(wf.Vars))}}); err != nil {
+		return err
+	}
+	for _, phase := range phases {
+		if err := emitDiagnosticEvent(opts, 3, logs.CLIEvent{Level: "debug", Component: "prepare", Event: "phase_trace", Attrs: map[string]any{"phase": phase.Name, "steps": len(phase.Steps), "imports": len(phase.Imports), "max_parallelism": phase.MaxParallelism}}); err != nil {
+			return err
+		}
+		for _, step := range phase.Steps {
+			if err := emitDiagnosticEvent(opts, 3, logs.CLIEvent{Level: "debug", Component: "prepare", Event: "step_trace", Attrs: map[string]any{"phase": phase.Name, "step": step.ID, "kind": step.Kind, "api_version": displayValueOrDash(step.APIVersion), "when": displayValueOrDash(step.When), "parallel_group": displayValueOrDash(step.ParallelGroup), "retry": step.Retry, "timeout": displayValueOrDash(step.Timeout), "register_keys": joinOrDash(sortedRegisterKeys(step.Register)), "metadata_keys": joinOrDash(sortedAnyKeys(step.Metadata)), "spec_keys": joinOrDash(sortedAnyKeys(step.Spec))}}); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func displayValueOrDash(value string) string {
+	trimmed := strings.TrimSpace(value)
+	if trimmed == "" {
+		return "-"
+	}
+	return trimmed
+}
+
+func joinOrDash(values []string) string {
+	if len(values) == 0 {
+		return "-"
+	}
+	return strings.Join(values, ",")
+}
+
+func sortedAnyKeys(values map[string]any) []string {
+	if len(values) == 0 {
+		return nil
+	}
+	keys := make([]string, 0, len(values))
+	for key := range values {
+		keys = append(keys, key)
+	}
+	slices.Sort(keys)
+	return keys
+}
+
+func sortedRegisterKeys(values map[string]string) []string {
+	if len(values) == 0 {
+		return nil
+	}
+	keys := make([]string, 0, len(values))
+	for key := range values {
+		keys = append(keys, key)
+	}
+	slices.Sort(keys)
+	return keys
 }
 
 func printLine(w io.Writer, line string) error {


### PR DESCRIPTION
## Summary
- Route `deck ask` diagnostics and progress through global `--v=0..3`, removing stored `ask.logLevel` from active config.
- Expand apply, prepare, bundle, cache, list, and server diagnostics with summaries, trace detail, correlation IDs, URL redaction, and selected failure suggestions.
- Document diagnostic event/field conventions and prefer high-signal field ordering in text logs.

## Verification
- `make test`
- `make lint`