### PR TITLE
Support portable server daemon mode

### DIFF
--- a/.github/workflows/macos-server-daemon.yml
+++ b/.github/workflows/macos-server-daemon.yml
@@ -1,0 +1,86 @@
+name: macOS Server Daemon
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: macos-server-daemon-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  smoke:
+    runs-on: macos-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Setup Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+
+      - name: Build deck CLI
+        run: go build -o bin/deck ./cmd/deck
+
+      - name: Run daemon smoke test
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          tmp="$(mktemp -d)"
+          unit="deck-server-ci"
+          mkdir -p "${tmp}/root"
+          export XDG_STATE_HOME="${tmp}/state"
+
+          cleanup() {
+            ./bin/deck server down --unit "${unit}" >/dev/null 2>&1 || true
+            rm -rf "${tmp}"
+          }
+          trap cleanup EXIT
+
+          port="$(python3 - <<'PY'
+          import socket
+
+          with socket.socket() as s:
+              s.bind(("127.0.0.1", 0))
+              print(s.getsockname()[1])
+          PY
+          )"
+
+          ./bin/deck server up \
+            --daemon \
+            --root "${tmp}/root" \
+            --addr "127.0.0.1:${port}" \
+            --unit "${unit}"
+
+          pid_file="${XDG_STATE_HOME}/deck/server/${unit}.pid"
+          log_file="${XDG_STATE_HOME}/deck/server/${unit}.log"
+          test -s "${pid_file}"
+          test -f "${log_file}"
+          pid="$(cat "${pid_file}")"
+
+          for _ in {1..50}; do
+            if curl -fsS "http://127.0.0.1:${port}/healthz" >/dev/null; then
+              break
+            fi
+            sleep 0.2
+          done
+          curl -fsS "http://127.0.0.1:${port}/healthz" >/dev/null
+
+          ./bin/deck server down --unit "${unit}"
+
+          for _ in {1..50}; do
+            if ! kill -0 "${pid}" 2>/dev/null; then
+              exit 0
+            fi
+            sleep 0.2
+          done
+
+          echo "daemon process still running after server down"
+          exit 1

--- a/.github/workflows/windows-server-daemon.yml
+++ b/.github/workflows/windows-server-daemon.yml
@@ -1,0 +1,85 @@
+name: Windows Server Daemon
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: windows-server-daemon-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  smoke:
+    runs-on: windows-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Setup Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+
+      - name: Build deck CLI
+        run: go build -o bin/deck.exe ./cmd/deck
+
+      - name: Run daemon smoke test
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = "Stop"
+
+          $tmp = Join-Path ([System.IO.Path]::GetTempPath()) ([System.Guid]::NewGuid().ToString())
+          $unit = "deck-server-ci"
+          $root = Join-Path $tmp "root"
+          New-Item -ItemType Directory -Force -Path $root | Out-Null
+          $env:XDG_STATE_HOME = Join-Path $tmp "state"
+
+          function Cleanup {
+            try { & .\bin\deck.exe server down --unit $unit | Out-Null } catch {}
+            Remove-Item -Recurse -Force $tmp -ErrorAction SilentlyContinue
+          }
+
+          try {
+            $listener = [System.Net.Sockets.TcpListener]::new([System.Net.IPAddress]::Parse("127.0.0.1"), 0)
+            $listener.Start()
+            $port = $listener.LocalEndpoint.Port
+            $listener.Stop()
+
+            & .\bin\deck.exe server up --daemon --root $root --addr "127.0.0.1:$port" --unit $unit
+            if ($LASTEXITCODE -ne 0) { throw "server up failed" }
+
+            $pidFile = Join-Path $env:XDG_STATE_HOME "deck\server\$unit.pid"
+            $logFile = Join-Path $env:XDG_STATE_HOME "deck\server\$unit.log"
+            if (-not (Test-Path $pidFile)) { throw "missing pid file: $pidFile" }
+            if (-not (Test-Path $logFile)) { throw "missing log file: $logFile" }
+            $daemonPid = [int](Get-Content -Raw $pidFile).Trim()
+
+            $healthy = $false
+            for ($i = 0; $i -lt 50; $i++) {
+              curl.exe -fsS "http://127.0.0.1:$port/healthz" *> $null
+              if ($LASTEXITCODE -eq 0) {
+                $healthy = $true
+                break
+              }
+              Start-Sleep -Milliseconds 200
+            }
+            if (-not $healthy) { throw "server did not become healthy" }
+
+            & .\bin\deck.exe server down --unit $unit
+            if ($LASTEXITCODE -ne 0) { throw "server down failed" }
+
+            for ($i = 0; $i -lt 50; $i++) {
+              $process = Get-Process -Id $daemonPid -ErrorAction SilentlyContinue
+              if ($null -eq $process) { exit 0 }
+              Start-Sleep -Milliseconds 200
+            }
+
+            throw "daemon process still running after server down"
+          } finally {
+            Cleanup
+          }

--- a/cmd/deck/cobra_server.go
+++ b/cmd/deck/cobra_server.go
@@ -5,13 +5,17 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
+	"runtime"
+	"strconv"
 	"strings"
 
 	"github.com/spf13/cobra"
 
 	"github.com/Airgap-Castaways/deck/internal/executil"
 	ctrllogs "github.com/Airgap-Castaways/deck/internal/logs"
+	"github.com/Airgap-Castaways/deck/internal/userdirs"
 )
 
 func newServerCommand(env *cliEnv) *cobra.Command {
@@ -97,8 +101,8 @@ func newServerUpCommand(env *cliEnv) *cobra.Command {
 	cmd.Flags().String("tls-cert", "", "TLS certificate path")
 	cmd.Flags().String("tls-key", "", "TLS private key path")
 	cmd.Flags().Bool("tls-self-signed", false, "auto-generate and use self-signed TLS cert")
-	cmd.Flags().BoolP("daemon", "d", false, "run as a transient systemd service")
-	cmd.Flags().String("unit", "deck-server", "systemd unit name for daemon mode")
+	cmd.Flags().BoolP("daemon", "d", false, "run as a daemon (systemd service on Linux)")
+	cmd.Flags().String("unit", "deck-server", "daemon unit/name")
 	return cmd
 }
 
@@ -115,7 +119,7 @@ func newServerDownCommand(env *cliEnv) *cobra.Command {
 			return executeServerDown(env, cmd.Context(), unit)
 		},
 	}
-	cmd.Flags().String("unit", "deck-server", "systemd unit name to stop")
+	cmd.Flags().String("unit", "deck-server", "daemon unit/name to stop")
 	return cmd
 }
 
@@ -318,6 +322,9 @@ func executeServerDown(env *cliEnv, ctx context.Context, unit string) error {
 	if ctx == nil {
 		return fmt.Errorf("context is nil")
 	}
+	if !serverDaemonUsesSystemd() {
+		return stopServerProcessDaemon(env, unit)
+	}
 	resolvedUnit := normalizeServerUnitName(unit)
 	raw, err := executil.CombinedOutputSystemctl(ctx, "stop", resolvedUnit)
 	if err != nil {
@@ -331,6 +338,13 @@ func executeServerDown(env *cliEnv, ctx context.Context, unit string) error {
 }
 
 func runServerDaemon(env *cliEnv, ctx context.Context, opts serverUpOptions) error {
+	if !serverDaemonUsesSystemd() {
+		return runServerProcessDaemon(env, ctx, opts)
+	}
+	return runServerSystemdDaemon(env, ctx, opts)
+}
+
+func runServerSystemdDaemon(env *cliEnv, ctx context.Context, opts serverUpOptions) error {
 	if ctx == nil {
 		return fmt.Errorf("context is nil")
 	}
@@ -362,6 +376,66 @@ func runServerDaemon(env *cliEnv, ctx context.Context, opts serverUpOptions) err
 	return env.stdoutPrintf("%s\n", trimmed)
 }
 
+func runServerProcessDaemon(env *cliEnv, ctx context.Context, opts serverUpOptions) error {
+	if ctx == nil {
+		return fmt.Errorf("context is nil")
+	}
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	resolvedUnit := normalizeServerUnitBaseName(opts.unit)
+	execPath, err := os.Executable()
+	if err != nil {
+		return fmt.Errorf("server up: resolve executable: %w", err)
+	}
+	cwd, err := os.Getwd()
+	if err != nil {
+		return fmt.Errorf("server up: resolve working directory: %w", err)
+	}
+	paths, err := serverProcessDaemonStatePaths(resolvedUnit)
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Dir(paths.pidPath), 0o700); err != nil {
+		return fmt.Errorf("server up: create daemon state directory: %w", err)
+	}
+	logFile, err := os.OpenFile(paths.logPath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o600)
+	if err != nil {
+		return fmt.Errorf("server up: open daemon log: %w", err)
+	}
+	defer closeSilently(logFile)
+	stdin, err := os.Open(os.DevNull)
+	if err != nil {
+		return fmt.Errorf("server up: open daemon stdin: %w", err)
+	}
+	defer closeSilently(stdin)
+
+	// #nosec G204 -- execPath is the current deck executable; args are deck server flags.
+	command := exec.Command(execPath, buildServerProcessDaemonArgs(opts)...)
+	command.Dir = cwd
+	command.Stdin = stdin
+	command.Stdout = logFile
+	command.Stderr = logFile
+	configureDetachedServerProcess(command)
+	if err := command.Start(); err != nil {
+		return fmt.Errorf("server up: start daemon process: %w", err)
+	}
+	pid := command.Process.Pid
+	if err := os.WriteFile(paths.pidPath, []byte(strconv.Itoa(pid)+"\n"), 0o600); err != nil {
+		_ = terminateDetachedServerProcess(pid)
+		_ = command.Process.Release()
+		return fmt.Errorf("server up: write daemon pid file: %w", err)
+	}
+	if err := command.Process.Release(); err != nil {
+		_ = terminateDetachedServerProcess(pid)
+		return fmt.Errorf("server up: release daemon process: %w", err)
+	}
+	if err := env.stdoutPrintf("server up: ok (%s, pid %d)\n", resolvedUnit, pid); err != nil {
+		return err
+	}
+	return env.stdoutPrintf("server log: %s\n", paths.logPath)
+}
+
 func buildServerDaemonArgs(resolvedUnit string, execPath string, cwd string, opts serverUpOptions) []string {
 	args := []string{
 		"--unit", resolvedUnit,
@@ -386,6 +460,75 @@ func buildServerDaemonArgs(resolvedUnit string, execPath string, cwd string, opt
 	return args
 }
 
+func buildServerProcessDaemonArgs(opts serverUpOptions) []string {
+	args := []string{
+		"server", "up",
+		"--root", opts.root,
+		"--addr", opts.addr,
+		"--audit-max-size-mb", fmt.Sprintf("%d", opts.auditMaxSize),
+		"--audit-max-files", fmt.Sprintf("%d", opts.auditMaxFiles),
+	}
+	if strings.TrimSpace(opts.tlsCert) != "" {
+		args = append(args, "--tls-cert", opts.tlsCert)
+	}
+	if strings.TrimSpace(opts.tlsKey) != "" {
+		args = append(args, "--tls-key", opts.tlsKey)
+	}
+	if opts.tlsSelfSigned {
+		args = append(args, "--tls-self-signed")
+	}
+	return args
+}
+
+type serverProcessDaemonPaths struct {
+	pidPath string
+	logPath string
+}
+
+func serverProcessDaemonStatePaths(unit string) (serverProcessDaemonPaths, error) {
+	root, err := userdirs.StateRoot()
+	if err != nil {
+		return serverProcessDaemonPaths{}, err
+	}
+	base := normalizeServerUnitBaseName(unit)
+	dir := filepath.Join(root, "server")
+	return serverProcessDaemonPaths{
+		pidPath: filepath.Join(dir, base+".pid"),
+		logPath: filepath.Join(dir, base+".log"),
+	}, nil
+}
+
+func stopServerProcessDaemon(env *cliEnv, unit string) error {
+	resolvedUnit := normalizeServerUnitBaseName(unit)
+	if err := validateServerDaemonUnitName("server down", resolvedUnit); err != nil {
+		return err
+	}
+	paths, err := serverProcessDaemonStatePaths(resolvedUnit)
+	if err != nil {
+		return err
+	}
+	raw, err := os.ReadFile(paths.pidPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return fmt.Errorf("server down: pid file not found: %s", paths.pidPath)
+		}
+		return fmt.Errorf("server down: read pid file: %w", err)
+	}
+	pid, err := strconv.Atoi(strings.TrimSpace(string(raw)))
+	if err != nil || pid <= 0 {
+		return fmt.Errorf("server down: invalid pid file: %s", paths.pidPath)
+	}
+	if err := terminateDetachedServerProcess(pid); err != nil {
+		if !isDetachedServerProcessMissing(err) {
+			return fmt.Errorf("server down: terminate process %d: %w", pid, err)
+		}
+	}
+	if err := os.Remove(paths.pidPath); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("server down: remove pid file: %w", err)
+	}
+	return env.stdoutPrintf("server down: ok (%s, pid %d)\n", resolvedUnit, pid)
+}
+
 func normalizeServerUnitBaseName(raw string) string {
 	trimmed := strings.TrimSpace(raw)
 	if trimmed == "" {
@@ -406,17 +549,31 @@ func validateServerUpDaemonMode(opts serverUpOptions) error {
 	if !opts.daemon {
 		return nil
 	}
+	if err := validateServerDaemonUnitName("server up", opts.unit); err != nil {
+		return err
+	}
+	if !serverDaemonUsesSystemd() {
+		return nil
+	}
 	if _, err := executil.LookPathSystemdRun(); err != nil {
 		return errors.New("server up: systemd-run not found")
 	}
 	if _, err := executil.LookPathSystemctl(); err != nil {
 		return errors.New("server up: systemctl not found")
 	}
-	if strings.TrimSpace(opts.unit) == "" {
-		return errors.New("server up: --unit must not be empty")
+	return nil
+}
+
+func validateServerDaemonUnitName(command string, unit string) error {
+	if strings.TrimSpace(unit) == "" {
+		return fmt.Errorf("%s: --unit must not be empty", command)
 	}
-	if strings.ContainsRune(opts.unit, filepath.Separator) {
-		return errors.New("server up: --unit must be a unit name, not a path")
+	if strings.ContainsAny(unit, `/\`) {
+		return fmt.Errorf("%s: --unit must be a unit name, not a path", command)
 	}
 	return nil
+}
+
+func serverDaemonUsesSystemd() bool {
+	return runtime.GOOS == "linux"
 }

--- a/cmd/deck/server_daemon_cli_test.go
+++ b/cmd/deck/server_daemon_cli_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"runtime"
 	"strings"
 	"testing"
 )
@@ -43,7 +44,54 @@ func TestBuildServerDaemonArgsEscapesWorkingDirectoryPercents(t *testing.T) {
 	}
 }
 
+func TestBuildServerProcessDaemonArgsRunsForegroundServer(t *testing.T) {
+	args := buildServerProcessDaemonArgs(serverUpOptions{
+		root:          "/tmp/content",
+		addr:          "127.0.0.1:18080",
+		auditMaxSize:  12,
+		auditMaxFiles: 3,
+		tlsCert:       "/tmp/cert.pem",
+		tlsKey:        "/tmp/key.pem",
+		tlsSelfSigned: true,
+	})
+	want := []string{
+		"server", "up",
+		"--root", "/tmp/content",
+		"--addr", "127.0.0.1:18080",
+		"--audit-max-size-mb", "12",
+		"--audit-max-files", "3",
+		"--tls-cert", "/tmp/cert.pem",
+		"--tls-key", "/tmp/key.pem",
+		"--tls-self-signed",
+	}
+	if !reflect.DeepEqual(args, want) {
+		t.Fatalf("unexpected process daemon args:\n got: %#v\nwant: %#v", args, want)
+	}
+	if strings.Contains(strings.Join(args, " "), "--daemon") {
+		t.Fatalf("process daemon child must not pass --daemon: %#v", args)
+	}
+}
+
+func TestServerProcessDaemonStatePathsUseStateHome(t *testing.T) {
+	stateHome := t.TempDir()
+	t.Setenv("XDG_STATE_HOME", stateHome)
+
+	paths, err := serverProcessDaemonStatePaths("deck-server.service")
+	if err != nil {
+		t.Fatalf("state paths failed: %v", err)
+	}
+	if got, want := paths.pidPath, filepath.Join(stateHome, "deck", "server", "deck-server.pid"); got != want {
+		t.Fatalf("unexpected pid path: got %q want %q", got, want)
+	}
+	if got, want := paths.logPath, filepath.Join(stateHome, "deck", "server", "deck-server.log"); got != want {
+		t.Fatalf("unexpected log path: got %q want %q", got, want)
+	}
+}
+
 func TestServerUpDaemonReportsSystemdRunPropertyFailures(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("systemd daemon path is Linux-only")
+	}
 	root := t.TempDir()
 	binDir := filepath.Join(t.TempDir(), "bin")
 	if err := os.MkdirAll(binDir, 0o755); err != nil {

--- a/cmd/deck/server_daemon_unix.go
+++ b/cmd/deck/server_daemon_unix.go
@@ -1,0 +1,26 @@
+//go:build !windows
+
+package main
+
+import (
+	"errors"
+	"os"
+	"os/exec"
+	"syscall"
+)
+
+func configureDetachedServerProcess(command *exec.Cmd) {
+	command.SysProcAttr = &syscall.SysProcAttr{Setsid: true}
+}
+
+func terminateDetachedServerProcess(pid int) error {
+	process, err := os.FindProcess(pid)
+	if err != nil {
+		return err
+	}
+	return process.Signal(syscall.SIGTERM)
+}
+
+func isDetachedServerProcessMissing(err error) bool {
+	return errors.Is(err, syscall.ESRCH)
+}

--- a/cmd/deck/server_daemon_windows.go
+++ b/cmd/deck/server_daemon_windows.go
@@ -3,12 +3,14 @@
 package main
 
 import (
+	"errors"
 	"os"
 	"os/exec"
 	"syscall"
 )
 
 const detachedProcess = 0x00000008
+const windowsErrorInvalidParameter syscall.Errno = 87
 
 func configureDetachedServerProcess(command *exec.Cmd) {
 	command.SysProcAttr = &syscall.SysProcAttr{CreationFlags: syscall.CREATE_NEW_PROCESS_GROUP | detachedProcess}
@@ -22,6 +24,13 @@ func terminateDetachedServerProcess(pid int) error {
 	return process.Kill()
 }
 
-func isDetachedServerProcessMissing(_ error) bool {
+func isDetachedServerProcessMissing(err error) bool {
+	if errors.Is(err, os.ErrProcessDone) {
+		return true
+	}
+	var errno syscall.Errno
+	if errors.As(err, &errno) {
+		return errno == windowsErrorInvalidParameter
+	}
 	return false
 }

--- a/cmd/deck/server_daemon_windows.go
+++ b/cmd/deck/server_daemon_windows.go
@@ -1,0 +1,22 @@
+//go:build windows
+
+package main
+
+import (
+	"os"
+	"os/exec"
+)
+
+func configureDetachedServerProcess(_ *exec.Cmd) {}
+
+func terminateDetachedServerProcess(pid int) error {
+	process, err := os.FindProcess(pid)
+	if err != nil {
+		return err
+	}
+	return process.Kill()
+}
+
+func isDetachedServerProcessMissing(_ error) bool {
+	return false
+}

--- a/cmd/deck/server_daemon_windows.go
+++ b/cmd/deck/server_daemon_windows.go
@@ -5,9 +5,14 @@ package main
 import (
 	"os"
 	"os/exec"
+	"syscall"
 )
 
-func configureDetachedServerProcess(_ *exec.Cmd) {}
+const detachedProcess = 0x00000008
+
+func configureDetachedServerProcess(command *exec.Cmd) {
+	command.SysProcAttr = &syscall.SysProcAttr{CreationFlags: syscall.CREATE_NEW_PROCESS_GROUP | detachedProcess}
+}
 
 func terminateDetachedServerProcess(pid int) error {
 	process, err := os.FindProcess(pid)

--- a/cmd/deck/server_daemon_windows_test.go
+++ b/cmd/deck/server_daemon_windows_test.go
@@ -1,0 +1,22 @@
+//go:build windows
+
+package main
+
+import (
+	"fmt"
+	"os"
+	"syscall"
+	"testing"
+)
+
+func TestIsDetachedServerProcessMissingOnWindows(t *testing.T) {
+	if !isDetachedServerProcessMissing(os.ErrProcessDone) {
+		t.Fatalf("expected os.ErrProcessDone to be treated as missing")
+	}
+	if !isDetachedServerProcessMissing(fmt.Errorf("kill process: %w", windowsErrorInvalidParameter)) {
+		t.Fatalf("expected invalid parameter errno to be treated as missing")
+	}
+	if isDetachedServerProcessMissing(syscall.ERROR_ACCESS_DENIED) {
+		t.Fatalf("expected access denied to remain a hard error")
+	}
+}

--- a/internal/askcli/interactive.go
+++ b/internal/askcli/interactive.go
@@ -4,9 +4,7 @@ import (
 	"bufio"
 	"fmt"
 	"io"
-	"math"
 	"strings"
-	"syscall"
 
 	"github.com/Airgap-Castaways/deck/internal/askcontract"
 )
@@ -22,18 +20,6 @@ func isInteractiveSession(stdin io.Reader, stdout io.Writer) bool {
 		return false
 	}
 	return true
-}
-
-func isCharDevice(fd uintptr, name string) bool {
-	_ = name
-	if fd > math.MaxInt {
-		return false
-	}
-	var stat syscall.Stat_t
-	if err := syscall.Fstat(int(fd), &stat); err != nil {
-		return false
-	}
-	return stat.Mode&syscall.S_IFMT == syscall.S_IFCHR
 }
 
 func runInteractiveClarifications(stdin io.Reader, stdout io.Writer, plan askcontract.PlanResponse) (askcontract.PlanResponse, bool, error) {

--- a/internal/askcli/interactive_unix.go
+++ b/internal/askcli/interactive_unix.go
@@ -1,0 +1,20 @@
+//go:build !windows
+
+package askcli
+
+import (
+	"math"
+	"syscall"
+)
+
+func isCharDevice(fd uintptr, name string) bool {
+	_ = name
+	if fd > math.MaxInt {
+		return false
+	}
+	var stat syscall.Stat_t
+	if err := syscall.Fstat(int(fd), &stat); err != nil {
+		return false
+	}
+	return stat.Mode&syscall.S_IFMT == syscall.S_IFCHR
+}

--- a/internal/askcli/interactive_windows.go
+++ b/internal/askcli/interactive_windows.go
@@ -1,0 +1,14 @@
+//go:build windows
+
+package askcli
+
+import "syscall"
+
+func isCharDevice(fd uintptr, name string) bool {
+	_ = name
+	typ, err := syscall.GetFileType(syscall.Handle(fd))
+	if err != nil {
+		return false
+	}
+	return typ == syscall.FILE_TYPE_CHAR
+}


### PR DESCRIPTION
## Summary
- keep Linux daemon mode on systemd while adding a non-Linux detached process daemon path
- store non-systemd daemon PID/log files under XDG state for `server down` and troubleshooting
- add a separate macOS GitHub Actions smoke workflow for `deck server up --daemon`

## Verification
- `make test`
- `make lint`
- `GOOS=darwin go test -c -o /tmp/opencode/deck-cmd-darwin.test ./cmd/deck`