### PR TITLE
Add workspace-local apply state management

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ coverage.out
 /dist/
 /bundle/
 /reports/
+/.deck/state/
 /.vagrant/
 /test/vagrant/.vagrant/
 /test/artifacts/

--- a/cmd/deck/apply_cli_test.go
+++ b/cmd/deck/apply_cli_test.go
@@ -878,6 +878,38 @@ func TestStateShowListAndClear(t *testing.T) {
 	}
 }
 
+func TestStateListSkipsInvalidStateFiles(t *testing.T) {
+	stateDir := t.TempDir()
+	validPath := filepath.Join(stateDir, "valid.json")
+	validState := `{
+  "version": 2,
+  "kind": "deck.applyState",
+  "stateKey": "valid",
+  "status": "succeeded",
+  "currentPhase": "completed",
+  "createdAt": "2026-06-02T00:00:00Z",
+  "updatedAt": "2026-06-02T00:00:00Z",
+  "phases": [{"name":"install","status":"succeeded"}]
+}`
+	if err := os.WriteFile(validPath, []byte(validState), 0o600); err != nil {
+		t.Fatalf("write valid state: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(stateDir, "broken.json"), []byte("{"), 0o600); err != nil {
+		t.Fatalf("write broken state: %v", err)
+	}
+
+	out, err := runWithCapturedStdout([]string{"state", "list", "--state-dir", stateDir})
+	if err != nil {
+		t.Fatalf("state list failed: %v", err)
+	}
+	if !strings.Contains(out, "valid status=succeeded") {
+		t.Fatalf("expected valid state entry, got %q", out)
+	}
+	if strings.Contains(out, "broken") {
+		t.Fatalf("expected broken state to be skipped, got %q", out)
+	}
+}
+
 func TestApplyVerboseDiagnostics(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 	wfPath := filepath.Join(t.TempDir(), "apply-verbose.yaml")

--- a/cmd/deck/apply_cli_test.go
+++ b/cmd/deck/apply_cli_test.go
@@ -17,20 +17,48 @@ import (
 	"github.com/Airgap-Castaways/deck/internal/config"
 )
 
-func TestResolveInstallStatePathUsesHomeAndStateKey(t *testing.T) {
-	home := filepath.Join(t.TempDir(), "home")
-	if err := os.MkdirAll(home, 0o755); err != nil {
-		t.Fatalf("mkdir home: %v", err)
-	}
-	t.Setenv("HOME", home)
-
+func TestResolveInstallStatePathUsesLocalWorkspaceStateDir(t *testing.T) {
+	root := t.TempDir()
+	wfPath := filepath.Join(root, "workflows", "scenarios", "apply.yaml")
 	wf := &config.Workflow{StateKey: "abc123"}
-	statePath, err := applycli.ResolveInstallStatePath(wf)
+
+	statePath, err := applycli.ResolveInstallStatePathForWorkflowPath(wf, wfPath, "")
 	if err != nil {
-		t.Fatalf("resolveInstallStatePath failed: %v", err)
+		t.Fatalf("resolve install state path failed: %v", err)
 	}
 
-	expected := filepath.Join(home, ".local", "state", "deck", "state", "abc123.json")
+	expected := filepath.Join(root, ".deck", "state", "apply", "abc123.json")
+	if statePath != expected {
+		t.Fatalf("state path mismatch: got %q want %q", statePath, expected)
+	}
+}
+
+func TestResolveInstallStatePathUsesXDGForRemoteWorkflow(t *testing.T) {
+	stateHome := filepath.Join(t.TempDir(), "state-home")
+	t.Setenv("XDG_STATE_HOME", stateHome)
+	wf := &config.Workflow{StateKey: "abc123"}
+
+	statePath, err := applycli.ResolveInstallStatePathForWorkflowPath(wf, "https://example.invalid/apply.yaml", "")
+	if err != nil {
+		t.Fatalf("resolve install state path failed: %v", err)
+	}
+
+	expected := filepath.Join(stateHome, "deck", "state", "apply", "abc123.json")
+	if statePath != expected {
+		t.Fatalf("state path mismatch: got %q want %q", statePath, expected)
+	}
+}
+
+func TestResolveInstallStatePathUsesExplicitStateDir(t *testing.T) {
+	stateDir := filepath.Join(t.TempDir(), "state")
+	wf := &config.Workflow{StateKey: "abc123"}
+
+	statePath, err := applycli.ResolveInstallStatePathForWorkflowPath(wf, "https://example.invalid/apply.yaml", stateDir)
+	if err != nil {
+		t.Fatalf("resolve install state path failed: %v", err)
+	}
+
+	expected := filepath.Join(stateDir, "abc123.json")
 	if statePath != expected {
 		t.Fatalf("state path mismatch: got %q want %q", statePath, expected)
 	}
@@ -806,6 +834,47 @@ func TestApplyAndPlanFresh(t *testing.T) {
 	}
 	if got := strings.Count(strings.TrimSpace(string(raw)), "run"); got != 2 {
 		t.Fatalf("expected 2 executions after fresh apply, got %d (%q)", got, string(raw))
+	}
+}
+
+func TestStateShowListAndClear(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	root := t.TempDir()
+	wfPath := filepath.Join(root, "workflows", "scenarios", "apply.yaml")
+	if err := os.MkdirAll(filepath.Dir(wfPath), 0o755); err != nil {
+		t.Fatalf("mkdir workflow dir: %v", err)
+	}
+	createValidBundleManifest(t, root)
+	writeWorkflowYAML(t, wfPath, "version: v1alpha1\nphases:\n  - name: install\n    steps:\n      - id: once\n        kind: Command\n        spec:\n          command: [\"true\"]\n")
+
+	if _, err := runWithCapturedStdout([]string{"apply", "--workflow", wfPath}); err != nil {
+		t.Fatalf("apply failed: %v", err)
+	}
+	showOut, err := runWithCapturedStdout([]string{"state", "show", "--workflow", wfPath})
+	if err != nil {
+		t.Fatalf("state show failed: %v", err)
+	}
+	for _, want := range []string{"version=2", "status=succeeded", "completedPhases=install", filepath.Join(root, ".deck", "state", "apply")} {
+		if !strings.Contains(showOut, want) {
+			t.Fatalf("expected %q in state show output, got %q", want, showOut)
+		}
+	}
+	listOut, err := runWithCapturedStdout([]string{"state", "list", "--state-dir", filepath.Join(root, ".deck", "state", "apply")})
+	if err != nil {
+		t.Fatalf("state list failed: %v", err)
+	}
+	if !strings.Contains(listOut, "status=succeeded") || !strings.Contains(listOut, "completed=1") {
+		t.Fatalf("unexpected state list output: %q", listOut)
+	}
+	if _, err := runWithCapturedStdout([]string{"state", "clear", "--workflow", wfPath, "--yes"}); err != nil {
+		t.Fatalf("state clear failed: %v", err)
+	}
+	showAfterClear, err := runWithCapturedStdout([]string{"state", "show", "--workflow", wfPath})
+	if err != nil {
+		t.Fatalf("state show after clear failed: %v", err)
+	}
+	if !strings.Contains(showAfterClear, "status=running") || strings.Contains(showAfterClear, "completedPhases=install") {
+		t.Fatalf("expected empty running state after clear, got %q", showAfterClear)
 	}
 }
 

--- a/cmd/deck/cmd_apply.go
+++ b/cmd/deck/cmd_apply.go
@@ -18,6 +18,7 @@ type diffOptions struct {
 	scenario      string
 	source        string
 	fresh         bool
+	stateDir      string
 	selectedPhase string
 	output        string
 	varOverrides  map[string]string
@@ -40,6 +41,7 @@ type planVarsOptions struct {
 func newPlanCommand(env *cliEnv) *cobra.Command {
 	vars := &varFlag{}
 	varsFiles := &stringSliceFlag{}
+	var stateDir string
 	cmd := &cobra.Command{
 		Use:     "plan",
 		Aliases: []string{"diff"},
@@ -74,6 +76,7 @@ func newPlanCommand(env *cliEnv) *cobra.Command {
 				scenario:      scenario,
 				source:        source,
 				fresh:         fresh,
+				stateDir:      stateDir,
 				selectedPhase: selectedPhase,
 				output:        output,
 				varOverrides:  vars.AsMap(),
@@ -87,6 +90,7 @@ func newPlanCommand(env *cliEnv) *cobra.Command {
 	cmd.Flags().String("source", scenarioSourceLocal, "scenario source (local|server)")
 	cmd.Flags().String("phase", "", "phase name to plan (defaults to all phases)")
 	cmd.Flags().Bool("fresh", false, "ignore saved apply state for this invocation")
+	cmd.Flags().StringVar(&stateDir, "state-dir", "", "directory for apply state files (overrides local .deck/state/apply or remote XDG state)")
 	cmd.Flags().StringP("output", "o", "text", "output format (text|json)")
 	cmd.Flags().VarP(varsFiles, "vars-file", "f", "vars file overlay relative to workflows/ (repeatable)")
 	cmd.Flags().Var(vars, "var", "set variable override (key=value), repeatable")
@@ -205,22 +209,25 @@ func runDiffWithOptions(env *cliEnv, ctx context.Context, opts diffOptions) erro
 		return err
 	}
 	selectedPhase := strings.TrimSpace(opts.selectedPhase)
-	return executeDiff(env, ctx, workflowPath, strings.TrimSpace(opts.scenario), selectedPhase, opts.output, opts.fresh, opts.varsFiles, varsAsAnyMap(opts.varOverrides))
+	return executeDiff(env, ctx, workflowPath, strings.TrimSpace(opts.scenario), selectedPhase, opts.output, opts.fresh, opts.stateDir, opts.varsFiles, varsAsAnyMap(opts.varOverrides))
 }
 
-func executeDiff(env *cliEnv, ctx context.Context, workflowPath, scenario, selectedPhase, output string, fresh bool, varsFiles []string, varOverrides map[string]any) error {
+func executeDiff(env *cliEnv, ctx context.Context, workflowPath, scenario, selectedPhase, output string, fresh bool, stateDir string, varsFiles []string, varOverrides map[string]any) error {
+	stateDir = strings.TrimSpace(stateDir)
 	return applycli.RunPlanCommand(ctx, applycli.PlanCommandOptions{
-		WorkflowPath:    workflowPath,
-		Scenario:        scenario,
-		SelectedPhase:   selectedPhase,
-		Output:          output,
-		Fresh:           fresh,
-		VarOverrides:    varOverrides,
-		VarsFiles:       append([]string(nil), varsFiles...),
-		Verbosef:        env.verbosef,
-		StdoutPrintf:    env.stdoutPrintf,
-		JSONEncoderFunc: env.stdoutJSONEncoder,
-		ResolveOutput:   resolveOutputFormat,
+		WorkflowPath:     workflowPath,
+		Scenario:         scenario,
+		SelectedPhase:    selectedPhase,
+		Output:           output,
+		Fresh:            fresh,
+		StateDir:         stateDir,
+		StateDirExplicit: stateDir != "",
+		VarOverrides:     varOverrides,
+		VarsFiles:        append([]string(nil), varsFiles...),
+		Verbosef:         env.verbosef,
+		StdoutPrintf:     env.stdoutPrintf,
+		JSONEncoderFunc:  env.stdoutJSONEncoder,
+		ResolveOutput:    resolveOutputFormat,
 	})
 }
 
@@ -230,6 +237,7 @@ type applyOptions struct {
 	source         string
 	selectedPhase  string
 	fresh          bool
+	stateDir       string
 	dryRun         bool
 	nonInteractive bool
 	varOverrides   map[string]string
@@ -240,6 +248,7 @@ type applyOptions struct {
 func newApplyCommand(env *cliEnv) *cobra.Command {
 	vars := &varFlag{}
 	varsFiles := &stringSliceFlag{}
+	var stateDir string
 	cmd := &cobra.Command{
 		Use:   "apply [workflow] [bundle]",
 		Short: "Execute an apply file against a bundle",
@@ -284,6 +293,7 @@ func newApplyCommand(env *cliEnv) *cobra.Command {
 				source:         source,
 				selectedPhase:  selectedPhase,
 				fresh:          fresh,
+				stateDir:       stateDir,
 				dryRun:         dryRun,
 				nonInteractive: nonInteractive,
 				varOverrides:   vars.AsMap(),
@@ -298,6 +308,7 @@ func newApplyCommand(env *cliEnv) *cobra.Command {
 	cmd.Flags().String("source", scenarioSourceLocal, "scenario source (local|server)")
 	cmd.Flags().String("phase", "", "phase name to execute (defaults to all phases)")
 	cmd.Flags().Bool("fresh", false, "ignore saved apply state for this invocation")
+	cmd.Flags().StringVar(&stateDir, "state-dir", "", "directory for apply state files (overrides local .deck/state/apply or remote XDG state)")
 	cmd.Flags().Bool("dry-run", false, "print apply plan without executing steps")
 	cmd.Flags().Bool("non-interactive", false, "fail or use defaults for operator interaction steps instead of prompting")
 	cmd.Flags().VarP(varsFiles, "vars-file", "f", "vars file overlay relative to workflows/ (repeatable)")
@@ -328,21 +339,23 @@ func runApplyWithOptions(env *cliEnv, ctx context.Context, opts applyOptions) er
 	}
 	invocationID := newInvocationID("apply")
 	return applycli.RunApplyCommand(ctx, applycli.ApplyCommandOptions{
-		WorkflowPath:   workflowPath,
-		BundleRoot:     bundleRoot,
-		WorkflowSource: inferWorkflowSource(workflowPath, strings.TrimSpace(opts.source)),
-		Scenario:       strings.TrimSpace(opts.scenario),
-		SelectedPhase:  opts.selectedPhase,
-		Fresh:          opts.fresh,
-		DryRun:         opts.dryRun,
-		NonInteractive: opts.nonInteractive,
-		VarOverrides:   varsAsAnyMap(opts.varOverrides),
-		VarsFiles:      append([]string(nil), opts.varsFiles...),
-		Verbosef:       env.verbosef,
-		StdoutPrintf:   env.stdoutPrintf,
-		StdoutPrintln:  env.stdoutPrintln,
-		InvocationID:   invocationID,
-		AdditionalSink: verboseApplyStepSink(env, invocationID),
+		WorkflowPath:     workflowPath,
+		BundleRoot:       bundleRoot,
+		WorkflowSource:   inferWorkflowSource(workflowPath, strings.TrimSpace(opts.source)),
+		Scenario:         strings.TrimSpace(opts.scenario),
+		SelectedPhase:    opts.selectedPhase,
+		Fresh:            opts.fresh,
+		StateDir:         strings.TrimSpace(opts.stateDir),
+		StateDirExplicit: strings.TrimSpace(opts.stateDir) != "",
+		DryRun:           opts.dryRun,
+		NonInteractive:   opts.nonInteractive,
+		VarOverrides:     varsAsAnyMap(opts.varOverrides),
+		VarsFiles:        append([]string(nil), opts.varsFiles...),
+		Verbosef:         env.verbosef,
+		StdoutPrintf:     env.stdoutPrintf,
+		StdoutPrintln:    env.stdoutPrintln,
+		InvocationID:     invocationID,
+		AdditionalSink:   verboseApplyStepSink(env, invocationID),
 		NewRunLogger: func(workflowPath, workflowSource, scenario, bundleRoot, selectedPhase string) (applycli.RunLogger, error) {
 			return newApplyRunLogger(env, workflowPath, workflowSource, scenario, bundleRoot, selectedPhase)
 		},

--- a/cmd/deck/cmd_state.go
+++ b/cmd/deck/cmd_state.go
@@ -1,0 +1,364 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/Airgap-Castaways/deck/internal/applycli"
+	"github.com/Airgap-Castaways/deck/internal/install"
+	"github.com/Airgap-Castaways/deck/internal/workspacepaths"
+)
+
+type stateWorkflowOptions struct {
+	workflowPath string
+	scenario     string
+	source       string
+	stateDir     string
+	output       string
+	varOverrides map[string]string
+	varsFiles    []string
+}
+
+type stateListOptions struct {
+	stateDir string
+	output   string
+}
+
+type stateClearOptions struct {
+	workflow stateWorkflowOptions
+	all      bool
+	yes      bool
+}
+
+type stateEntry struct {
+	StateKey        string   `json:"stateKey"`
+	Status          string   `json:"status"`
+	WorkflowPath    string   `json:"workflowPath,omitempty"`
+	WorkflowSource  string   `json:"workflowSource,omitempty"`
+	WorkflowSHA256  string   `json:"workflowSha256,omitempty"`
+	CurrentPhase    string   `json:"currentPhase,omitempty"`
+	CompletedPhases []string `json:"completedPhases,omitempty"`
+	CompletedCount  int      `json:"completedPhaseCount"`
+	RuntimeVarKeys  []string `json:"runtimeVarKeys,omitempty"`
+	UpdatedAt       string   `json:"updatedAt,omitempty"`
+	Version         int      `json:"version"`
+	Path            string   `json:"path"`
+}
+
+func newStateCommand(env *cliEnv) *cobra.Command {
+	cmd := &cobra.Command{Use: "state", Short: "Inspect and clear saved apply state"}
+	cmd.AddCommand(newStateShowCommand(env), newStateListCommand(env), newStateClearCommand(env))
+	return cmd
+}
+
+func newStateShowCommand(env *cliEnv) *cobra.Command {
+	vars := &varFlag{}
+	varsFiles := &stringSliceFlag{}
+	opts := stateWorkflowOptions{}
+	cmd := &cobra.Command{
+		Use:   "show",
+		Short: "Show apply state selected by workflow inputs",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			opts.varOverrides = vars.AsMap()
+			opts.varsFiles = varsFiles.Values()
+			return runStateShow(env, cmd.Context(), opts)
+		},
+	}
+	addStateWorkflowFlags(cmd, &opts, vars, varsFiles)
+	return cmd
+}
+
+func newStateListCommand(env *cliEnv) *cobra.Command {
+	opts := stateListOptions{}
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List apply state files",
+		RunE: func(_ *cobra.Command, _ []string) error {
+			return runStateList(env, opts)
+		},
+	}
+	cmd.Flags().StringVar(&opts.stateDir, "state-dir", "", "directory for apply state files (defaults to .deck/state/apply)")
+	cmd.Flags().StringVarP(&opts.output, "output", "o", "text", "output format (text|json)")
+	return cmd
+}
+
+func newStateClearCommand(env *cliEnv) *cobra.Command {
+	vars := &varFlag{}
+	varsFiles := &stringSliceFlag{}
+	opts := stateClearOptions{}
+	cmd := &cobra.Command{
+		Use:   "clear",
+		Short: "Delete apply state",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			opts.workflow.varOverrides = vars.AsMap()
+			opts.workflow.varsFiles = varsFiles.Values()
+			return runStateClear(env, cmd.Context(), opts)
+		},
+	}
+	addStateWorkflowFlags(cmd, &opts.workflow, vars, varsFiles)
+	cmd.Flags().BoolVar(&opts.all, "all", false, "delete all apply state files in the selected state directory")
+	cmd.Flags().BoolVar(&opts.yes, "yes", false, "confirm state deletion without prompting")
+	return cmd
+}
+
+func addStateWorkflowFlags(cmd *cobra.Command, opts *stateWorkflowOptions, vars *varFlag, varsFiles *stringSliceFlag) {
+	cmd.Flags().StringVar(&opts.workflowPath, "workflow", "", "path or URL to workflow file")
+	cmd.Flags().StringVar(&opts.scenario, "scenario", "", "scenario name")
+	cmd.Flags().StringVar(&opts.source, "source", scenarioSourceLocal, "scenario source (local|server)")
+	cmd.Flags().StringVar(&opts.stateDir, "state-dir", "", "directory for apply state files (overrides local .deck/state/apply or remote XDG state)")
+	cmd.Flags().StringVarP(&opts.output, "output", "o", "text", "output format (text|json)")
+	cmd.Flags().VarP(varsFiles, "vars-file", "f", "vars file overlay relative to workflows/ (repeatable)")
+	cmd.Flags().Var(vars, "var", "set variable override (key=value), repeatable")
+	registerScenarioSourceCompletion(cmd, "source", false)
+	registerScenarioNameCompletion(cmd, "scenario", "source", "", false)
+}
+
+func runStateShow(env *cliEnv, ctx context.Context, opts stateWorkflowOptions) error {
+	request, err := resolveStateRequest(ctx, opts)
+	if err != nil {
+		return err
+	}
+	state, err := install.LoadState(request.StatePath)
+	if err != nil {
+		return err
+	}
+	entry := stateEntryFromState(request.StatePath, state)
+	if strings.TrimSpace(entry.WorkflowPath) == "" {
+		entry.WorkflowPath = request.WorkflowPath
+	}
+	if strings.TrimSpace(entry.StateKey) == "" && request.Workflow != nil {
+		entry.StateKey = request.Workflow.StateKey
+	}
+	return writeStateEntries(env, strings.TrimSpace(opts.output), []stateEntry{entry}, false)
+}
+
+func runStateList(env *cliEnv, opts stateListOptions) error {
+	stateDir := strings.TrimSpace(opts.stateDir)
+	if stateDir == "" {
+		stateDir = workspacepaths.ApplyStateDir(".")
+	}
+	entries, err := readStateEntries(stateDir)
+	if err != nil {
+		return err
+	}
+	return writeStateEntries(env, strings.TrimSpace(opts.output), entries, true)
+}
+
+func runStateClear(_ *cliEnv, ctx context.Context, opts stateClearOptions) error {
+	if !opts.yes {
+		return fmt.Errorf("state clear requires --yes")
+	}
+	workflowSelected := strings.TrimSpace(opts.workflow.workflowPath) != "" || strings.TrimSpace(opts.workflow.scenario) != ""
+	if opts.all && workflowSelected {
+		return fmt.Errorf("state clear accepts either --all or --workflow/--scenario, not both")
+	}
+	if !opts.all && !workflowSelected {
+		return fmt.Errorf("state clear requires --all or --workflow/--scenario")
+	}
+	if opts.all {
+		stateDir := strings.TrimSpace(opts.workflow.stateDir)
+		if stateDir == "" {
+			stateDir = workspacepaths.ApplyStateDir(".")
+		}
+		return clearStateDir(stateDir)
+	}
+	request, err := resolveStateRequest(ctx, opts.workflow)
+	if err != nil {
+		return err
+	}
+	paths := []string{request.StatePath}
+	if !request.StateDirExplicit && request.Workflow != nil {
+		if xdgPath, err := install.XDGStatePath(request.Workflow); err == nil {
+			paths = append(paths, xdgPath)
+		}
+		if legacyPath, err := install.LegacyStatePath(request.Workflow); err == nil {
+			paths = append(paths, legacyPath)
+		}
+	}
+	return removeStateFiles(paths)
+}
+
+func resolveStateRequest(ctx context.Context, opts stateWorkflowOptions) (applycli.ExecutionRequest, error) {
+	workflowPath, err := resolvePlanWorkflowPath(ctx, strings.TrimSpace(opts.workflowPath), strings.TrimSpace(opts.scenario), strings.TrimSpace(opts.source))
+	if err != nil {
+		return applycli.ExecutionRequest{}, err
+	}
+	stateDir := strings.TrimSpace(opts.stateDir)
+	return applycli.ResolveStateRequest(ctx, applycli.StateRequestOptions{
+		WorkflowPath:     workflowPath,
+		StateDir:         stateDir,
+		StateDirExplicit: stateDir != "",
+		VarOverrides:     varsAsAnyMap(opts.varOverrides),
+		VarsFiles:        append([]string(nil), opts.varsFiles...),
+	})
+}
+
+func readStateEntries(stateDir string) ([]stateEntry, error) {
+	entries, err := os.ReadDir(stateDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("read state directory: %w", err)
+	}
+	result := make([]stateEntry, 0, len(entries))
+	for _, entry := range entries {
+		if entry.IsDir() || strings.ToLower(filepath.Ext(entry.Name())) != ".json" {
+			continue
+		}
+		path := filepath.Join(stateDir, entry.Name())
+		state, err := install.LoadState(path)
+		if err != nil {
+			return nil, err
+		}
+		result = append(result, stateEntryFromState(path, state))
+	}
+	slices.SortFunc(result, func(a, b stateEntry) int { return strings.Compare(a.Path, b.Path) })
+	return result, nil
+}
+
+func stateEntryFromState(path string, state *install.State) stateEntry {
+	if state == nil {
+		state = &install.State{}
+	}
+	stateKey := strings.TrimSpace(state.StateKey)
+	if stateKey == "" {
+		stateKey = strings.TrimSuffix(filepath.Base(path), filepath.Ext(path))
+	}
+	runtimeVarKeys := make([]string, 0, len(state.RuntimeVars))
+	for key := range state.RuntimeVars {
+		runtimeVarKeys = append(runtimeVarKeys, key)
+	}
+	slices.Sort(runtimeVarKeys)
+	return stateEntry{
+		StateKey:        stateKey,
+		Status:          displayStateStatus(state),
+		WorkflowPath:    state.Workflow.Path,
+		WorkflowSource:  state.Workflow.Source,
+		WorkflowSHA256:  state.Workflow.SHA256,
+		CurrentPhase:    state.Phase,
+		CompletedPhases: append([]string(nil), state.CompletedPhases...),
+		CompletedCount:  len(state.CompletedPhases),
+		RuntimeVarKeys:  runtimeVarKeys,
+		UpdatedAt:       state.UpdatedAt,
+		Version:         displayStateVersion(state),
+		Path:            path,
+	}
+}
+
+func displayStateStatus(state *install.State) string {
+	if state == nil {
+		return "running"
+	}
+	if strings.TrimSpace(state.Status) != "" {
+		return state.Status
+	}
+	if strings.TrimSpace(state.FailedPhase) != "" || strings.TrimSpace(state.Error) != "" {
+		return "failed"
+	}
+	if strings.TrimSpace(state.Phase) == "completed" {
+		return "succeeded"
+	}
+	return "running"
+}
+
+func displayStateVersion(state *install.State) int {
+	if state == nil || state.Version == 0 {
+		return 1
+	}
+	return state.Version
+}
+
+func writeStateEntries(env *cliEnv, output string, entries []stateEntry, list bool) error {
+	resolvedOutput, err := resolveOutputFormat(output)
+	if err != nil {
+		return err
+	}
+	if resolvedOutput == "json" {
+		encoder := env.stdoutJSONEncoder()
+		encoder.SetIndent("", "  ")
+		if list {
+			return encoder.Encode(entries)
+		}
+		if len(entries) == 0 {
+			return encoder.Encode(nil)
+		}
+		return encoder.Encode(entries[0])
+	}
+	if list {
+		for _, entry := range entries {
+			if err := env.stdoutPrintf("%s status=%s workflow=%s completed=%d updated=%s path=%s\n", entry.StateKey, entry.Status, displayValueOrDash(entry.WorkflowPath), entry.CompletedCount, displayValueOrDash(entry.UpdatedAt), entry.Path); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+	if len(entries) == 0 {
+		return nil
+	}
+	entry := entries[0]
+	if err := env.stdoutPrintf("state=%s\n", entry.Path); err != nil {
+		return err
+	}
+	if err := env.stdoutPrintf("stateKey=%s\n", entry.StateKey); err != nil {
+		return err
+	}
+	if err := env.stdoutPrintf("version=%d\n", entry.Version); err != nil {
+		return err
+	}
+	if err := env.stdoutPrintf("workflow=%s\n", displayValueOrDash(entry.WorkflowPath)); err != nil {
+		return err
+	}
+	if err := env.stdoutPrintf("status=%s\n", entry.Status); err != nil {
+		return err
+	}
+	if err := env.stdoutPrintf("currentPhase=%s\n", displayValueOrDash(entry.CurrentPhase)); err != nil {
+		return err
+	}
+	if err := env.stdoutPrintf("completedPhases=%s\n", strings.Join(entry.CompletedPhases, ",")); err != nil {
+		return err
+	}
+	if err := env.stdoutPrintf("runtimeVarKeys=%s\n", strings.Join(entry.RuntimeVarKeys, ",")); err != nil {
+		return err
+	}
+	return env.stdoutPrintf("updatedAt=%s\n", displayValueOrDash(entry.UpdatedAt))
+}
+
+func clearStateDir(stateDir string) error {
+	entries, err := os.ReadDir(stateDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return fmt.Errorf("read state directory: %w", err)
+	}
+	paths := make([]string, 0, len(entries))
+	for _, entry := range entries {
+		if entry.IsDir() || strings.ToLower(filepath.Ext(entry.Name())) != ".json" {
+			continue
+		}
+		paths = append(paths, filepath.Join(stateDir, entry.Name()))
+	}
+	return removeStateFiles(paths)
+}
+
+func removeStateFiles(paths []string) error {
+	seen := map[string]bool{}
+	for _, path := range paths {
+		trimmed := strings.TrimSpace(path)
+		if trimmed == "" || seen[trimmed] {
+			continue
+		}
+		seen[trimmed] = true
+		if err := os.Remove(trimmed); err != nil && !os.IsNotExist(err) {
+			return fmt.Errorf("remove state file %s: %w", trimmed, err)
+		}
+	}
+	return nil
+}

--- a/cmd/deck/cmd_state.go
+++ b/cmd/deck/cmd_state.go
@@ -215,7 +215,7 @@ func readStateEntries(stateDir string) ([]stateEntry, error) {
 		path := filepath.Join(stateDir, entry.Name())
 		state, err := install.LoadState(path)
 		if err != nil {
-			return nil, err
+			continue
 		}
 		result = append(result, stateEntryFromState(path, state))
 	}

--- a/cmd/deck/root_cobra.go
+++ b/cmd/deck/root_cobra.go
@@ -53,6 +53,7 @@ func newRootCommand(env *cliEnv) *cobra.Command {
 		withGroup(newBundleCommand(env), commandGroupCore),
 		withGroup(newPlanCommand(env), commandGroupCore),
 		withGroup(newApplyCommand(env), commandGroupCore),
+		withGroup(newStateCommand(env), commandGroupAdditional),
 		withGroup(newListCommand(env), commandGroupAdditional),
 		withGroup(newServerCommand(env), commandGroupAdditional),
 		withGroup(newAskCommand(env), commandGroupAdditional),

--- a/docs/contributing/legacy-compatibility.md
+++ b/docs/contributing/legacy-compatibility.md
@@ -11,7 +11,7 @@ This document describes the few pre-`v1.0.0` compatibility exceptions that are s
 | Server remote defaults | `XDG_CONFIG_HOME/deck/server.json` | `~/.deck/server.json` | `cmd/deck/source_defaults_compat.go` | Remove after a documented migration command or release note explicitly drops `~/.deck/server.json` support |
 | CLI cache root discovery | `XDG_CACHE_HOME/deck/` | `~/.deck/cache/` | `cmd/deck/cache_compat.go` | Remove after cache inspection/cleanup commands no longer need to surface legacy roots |
 | Prepare package cache state | `XDG_CACHE_HOME/deck/state/<sha>.json` | `~/.deck/cache/state/<sha>.json` | `internal/prepare/cache_compat.go` | Remove after one release cycle with migration notes for users carrying old prepared cache state |
-| Apply state read path | `XDG_STATE_HOME/deck/state/<key>.json` | `~/.deck/state/<key>.json` | `internal/install/state_compat.go` | Remove after one release cycle with migration notes for existing apply state files |
+| Apply state read path | Local: `<workspace>/.deck/state/apply/<key>.json`; remote: `XDG_STATE_HOME/deck/state/apply/<key>.json` | `XDG_STATE_HOME/deck/state/<key>.json`, `~/.deck/state/<key>.json` | `internal/install/state_compat.go` | Remove after one release cycle with migration notes for existing apply state files |
 | Apply state JSON shape | phase-based state file | legacy step-based state payload | `internal/install/state.go` | Remove only after legacy state files are no longer read in supported upgrades |
 
 ## Rules

--- a/docs/reference/apply-state.md
+++ b/docs/reference/apply-state.md
@@ -2,12 +2,76 @@
 
 `deck apply` stores progress in a state file derived from the workflow `StateKey`.
 
+## Where state is stored
+
+Local workflow state is stored in the workspace:
+
+```text
+<workspace>/.deck/state/apply/<state-key>.json
+```
+
+Remote workflow state is stored in the user-local XDG state root:
+
+```text
+$XDG_STATE_HOME/deck/state/apply/<state-key>.json
+~/.local/state/deck/state/apply/<state-key>.json
+```
+
+Use `--state-dir` to choose an explicit directory:
+
+```bash
+deck apply --state-dir /var/lib/deck/state/apply --workflow https://example.invalid/apply.yaml
+deck plan --state-dir /var/lib/deck/state/apply --workflow https://example.invalid/apply.yaml
+```
+
+When `--state-dir` is supplied, deck uses only `<dir>/<state-key>.json`. It does not infer workspace-local state, read old default paths, or run automatic migration.
+
+State under `.deck/state/` is runtime-local metadata. It should not be committed and is not included in bundles. Fresh clones and freshly extracted bundles start without saved apply state unless a state directory is copied or supplied explicitly.
+
+Remote workflows are not anchored to the current directory, bundle root, or fixed temporary paths such as `/tmp/deck`. Those locations can be surprising, shared, or volatile.
+
+## Privilege and user scope
+
+Default state is user-scoped.
+
+- `deck apply` and `sudo deck apply` use different default XDG roots for remote workflows.
+- `sudo -E deck apply` can preserve user XDG variables and create root-owned files in a user-owned state directory.
+- Repeated privileged remote workflow runs should use an explicit system state directory such as `/var/lib/deck/state/apply`.
+- If privileged and unprivileged commands both need to inspect state, choose explicit directory permissions deliberately.
+
 ## What identifies saved state
 
 - resolved workflow bytes after imports expand
 - effective vars for the run
+- the apply execution context fingerprint
 
 This keeps state isolated by the final workflow fingerprint and input vars.
+
+Workflow, vars, or context changes produce a different state key. Old state is not treated as corrupt or invalid; it is simply no longer selected by the new key.
+
+## Migration
+
+Default-path runs migrate existing state forward when the new target file does not already exist.
+
+Migration sources:
+
+```text
+$XDG_STATE_HOME/deck/state/<state-key>.json
+~/.local/state/deck/state/<state-key>.json
+~/.deck/state/<state-key>.json
+```
+
+Migration targets:
+
+```text
+local workflow:  <workspace>/.deck/state/apply/<state-key>.json
+remote workflow: $XDG_STATE_HOME/deck/state/apply/<state-key>.json
+remote workflow: ~/.local/state/deck/state/apply/<state-key>.json
+```
+
+Migration copies state instead of deleting old files. If both old XDG state and legacy `~/.deck/state/` exist for the same key, old XDG state wins. Existing target files are never overwritten.
+
+At `--v>=1`, deck reports migration as `event=state_migrated source=<old> target=<new>`.
 
 ## Phase-based resume
 
@@ -19,10 +83,16 @@ Apply now resumes at phase boundaries, not step boundaries.
 
 ## What is stored
 
-- current phase name
+- format version and kind
+- state key
+- workflow path, source, and hash when available
+- status and current phase
 - completed phase names
-- failed phase name and error, when the run stops
+- failed phase error, when the run stops
 - runtime vars exported by fully completed phases
+- runtime secret metadata, without secret values
+
+New state files use a versioned v2 JSON shape. Older v1 files remain readable and are normalized internally.
 
 ## Parallel batches inside a phase
 
@@ -48,3 +118,16 @@ Use `--fresh` to ignore saved apply state for that invocation.
 - `deck plan --fresh` shows a fresh-run view with no completed-phase skips or saved runtime vars
 
 `--fresh` does not delete the state file before execution.
+
+## State management
+
+Use `deck state` to inspect and delete apply state:
+
+```bash
+deck state show --workflow workflows/scenarios/apply.yaml
+deck state list
+deck state clear --workflow workflows/scenarios/apply.yaml --yes
+deck state clear --all --yes
+```
+
+`deck state show` uses the same workflow, vars, and state-key logic as `deck plan` and `deck apply`. Use `--state-dir` with `deck state` when apply/plan used an explicit state directory.

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -357,8 +357,11 @@ Optional transport override example:
 - scenario entrypoints live under `workflows/scenarios/`
 - `plan` and `apply` accept `--scenario` for named scenarios and `--workflow` for an explicit path or URL.
 - `plan` and `apply` support `--fresh` to ignore saved apply state for that invocation.
+- `plan`, `apply`, and `state` support `--state-dir` to use an explicit apply state directory.
+- `deck state show/list/clear` inspects and removes saved apply state.
 - `--source` controls whether `--scenario` resolves from the local workspace or the saved remote server.
-- workspace-local metadata stays under `./.deck/`, while user-global config, state, cache, and run history use standard XDG locations.
+- local workflow apply state stays under `./.deck/state/apply/`; remote workflow apply state uses the user-local XDG state root under `deck/state/apply/`.
+- workspace-local metadata stays under `./.deck/`, while user-global config, remote workflow state, cache, and run history use standard XDG locations.
 - `ask` workspace context lives under `./.deck/ask/`, while saved ask config defaults live under `~/.config/deck/config.json` as the top-level `ask` object.
 - `deck ask plan` writes plan artifacts under `./.deck/plan/` by default (`<timestamp>-<slug>.md`, `<timestamp>-<slug>.json`, `latest.md`, `latest.json`).
 - `deck ask --from .deck/plan/<name>.md "implement this plan"` prefers the same-basename `.json` artifact when present.

--- a/internal/applycli/command.go
+++ b/internal/applycli/command.go
@@ -14,40 +14,88 @@ import (
 )
 
 type PlanCommandOptions struct {
-	WorkflowPath    string
-	Scenario        string
-	SelectedPhase   string
-	Output          string
-	Fresh           bool
-	VarOverrides    map[string]any
-	VarsFiles       []string
-	Hostname        string
-	DetectHostname  func() (string, error)
-	Verbosef        func(level int, format string, args ...any) error
-	StdoutPrintf    func(format string, args ...any) error
-	JSONEncoderFunc func() *json.Encoder
-	ResolveOutput   func(string) (string, error)
+	WorkflowPath     string
+	Scenario         string
+	SelectedPhase    string
+	Output           string
+	Fresh            bool
+	StateDir         string
+	StateDirExplicit bool
+	VarOverrides     map[string]any
+	VarsFiles        []string
+	Hostname         string
+	DetectHostname   func() (string, error)
+	Verbosef         func(level int, format string, args ...any) error
+	StdoutPrintf     func(format string, args ...any) error
+	JSONEncoderFunc  func() *json.Encoder
+	ResolveOutput    func(string) (string, error)
 }
 
 type ApplyCommandOptions struct {
-	WorkflowPath   string
-	BundleRoot     string
-	WorkflowSource string
-	Scenario       string
-	SelectedPhase  string
-	Fresh          bool
-	DryRun         bool
-	NonInteractive bool
-	VarOverrides   map[string]any
-	VarsFiles      []string
-	Hostname       string
-	DetectHostname func() (string, error)
-	Verbosef       func(level int, format string, args ...any) error
-	StdoutPrintf   func(format string, args ...any) error
-	StdoutPrintln  func(args ...any) error
-	InvocationID   string
-	AdditionalSink install.StepEventSink
-	NewRunLogger   func(workflowPath, workflowSource, scenario, bundleRoot, selectedPhase string) (RunLogger, error)
+	WorkflowPath     string
+	BundleRoot       string
+	WorkflowSource   string
+	Scenario         string
+	SelectedPhase    string
+	Fresh            bool
+	StateDir         string
+	StateDirExplicit bool
+	DryRun           bool
+	NonInteractive   bool
+	VarOverrides     map[string]any
+	VarsFiles        []string
+	Hostname         string
+	DetectHostname   func() (string, error)
+	Verbosef         func(level int, format string, args ...any) error
+	StdoutPrintf     func(format string, args ...any) error
+	StdoutPrintln    func(args ...any) error
+	InvocationID     string
+	AdditionalSink   install.StepEventSink
+	NewRunLogger     func(workflowPath, workflowSource, scenario, bundleRoot, selectedPhase string) (RunLogger, error)
+}
+
+type StateRequestOptions struct {
+	WorkflowPath     string
+	SelectedPhase    string
+	StateDir         string
+	StateDirExplicit bool
+	VarOverrides     map[string]any
+	VarsFiles        []string
+	Hostname         string
+	DetectHostname   func() (string, error)
+}
+
+func ResolveStateRequest(ctx context.Context, opts StateRequestOptions) (ExecutionRequest, error) {
+	if ctx == nil {
+		return ExecutionRequest{}, fmt.Errorf("context is nil")
+	}
+	resolvedRequest, err := ResolveExecutionRequest(ctx, ExecutionRequestOptions{
+		CommandName:                  "state",
+		WorkflowPath:                 strings.TrimSpace(opts.WorkflowPath),
+		AllowRemoteWorkflow:          true,
+		VarOverrides:                 opts.VarOverrides,
+		VarsFiles:                    append([]string(nil), opts.VarsFiles...),
+		NodeScopedVars:               true,
+		Hostname:                     opts.Hostname,
+		DetectHostname:               opts.DetectHostname,
+		StateDir:                     strings.TrimSpace(opts.StateDir),
+		StateDirExplicit:             opts.StateDirExplicit,
+		SelectedPhase:                strings.TrimSpace(opts.SelectedPhase),
+		BuildExecutionWorkflow:       true,
+		ResolveStatePath:             true,
+		StatePathFromExecutionTarget: false,
+	})
+	if err != nil {
+		return ExecutionRequest{}, err
+	}
+	execContext, err := buildPlanExecutionContext(&resolvedRequest, "")
+	if err != nil {
+		return ExecutionRequest{}, err
+	}
+	if err := applyContextStateKey(&resolvedRequest, execContext); err != nil {
+		return ExecutionRequest{}, err
+	}
+	return resolvedRequest, nil
 }
 
 func RunPlanCommand(ctx context.Context, opts PlanCommandOptions) error {
@@ -64,12 +112,15 @@ func RunPlanCommand(ctx context.Context, opts PlanCommandOptions) error {
 	resolvedRequest, err := ResolveExecutionRequest(ctx, ExecutionRequestOptions{
 		CommandName:                  "diff",
 		WorkflowPath:                 strings.TrimSpace(opts.WorkflowPath),
+		AllowRemoteWorkflow:          true,
 		VarOverrides:                 opts.VarOverrides,
 		VarsFiles:                    append([]string(nil), opts.VarsFiles...),
 		NodeScopedVars:               true,
 		Hostname:                     opts.Hostname,
 		DetectHostname:               opts.DetectHostname,
 		Fresh:                        opts.Fresh,
+		StateDir:                     strings.TrimSpace(opts.StateDir),
+		StateDirExplicit:             opts.StateDirExplicit,
 		SelectedPhase:                strings.TrimSpace(opts.SelectedPhase),
 		DefaultPhase:                 "",
 		BuildExecutionWorkflow:       true,
@@ -79,6 +130,7 @@ func RunPlanCommand(ctx context.Context, opts PlanCommandOptions) error {
 	if err != nil {
 		return err
 	}
+	resolvedRequest.StateMigrationSink = stateMigrationDiagnosticSink("plan", opts.Verbosef)
 	execContext, err := buildPlanExecutionContext(&resolvedRequest, strings.TrimSpace(opts.Scenario))
 	if err != nil {
 		return err
@@ -111,6 +163,8 @@ func RunApplyCommand(ctx context.Context, opts ApplyCommandOptions) error {
 		Hostname:                     opts.Hostname,
 		DetectHostname:               opts.DetectHostname,
 		Fresh:                        opts.Fresh,
+		StateDir:                     strings.TrimSpace(opts.StateDir),
+		StateDirExplicit:             opts.StateDirExplicit,
 		SelectedPhase:                strings.TrimSpace(opts.SelectedPhase),
 		DefaultPhase:                 "",
 		BuildExecutionWorkflow:       true,
@@ -120,6 +174,7 @@ func RunApplyCommand(ctx context.Context, opts ApplyCommandOptions) error {
 	if err != nil {
 		return err
 	}
+	resolvedRequest.StateMigrationSink = stateMigrationDiagnosticSink("apply", opts.Verbosef)
 	execContext, bundleRoot, err := buildApplyExecutionContext(resolvedRequest, opts)
 	if err != nil {
 		return err
@@ -204,7 +259,7 @@ func applyContextStateKey(request *ExecutionRequest, execContext workflowcontext
 	if request.ExecutionWorkflow != nil {
 		request.ExecutionWorkflow.StateKey = stateKey
 	}
-	statePath, err := ResolveInstallStatePath(request.Workflow)
+	statePath, err := ResolveInstallStatePathForWorkflowPath(request.Workflow, request.WorkflowPath, request.StateDir)
 	if err != nil {
 		return err
 	}

--- a/internal/applycli/request.go
+++ b/internal/applycli/request.go
@@ -43,15 +43,21 @@ type ExecutionRequestOptions struct {
 	BuildExecutionWorkflow       bool
 	ResolveStatePath             bool
 	StatePathFromExecutionTarget bool
+	StateDir                     string
+	StateDirExplicit             bool
 }
 
 type ExecutionRequest struct {
-	WorkflowPath      string
-	Workflow          *config.Workflow
-	Fresh             bool
-	SelectedPhase     string
-	ExecutionWorkflow *config.Workflow
-	StatePath         string
+	WorkflowPath       string
+	Workflow           *config.Workflow
+	Fresh              bool
+	SelectedPhase      string
+	ExecutionWorkflow  *config.Workflow
+	StatePath          string
+	StateDir           string
+	StateDirExplicit   bool
+	StateMigrationSink func(source string, target string)
+	RemoteWorkflow     bool
 }
 
 func ResolveExecutionRequest(ctx context.Context, opts ExecutionRequestOptions) (ExecutionRequest, error) {
@@ -118,7 +124,7 @@ func ResolveExecutionRequest(ctx context.Context, opts ExecutionRequestOptions) 
 		if opts.StatePathFromExecutionTarget {
 			stateWorkflow = executionWorkflow
 		}
-		resolvedStatePath, err := ResolveInstallStatePath(stateWorkflow)
+		resolvedStatePath, err := ResolveInstallStatePathForWorkflowPath(stateWorkflow, workflowPath, opts.StateDir)
 		if err != nil {
 			return ExecutionRequest{}, err
 		}
@@ -132,6 +138,9 @@ func ResolveExecutionRequest(ctx context.Context, opts ExecutionRequestOptions) 
 		SelectedPhase:     selectedPhase,
 		ExecutionWorkflow: executionWorkflow,
 		StatePath:         statePath,
+		StateDir:          strings.TrimSpace(opts.StateDir),
+		StateDirExplicit:  opts.StateDirExplicit,
+		RemoteWorkflow:    isRemoteWorkflow,
 	}, nil
 }
 
@@ -143,11 +152,20 @@ func LoadInstallDryRunState(request ExecutionRequest) (*install.State, error) {
 	if wf == nil {
 		wf = request.ExecutionWorkflow
 	}
-	statePath, err := ResolveInstallStatePath(wf)
-	if err != nil {
-		return nil, err
+	statePath := strings.TrimSpace(request.StatePath)
+	if statePath == "" {
+		resolvedStatePath, err := ResolveInstallStatePathForWorkflowPath(wf, request.WorkflowPath, request.StateDir)
+		if err != nil {
+			return nil, err
+		}
+		statePath = resolvedStatePath
 	}
-	statePath, err = install.ResolveStateReadPathForWorkflow(wf, statePath)
+	var err error
+	if request.StateDirExplicit {
+		statePath, err = install.ResolveStateReadPathForWorkflowNoFallback(wf, statePath)
+	} else {
+		statePath, err = install.ResolveStateReadPathForWorkflowWithMigrationSink(wf, statePath, request.StateMigrationSink)
+	}
 	if err != nil {
 		return nil, err
 	}
@@ -155,7 +173,42 @@ func LoadInstallDryRunState(request ExecutionRequest) (*install.State, error) {
 }
 
 func ResolveInstallStatePath(wf *config.Workflow) (string, error) {
-	return install.DefaultStatePath(wf)
+	return ResolveInstallStatePathForWorkflowPath(wf, "", "")
+}
+
+func ResolveInstallStatePathWithDir(wf *config.Workflow, stateDir string) (string, error) {
+	return ResolveInstallStatePathForWorkflowPath(wf, "", stateDir)
+}
+
+func ResolveInstallStatePathForWorkflowPath(wf *config.Workflow, workflowPath string, stateDir string) (string, error) {
+	if strings.TrimSpace(stateDir) != "" {
+		return install.StatePathInDir(wf, stateDir)
+	}
+	if IsHTTPWorkflowPath(workflowPath) {
+		return install.XDGApplyStatePath(wf)
+	}
+	root, err := resolveLocalStateRoot(workflowPath)
+	if err != nil {
+		return "", err
+	}
+	return install.StatePathInDir(wf, workspacepaths.ApplyStateDir(root))
+}
+
+func resolveLocalStateRoot(workflowPath string) (string, error) {
+	trimmed := strings.TrimSpace(workflowPath)
+	if trimmed == "" {
+		return ".", nil
+	}
+	if bundleRoot, err := inferBundleRootFromWorkflowPath(trimmed); err != nil {
+		return "", err
+	} else if strings.TrimSpace(bundleRoot) != "" {
+		return bundleRoot, nil
+	}
+	abs, err := filepath.Abs(trimmed)
+	if err != nil {
+		return "", fmt.Errorf("resolve workflow path: %w", err)
+	}
+	return filepath.Dir(abs), nil
 }
 
 func IsHTTPWorkflowPath(raw string) bool {

--- a/internal/applycli/service.go
+++ b/internal/applycli/service.go
@@ -90,7 +90,12 @@ func Execute(ctx context.Context, opts ExecuteOptions) (err error) {
 		}
 	}()
 
-	if err := install.Run(ctx, request.ExecutionWorkflow, install.RunOptions{BundleRoot: opts.BundleRoot, StatePath: request.StatePath, Context: opts.Context, EventSink: eventSink, Fresh: request.Fresh, NonInteractive: opts.NonInteractive}); err != nil {
+	stateMetadata := install.StateMetadata{Workflow: install.StateWorkflow{Path: request.WorkflowPath, Source: strings.TrimSpace(opts.WorkflowSource)}}
+	if request.Workflow != nil {
+		stateMetadata.StateKey = request.Workflow.StateKey
+		stateMetadata.Workflow.SHA256 = request.Workflow.WorkflowSHA256
+	}
+	if err := install.Run(ctx, request.ExecutionWorkflow, install.RunOptions{BundleRoot: opts.BundleRoot, StatePath: request.StatePath, StateMetadata: stateMetadata, DisableStateFallback: request.StateDirExplicit, StateMigrationSink: request.StateMigrationSink, Context: opts.Context, EventSink: eventSink, Fresh: request.Fresh, NonInteractive: opts.NonInteractive}); err != nil {
 		return err
 	}
 	if opts.StdoutPrintln == nil {
@@ -296,6 +301,12 @@ func emitApplyDiagnostic(opts ExecuteOptions, level int, event logs.CLIEvent) er
 		event.Attrs = attrs
 	}
 	return verboseEvent(opts.Verbosef, level, event)
+}
+
+func stateMigrationDiagnosticSink(component string, verbosef func(level int, format string, args ...any) error) func(source string, target string) {
+	return func(source string, target string) {
+		_ = verboseEvent(verbosef, 1, logs.CLIEvent{Component: strings.TrimSpace(component), Event: "state_migrated", Attrs: map[string]any{"source": source, "target": target}})
+	}
 }
 
 func verboseEvent(fn func(level int, format string, args ...any) error, level int, event logs.CLIEvent) error {

--- a/internal/install/run_lifecycle_test.go
+++ b/internal/install/run_lifecycle_test.go
@@ -107,7 +107,7 @@ func TestRun_InstallTools(t *testing.T) {
 	}
 }
 
-func TestRun_DefaultStatePathUsesHomeStateKey(t *testing.T) {
+func TestRun_DefaultStatePathUsesWorkspaceStateKey(t *testing.T) {
 	dir := t.TempDir()
 	home := filepath.Join(dir, "home")
 	bundle := filepath.Join(dir, "bundle")
@@ -128,6 +128,7 @@ func TestRun_DefaultStatePathUsesHomeStateKey(t *testing.T) {
 		t.Fatalf("write manifest: %v", err)
 	}
 	t.Setenv("HOME", home)
+	t.Chdir(dir)
 
 	wf := &config.Workflow{
 		StateKey: "state-key-default-path-test",
@@ -141,9 +142,12 @@ func TestRun_DefaultStatePathUsesHomeStateKey(t *testing.T) {
 		t.Fatalf("Run failed: %v", err)
 	}
 
-	statePath := filepath.Join(home, ".local", "state", "deck", "state", wf.StateKey+".json")
+	statePath := filepath.Join(dir, ".deck", "state", "apply", wf.StateKey+".json")
 	if _, err := os.Stat(statePath); err != nil {
-		t.Fatalf("state file missing at expected home path: %v", err)
+		t.Fatalf("state file missing at expected workspace path: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(home, ".local", "state", "deck", "state", wf.StateKey+".json")); !os.IsNotExist(err) {
+		t.Fatalf("unexpected old XDG flat state file, err=%v", err)
 	}
 	if _, err := os.Stat(filepath.Join(bundle, ".deck", "state.json")); !os.IsNotExist(err) {
 		t.Fatalf("unexpected bundle state file, err=%v", err)

--- a/internal/install/runner.go
+++ b/internal/install/runner.go
@@ -16,14 +16,17 @@ import (
 )
 
 type RunOptions struct {
-	BundleRoot     string
-	StatePath      string
-	Context        workflowcontext.Context
-	EventSink      StepEventSink
-	Fresh          bool
-	Interaction    operatorio.Interface
-	NonInteractive bool
-	kubeadm        kubeadmExecutor
+	BundleRoot           string
+	StatePath            string
+	StateMetadata        StateMetadata
+	DisableStateFallback bool
+	StateMigrationSink   func(source string, target string)
+	Context              workflowcontext.Context
+	EventSink            StepEventSink
+	Fresh                bool
+	Interaction          operatorio.Interface
+	NonInteractive       bool
+	kubeadm              kubeadmExecutor
 }
 
 const (
@@ -122,7 +125,7 @@ func Run(ctx context.Context, wf *config.Workflow, opts RunOptions) error {
 	}
 	st := &State{CompletedPhases: []string{}, RuntimeVars: map[string]any{}}
 	if !opts.Fresh {
-		stateReadPath, err := resolveStateReadPath(wf, statePath)
+		stateReadPath, err := resolveStateReadPath(wf, statePath, !opts.DisableStateFallback, opts.StateMigrationSink)
 		if err != nil {
 			return err
 		}
@@ -163,7 +166,7 @@ func Run(ctx context.Context, wf *config.Workflow, opts RunOptions) error {
 				st.FailedPhase = phase.Name
 				st.Error = maskSecrets(err.Error(), runtimeSecretValues(runtimeVars, runtimeSecrets))
 				emitPhaseEvent(opts.EventSink, phase.Name, "failed", "", "")
-				if saveErr := SaveState(statePath, sanitizedState(st, runtimeVars, runtimeSecrets, false)); saveErr != nil {
+				if saveErr := SaveStateWithMetadata(statePath, sanitizedState(st, runtimeVars, runtimeSecrets, false), opts.StateMetadata); saveErr != nil {
 					return errors.Join(err, fmt.Errorf("save failed apply state: %w", saveErr))
 				}
 				return maskError(err, runtimeSecretValues(runtimeVars, runtimeSecrets))
@@ -174,7 +177,7 @@ func Run(ctx context.Context, wf *config.Workflow, opts RunOptions) error {
 		st.FailedPhase = ""
 		st.Error = ""
 		emitPhaseEvent(opts.EventSink, phase.Name, "succeeded", "", "")
-		if err := SaveState(statePath, sanitizedState(st, runtimeVars, runtimeSecrets, false)); err != nil {
+		if err := SaveStateWithMetadata(statePath, sanitizedState(st, runtimeVars, runtimeSecrets, false), opts.StateMetadata); err != nil {
 			return err
 		}
 	}
@@ -182,7 +185,7 @@ func Run(ctx context.Context, wf *config.Workflow, opts RunOptions) error {
 	st.Phase = "completed"
 	st.FailedPhase = ""
 	st.Error = ""
-	if err := SaveState(statePath, sanitizedState(st, runtimeVars, runtimeSecrets, true)); err != nil {
+	if err := SaveStateWithMetadata(statePath, sanitizedState(st, runtimeVars, runtimeSecrets, true), opts.StateMetadata); err != nil {
 		return err
 	}
 

--- a/internal/install/state.go
+++ b/internal/install/state.go
@@ -4,15 +4,25 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/Airgap-Castaways/deck/internal/config"
 	"github.com/Airgap-Castaways/deck/internal/filemode"
 	"github.com/Airgap-Castaways/deck/internal/fsutil"
 	"github.com/Airgap-Castaways/deck/internal/userdirs"
+	"github.com/Airgap-Castaways/deck/internal/workspacepaths"
 )
 
 type State struct {
+	Version         int                      `json:"-"`
+	Kind            string                   `json:"-"`
+	StateKey        string                   `json:"-"`
+	Workflow        StateWorkflow            `json:"-"`
+	Status          string                   `json:"-"`
+	CreatedAt       string                   `json:"-"`
+	UpdatedAt       string                   `json:"-"`
 	Phase           string                   `json:"phase,omitempty"`
 	CompletedPhases []string                 `json:"completedPhases,omitempty"`
 	FailedPhase     string                   `json:"failedPhase,omitempty"`
@@ -25,6 +35,43 @@ type RuntimeSecret struct {
 	Phase  string `json:"phase,omitempty"`
 	StepID string `json:"stepID,omitempty"`
 	Output string `json:"output,omitempty"`
+}
+
+type StateWorkflow struct {
+	Path   string `json:"path,omitempty"`
+	Source string `json:"source,omitempty"`
+	SHA256 string `json:"sha256,omitempty"`
+}
+
+type StateMetadata struct {
+	StateKey string
+	Workflow StateWorkflow
+	Now      func() time.Time
+}
+
+type stateFileV2 struct {
+	Version      int            `json:"version"`
+	Kind         string         `json:"kind"`
+	StateKey     string         `json:"stateKey"`
+	Workflow     StateWorkflow  `json:"workflow,omitempty"`
+	Status       string         `json:"status"`
+	CurrentPhase string         `json:"currentPhase,omitempty"`
+	CreatedAt    string         `json:"createdAt"`
+	UpdatedAt    string         `json:"updatedAt"`
+	Phases       []statePhaseV2 `json:"phases,omitempty"`
+	Runtime      stateRuntimeV2 `json:"runtime,omitempty"`
+	Error        string         `json:"error,omitempty"`
+}
+
+type statePhaseV2 struct {
+	Name        string `json:"name"`
+	Status      string `json:"status"`
+	CompletedAt string `json:"completedAt,omitempty"`
+}
+
+type stateRuntimeV2 struct {
+	Vars    map[string]any           `json:"vars,omitempty"`
+	Secrets map[string]RuntimeSecret `json:"secrets,omitempty"`
 }
 
 type legacyState struct {
@@ -48,12 +95,40 @@ func LoadState(path string) (*State, error) {
 		return nil, fmt.Errorf("read state file: %w", err)
 	}
 
+	return parseStateBytes(content)
+}
+
+func (st *State) UnmarshalJSON(content []byte) error {
+	loaded, err := parseStateBytes(content)
+	if err != nil {
+		return err
+	}
+	*st = *loaded
+	return nil
+}
+
+func parseStateBytes(content []byte) (*State, error) {
+	var header struct {
+		Version int    `json:"version"`
+		Kind    string `json:"kind"`
+	}
+	if err := json.Unmarshal(content, &header); err != nil {
+		return nil, fmt.Errorf("parse state file: %w", err)
+	}
+	if header.Version == 2 || header.Kind == "deck.applyState" {
+		return loadStateV2(content)
+	}
+	return loadStateV1(content)
+}
+
+func loadStateV1(content []byte) (*State, error) {
 	var legacy legacyState
 	var st State
 	if err := json.Unmarshal(content, &legacy); err != nil {
 		return nil, fmt.Errorf("parse state file: %w", err)
 	}
 	st = State{
+		Version:         1,
 		Phase:           legacy.Phase,
 		CompletedPhases: legacy.CompletedPhases,
 		FailedPhase:     legacy.FailedPhase,
@@ -76,16 +151,160 @@ func LoadState(path string) (*State, error) {
 	return &st, nil
 }
 
-func SaveState(path string, st *State) error {
-	if err := filemode.EnsureParentPrivateDir(path); err != nil {
-		return fmt.Errorf("create state directory: %w", err)
+func loadStateV2(content []byte) (*State, error) {
+	var file stateFileV2
+	if err := json.Unmarshal(content, &file); err != nil {
+		return nil, fmt.Errorf("parse state file: %w", err)
 	}
+	st := State{
+		Version:        file.Version,
+		Kind:           file.Kind,
+		StateKey:       file.StateKey,
+		Workflow:       file.Workflow,
+		Status:         file.Status,
+		CreatedAt:      file.CreatedAt,
+		UpdatedAt:      file.UpdatedAt,
+		Phase:          file.CurrentPhase,
+		RuntimeVars:    file.Runtime.Vars,
+		RuntimeSecrets: file.Runtime.Secrets,
+		Error:          file.Error,
+	}
+	for _, phase := range file.Phases {
+		name := strings.TrimSpace(phase.Name)
+		if name == "" {
+			continue
+		}
+		switch strings.TrimSpace(phase.Status) {
+		case "succeeded":
+			st.CompletedPhases = append(st.CompletedPhases, name)
+		case "failed":
+			st.FailedPhase = name
+		}
+	}
+	if st.Phase == "" {
+		st.Phase = phaseFromStatus(st.Status, st.FailedPhase)
+	}
+	normalizeState(&st)
+	return &st, nil
+}
 
-	raw, err := json.MarshalIndent(st, "", "  ")
+func SaveState(path string, st *State) error {
+	return SaveStateWithMetadata(path, st, StateMetadata{})
+}
+
+func SaveStateWithMetadata(path string, st *State, metadata StateMetadata) error {
+	file := stateFileFromState(path, st, metadata)
+	raw, err := json.MarshalIndent(file, "", "  ")
 	if err != nil {
 		return fmt.Errorf("encode state file: %w", err)
 	}
+	return SaveRawStateFile(path, raw)
+}
 
+func stateFileFromState(path string, st *State, metadata StateMetadata) stateFileV2 {
+	if st == nil {
+		st = &State{}
+	}
+	now := time.Now().UTC()
+	if metadata.Now != nil {
+		now = metadata.Now().UTC()
+	}
+	updatedAt := now.Format(time.RFC3339)
+	createdAt := strings.TrimSpace(st.CreatedAt)
+	if createdAt == "" {
+		createdAt = updatedAt
+	}
+	stateKey := strings.TrimSpace(metadata.StateKey)
+	if stateKey == "" {
+		stateKey = strings.TrimSpace(st.StateKey)
+	}
+	if stateKey == "" {
+		stateKey = strings.TrimSuffix(filepath.Base(path), filepath.Ext(path))
+	}
+	workflow := metadata.Workflow
+	if workflow == (StateWorkflow{}) {
+		workflow = st.Workflow
+	}
+	status := stateStatus(st)
+	return stateFileV2{
+		Version:      2,
+		Kind:         "deck.applyState",
+		StateKey:     stateKey,
+		Workflow:     workflow,
+		Status:       status,
+		CurrentPhase: strings.TrimSpace(st.Phase),
+		CreatedAt:    createdAt,
+		UpdatedAt:    updatedAt,
+		Phases:       phasesForState(st, updatedAt),
+		Runtime:      stateRuntimeV2{Vars: st.RuntimeVars, Secrets: st.RuntimeSecrets},
+		Error:        strings.TrimSpace(st.Error),
+	}
+}
+
+func phasesForState(st *State, completedAt string) []statePhaseV2 {
+	if st == nil {
+		return nil
+	}
+	phases := make([]statePhaseV2, 0, len(st.CompletedPhases)+1)
+	seen := map[string]bool{}
+	for _, name := range st.CompletedPhases {
+		trimmed := strings.TrimSpace(name)
+		if trimmed == "" || seen[trimmed] {
+			continue
+		}
+		seen[trimmed] = true
+		phases = append(phases, statePhaseV2{Name: trimmed, Status: "succeeded", CompletedAt: completedAt})
+	}
+	failed := strings.TrimSpace(st.FailedPhase)
+	if failed != "" && !seen[failed] {
+		phases = append(phases, statePhaseV2{Name: failed, Status: "failed"})
+	}
+	return phases
+}
+
+func stateStatus(st *State) string {
+	if st == nil {
+		return "running"
+	}
+	if strings.TrimSpace(st.FailedPhase) != "" || strings.TrimSpace(st.Error) != "" {
+		return "failed"
+	}
+	if strings.TrimSpace(st.Phase) == "completed" {
+		return "succeeded"
+	}
+	return "running"
+}
+
+func phaseFromStatus(status string, failedPhase string) string {
+	switch strings.TrimSpace(status) {
+	case "succeeded":
+		return "completed"
+	case "failed":
+		return strings.TrimSpace(failedPhase)
+	default:
+		return ""
+	}
+}
+
+func normalizeState(st *State) {
+	if st == nil {
+		return
+	}
+	if st.CompletedPhases == nil {
+		st.CompletedPhases = []string{}
+	}
+	if st.RuntimeVars == nil {
+		st.RuntimeVars = map[string]any{}
+	}
+	if st.RuntimeSecrets == nil {
+		st.RuntimeSecrets = map[string]RuntimeSecret{}
+	}
+}
+
+func SaveRawStateFile(path string, raw []byte) error {
+	if err := filemode.EnsureParentPrivateDir(path); err != nil {
+		return fmt.Errorf("create state directory: %w", err)
+	}
 	tmp := path + ".tmp"
 	if err := filemode.WritePrivateFile(tmp, raw); err != nil {
 		return fmt.Errorf("write temp state file: %w", err)
@@ -97,6 +316,25 @@ func SaveState(path string, st *State) error {
 }
 
 func DefaultStatePath(wf *config.Workflow) (string, error) {
+	return StatePathInDir(wf, workspacepaths.ApplyStateDir("."))
+}
+
+func StatePathInDir(wf *config.Workflow, stateDir string) (string, error) {
+	if wf == nil {
+		return "", fmt.Errorf("workflow is nil")
+	}
+	stateKey := strings.TrimSpace(wf.StateKey)
+	if stateKey == "" {
+		return "", fmt.Errorf("workflow state key is empty")
+	}
+	resolvedDir := strings.TrimSpace(stateDir)
+	if resolvedDir == "" {
+		resolvedDir = workspacepaths.ApplyStateDir(".")
+	}
+	return filepath.Join(resolvedDir, stateKey+".json"), nil
+}
+
+func XDGStatePath(wf *config.Workflow) (string, error) {
 	if wf == nil {
 		return "", fmt.Errorf("workflow is nil")
 	}
@@ -105,6 +343,21 @@ func DefaultStatePath(wf *config.Workflow) (string, error) {
 		return "", fmt.Errorf("workflow state key is empty")
 	}
 	return userdirs.StateFile(stateKey + ".json")
+}
+
+func XDGApplyStatePath(wf *config.Workflow) (string, error) {
+	if wf == nil {
+		return "", fmt.Errorf("workflow is nil")
+	}
+	stateKey := strings.TrimSpace(wf.StateKey)
+	if stateKey == "" {
+		return "", fmt.Errorf("workflow state key is empty")
+	}
+	root, err := userdirs.StateRoot()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(root, "state", workspacepaths.ApplyStateDirRel, stateKey+".json"), nil
 }
 
 func LegacyStatePath(wf *config.Workflow) (string, error) {
@@ -118,7 +371,7 @@ func LegacyStatePath(wf *config.Workflow) (string, error) {
 	return userdirs.LegacyStateFile(stateKey + ".json")
 }
 
-func resolveStateReadPath(wf *config.Workflow, preferredPath string) (string, error) {
+func resolveStateReadPath(wf *config.Workflow, preferredPath string, allowFallback bool, migrationSink func(source string, target string)) (string, error) {
 	resolved := strings.TrimSpace(preferredPath)
 	if resolved == "" {
 		return preferredPath, nil
@@ -128,16 +381,33 @@ func resolveStateReadPath(wf *config.Workflow, preferredPath string) (string, er
 	} else if err != nil && !os.IsNotExist(err) {
 		return "", fmt.Errorf("stat state file: %w", err)
 	}
+	if !allowFallback {
+		return resolved, nil
+	}
 	if wf == nil || strings.TrimSpace(wf.StateKey) == "" {
 		return resolved, nil
 	}
-	legacyPath, _, err := resolveLegacyStateReadPath(wf, resolved)
+	fallbackPath, migrated, err := resolveFallbackStateReadPath(wf, resolved)
 	if err != nil {
 		return "", err
 	}
-	return legacyPath, nil
+	if migrated {
+		if migrationSink != nil {
+			migrationSink(fallbackPath, resolved)
+		}
+		return resolved, nil
+	}
+	return fallbackPath, nil
 }
 
 func ResolveStateReadPathForWorkflow(wf *config.Workflow, preferredPath string) (string, error) {
-	return resolveStateReadPath(wf, preferredPath)
+	return resolveStateReadPath(wf, preferredPath, true, nil)
+}
+
+func ResolveStateReadPathForWorkflowNoFallback(wf *config.Workflow, preferredPath string) (string, error) {
+	return resolveStateReadPath(wf, preferredPath, false, nil)
+}
+
+func ResolveStateReadPathForWorkflowWithMigrationSink(wf *config.Workflow, preferredPath string, migrationSink func(source string, target string)) (string, error) {
+	return resolveStateReadPath(wf, preferredPath, true, migrationSink)
 }

--- a/internal/install/state_compat.go
+++ b/internal/install/state_compat.go
@@ -6,25 +6,53 @@ import (
 	"strings"
 
 	"github.com/Airgap-Castaways/deck/internal/config"
+	"github.com/Airgap-Castaways/deck/internal/fsutil"
 )
 
-// resolveLegacyStateReadPath keeps read-only fallback support for pre-XDG apply
-// state files while new writes continue to use the canonical state root.
-func resolveLegacyStateReadPath(wf *config.Workflow, preferredPath string) (string, bool, error) {
+// resolveFallbackStateReadPath migrates existing state into the selected
+// default target path. It never deletes or reads from old paths after a
+// successful migration.
+func resolveFallbackStateReadPath(wf *config.Workflow, preferredPath string) (string, bool, error) {
 	if wf == nil || strings.TrimSpace(wf.StateKey) == "" {
 		return strings.TrimSpace(preferredPath), false, nil
 	}
-	legacyPath, err := LegacyStatePath(wf)
-	if err != nil {
-		return "", false, err
-	}
-	if legacyPath == strings.TrimSpace(preferredPath) {
-		return strings.TrimSpace(preferredPath), false, nil
-	}
-	if _, err := os.Stat(legacyPath); err == nil {
-		return legacyPath, true, nil
-	} else if err != nil && !os.IsNotExist(err) {
-		return "", false, fmt.Errorf("stat legacy state file: %w", err)
+	for _, resolver := range []func(*config.Workflow) (string, error){XDGStatePath, LegacyStatePath} {
+		fallbackPath, err := resolver(wf)
+		if err != nil {
+			return "", false, err
+		}
+		if fallbackPath == strings.TrimSpace(preferredPath) {
+			continue
+		}
+		if _, err := os.Stat(fallbackPath); err == nil {
+			if err := migrateStateFile(fallbackPath, strings.TrimSpace(preferredPath)); err != nil {
+				return "", false, err
+			}
+			return fallbackPath, true, nil
+		} else if err != nil && !os.IsNotExist(err) {
+			return "", false, fmt.Errorf("stat fallback state file: %w", err)
+		}
 	}
 	return strings.TrimSpace(preferredPath), false, nil
+}
+
+func migrateStateFile(sourcePath string, targetPath string) error {
+	source := strings.TrimSpace(sourcePath)
+	target := strings.TrimSpace(targetPath)
+	if source == "" || target == "" || source == target {
+		return nil
+	}
+	if _, err := os.Stat(target); err == nil {
+		return nil
+	} else if err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("stat target state file: %w", err)
+	}
+	raw, err := fsutil.ReadFile(source)
+	if err != nil {
+		return fmt.Errorf("read fallback state file %s: %w", source, err)
+	}
+	if err := SaveRawStateFile(target, raw); err != nil {
+		return fmt.Errorf("migrate state file from %s to %s: %w", source, target, err)
+	}
+	return nil
 }

--- a/internal/install/state_compat_test.go
+++ b/internal/install/state_compat_test.go
@@ -1,17 +1,22 @@
 package install
 
 import (
+	"encoding/json"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/Airgap-Castaways/deck/internal/config"
 )
 
-func TestResolveStateReadPathUsesLegacyHomeStateFile(t *testing.T) {
+func TestResolveStateReadPathMigratesLegacyHomeStateFile(t *testing.T) {
 	home := t.TempDir()
+	workspace := t.TempDir()
 	t.Setenv("HOME", home)
 	t.Setenv("XDG_STATE_HOME", filepath.Join(home, ".local", "state"))
+	t.Chdir(workspace)
 
 	wf := &config.Workflow{StateKey: "legacy-state-key"}
 	preferred, err := DefaultStatePath(wf)
@@ -33,7 +38,226 @@ func TestResolveStateReadPathUsesLegacyHomeStateFile(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ResolveStateReadPathForWorkflow failed: %v", err)
 	}
-	if resolved != legacyPath {
-		t.Fatalf("expected legacy state path, got %q want %q", resolved, legacyPath)
+	if resolved != preferred {
+		t.Fatalf("expected migrated state path, got %q want %q", resolved, preferred)
+	}
+	if _, err := os.Stat(preferred); err != nil {
+		t.Fatalf("migrated state missing: %v", err)
+	}
+	if _, err := os.Stat(legacyPath); err != nil {
+		t.Fatalf("legacy state should not be deleted: %v", err)
+	}
+}
+
+func TestResolveStateReadPathMigratesOldXDGBeforeLegacy(t *testing.T) {
+	home := t.TempDir()
+	workspace := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_STATE_HOME", filepath.Join(home, ".local", "state"))
+	t.Chdir(workspace)
+
+	wf := &config.Workflow{StateKey: "xdg-state-key"}
+	preferred, err := DefaultStatePath(wf)
+	if err != nil {
+		t.Fatalf("DefaultStatePath failed: %v", err)
+	}
+	xdgPath, err := XDGStatePath(wf)
+	if err != nil {
+		t.Fatalf("XDGStatePath failed: %v", err)
+	}
+	legacyPath, err := LegacyStatePath(wf)
+	if err != nil {
+		t.Fatalf("LegacyStatePath failed: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(xdgPath), 0o755); err != nil {
+		t.Fatalf("mkdir XDG state dir: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(legacyPath), 0o755); err != nil {
+		t.Fatalf("mkdir legacy state dir: %v", err)
+	}
+	if err := os.WriteFile(xdgPath, []byte("{\"phase\":\"xdg\"}"), 0o600); err != nil {
+		t.Fatalf("write XDG state: %v", err)
+	}
+	if err := os.WriteFile(legacyPath, []byte("{\"phase\":\"legacy\"}"), 0o600); err != nil {
+		t.Fatalf("write legacy state: %v", err)
+	}
+
+	resolved, err := ResolveStateReadPathForWorkflow(wf, preferred)
+	if err != nil {
+		t.Fatalf("ResolveStateReadPathForWorkflow failed: %v", err)
+	}
+	if resolved != preferred {
+		t.Fatalf("expected migrated state path, got %q want %q", resolved, preferred)
+	}
+	raw, err := os.ReadFile(preferred)
+	if err != nil {
+		t.Fatalf("read migrated state: %v", err)
+	}
+	if string(raw) != "{\"phase\":\"xdg\"}" {
+		t.Fatalf("expected XDG state to win, got %q", string(raw))
+	}
+}
+
+func TestResolveStateReadPathNoFallbackUsesPreferredPath(t *testing.T) {
+	home := t.TempDir()
+	workspace := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_STATE_HOME", filepath.Join(home, ".local", "state"))
+	t.Chdir(workspace)
+
+	wf := &config.Workflow{StateKey: "explicit-state-key"}
+	preferred := filepath.Join(workspace, "explicit", wf.StateKey+".json")
+	xdgPath, err := XDGStatePath(wf)
+	if err != nil {
+		t.Fatalf("XDGStatePath failed: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(xdgPath), 0o755); err != nil {
+		t.Fatalf("mkdir XDG state dir: %v", err)
+	}
+	if err := os.WriteFile(xdgPath, []byte("{\"phase\":\"xdg\"}"), 0o600); err != nil {
+		t.Fatalf("write XDG state: %v", err)
+	}
+
+	resolved, err := ResolveStateReadPathForWorkflowNoFallback(wf, preferred)
+	if err != nil {
+		t.Fatalf("ResolveStateReadPathForWorkflowNoFallback failed: %v", err)
+	}
+	if resolved != preferred {
+		t.Fatalf("expected preferred state path, got %q want %q", resolved, preferred)
+	}
+	if _, err := os.Stat(preferred); !os.IsNotExist(err) {
+		t.Fatalf("preferred state should not be migrated, err=%v", err)
+	}
+}
+
+func TestResolveStateReadPathMigratesOldXDGToRemoteApplyState(t *testing.T) {
+	home := t.TempDir()
+	stateHome := filepath.Join(home, ".local", "state")
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_STATE_HOME", stateHome)
+
+	wf := &config.Workflow{StateKey: "remote-state-key"}
+	preferred, err := XDGApplyStatePath(wf)
+	if err != nil {
+		t.Fatalf("XDGApplyStatePath failed: %v", err)
+	}
+	xdgPath, err := XDGStatePath(wf)
+	if err != nil {
+		t.Fatalf("XDGStatePath failed: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(xdgPath), 0o755); err != nil {
+		t.Fatalf("mkdir XDG state dir: %v", err)
+	}
+	if err := os.WriteFile(xdgPath, []byte("{\"phase\":\"completed\"}"), 0o600); err != nil {
+		t.Fatalf("write XDG state: %v", err)
+	}
+
+	var migratedSource, migratedTarget string
+	resolved, err := ResolveStateReadPathForWorkflowWithMigrationSink(wf, preferred, func(source string, target string) {
+		migratedSource = source
+		migratedTarget = target
+	})
+	if err != nil {
+		t.Fatalf("ResolveStateReadPathForWorkflowWithMigrationSink failed: %v", err)
+	}
+	if resolved != preferred {
+		t.Fatalf("expected migrated state path, got %q want %q", resolved, preferred)
+	}
+	if migratedSource != xdgPath || migratedTarget != preferred {
+		t.Fatalf("unexpected migration event: source=%q target=%q", migratedSource, migratedTarget)
+	}
+	if _, err := os.Stat(preferred); err != nil {
+		t.Fatalf("migrated remote state missing: %v", err)
+	}
+}
+
+func TestXDGApplyStatePathFallsBackToHomeWhenXDGStateHomeUnset(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_STATE_HOME", "")
+
+	wf := &config.Workflow{StateKey: "home-fallback-key"}
+	statePath, err := XDGApplyStatePath(wf)
+	if err != nil {
+		t.Fatalf("XDGApplyStatePath failed: %v", err)
+	}
+	expected := filepath.Join(home, ".local", "state", "deck", "state", "apply", wf.StateKey+".json")
+	if statePath != expected {
+		t.Fatalf("state path mismatch: got %q want %q", statePath, expected)
+	}
+}
+
+func TestResolveStateReadPathMigrationFailureFails(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_STATE_HOME", filepath.Join(home, ".local", "state"))
+
+	wf := &config.Workflow{StateKey: "migration-failure-key"}
+	xdgPath, err := XDGStatePath(wf)
+	if err != nil {
+		t.Fatalf("XDGStatePath failed: %v", err)
+	}
+	if err := os.MkdirAll(xdgPath, 0o755); err != nil {
+		t.Fatalf("mkdir invalid XDG state file path: %v", err)
+	}
+	preferred := filepath.Join(t.TempDir(), "target", wf.StateKey+".json")
+
+	_, err = ResolveStateReadPathForWorkflow(wf, preferred)
+	if err == nil {
+		t.Fatalf("expected migration failure")
+	}
+	if !strings.Contains(err.Error(), "read fallback state file") {
+		t.Fatalf("expected migration error, got %v", err)
+	}
+}
+
+func TestSaveStateWritesV2MetadataAndLoadStateReadsIt(t *testing.T) {
+	statePath := filepath.Join(t.TempDir(), "state-key.json")
+	now := time.Date(2026, 6, 2, 1, 2, 3, 0, time.UTC)
+	state := &State{
+		Phase:           "completed",
+		CompletedPhases: []string{"install"},
+		RuntimeVars:     map[string]any{"public": "value"},
+		RuntimeSecrets:  map[string]RuntimeSecret{"token": {Phase: "install", StepID: "secret", Output: "value"}},
+	}
+	metadata := StateMetadata{
+		StateKey: "state-key",
+		Workflow: StateWorkflow{Path: "workflows/scenarios/apply.yaml", Source: "filesystem", SHA256: "abc123"},
+		Now:      func() time.Time { return now },
+	}
+
+	if err := SaveStateWithMetadata(statePath, state, metadata); err != nil {
+		t.Fatalf("SaveStateWithMetadata failed: %v", err)
+	}
+	raw, err := os.ReadFile(statePath)
+	if err != nil {
+		t.Fatalf("read state: %v", err)
+	}
+	var file stateFileV2
+	if err := json.Unmarshal(raw, &file); err != nil {
+		t.Fatalf("parse state: %v", err)
+	}
+	if file.Version != 2 || file.Kind != "deck.applyState" || file.StateKey != "state-key" {
+		t.Fatalf("unexpected v2 identity: %+v", file)
+	}
+	if file.Workflow.Path != metadata.Workflow.Path || file.Workflow.Source != metadata.Workflow.Source || file.Workflow.SHA256 != metadata.Workflow.SHA256 {
+		t.Fatalf("unexpected workflow metadata: %+v", file.Workflow)
+	}
+	if file.Status != "succeeded" || file.CurrentPhase != "completed" || file.UpdatedAt != "2026-06-02T01:02:03Z" {
+		t.Fatalf("unexpected status metadata: %+v", file)
+	}
+	if len(file.Phases) != 1 || file.Phases[0].Name != "install" || file.Phases[0].Status != "succeeded" {
+		t.Fatalf("unexpected phase metadata: %+v", file.Phases)
+	}
+
+	loaded, err := LoadState(statePath)
+	if err != nil {
+		t.Fatalf("LoadState failed: %v", err)
+	}
+	if loaded.Version != 2 || loaded.StateKey != "state-key" || loaded.Status != "succeeded" {
+		t.Fatalf("unexpected loaded metadata: %+v", loaded)
+	}
+	if len(loaded.CompletedPhases) != 1 || loaded.CompletedPhases[0] != "install" {
+		t.Fatalf("unexpected loaded phases: %+v", loaded.CompletedPhases)
 	}
 }

--- a/internal/planvars/report.go
+++ b/internal/planvars/report.go
@@ -210,7 +210,7 @@ func applyContextStateKey(request *applycli.ExecutionRequest, execContext workfl
 	if request.ExecutionWorkflow != nil {
 		request.ExecutionWorkflow.StateKey = stateKey
 	}
-	statePath, err := applycli.ResolveInstallStatePath(request.Workflow)
+	statePath, err := applycli.ResolveInstallStatePathForWorkflowPath(request.Workflow, request.WorkflowPath, request.StateDir)
 	if err != nil {
 		return err
 	}

--- a/internal/workspacepaths/paths.go
+++ b/internal/workspacepaths/paths.go
@@ -27,6 +27,9 @@ const (
 	PreparedPackagesRoot        = "packages"
 	PreparedImagesRoot          = "images"
 	PreparedBinRoot             = "bin"
+	DeckDirRel                  = ".deck"
+	WorkspaceStateDirRel        = "state"
+	ApplyStateDirRel            = "apply"
 )
 
 var canonicalPreparedRoots = []string{
@@ -80,6 +83,14 @@ func CanonicalVarsPath(root string) string {
 
 func DefaultPreparedRoot(root string) string {
 	return filepath.Join(root, PreparedDirRel)
+}
+
+func ApplyStateDir(root string) string {
+	return filepath.Join(root, DeckDirRel, WorkspaceStateDirRel, ApplyStateDirRel)
+}
+
+func ApplyStateFile(root string, name string) string {
+	return filepath.Join(ApplyStateDir(root), name)
 }
 
 func CanonicalPreparedRoots() []string {


### PR DESCRIPTION
## Summary
- Store local workflow apply state under workspace `.deck/state/apply/` and remote workflow state under the XDG apply state directory.
- Add `--state-dir` support, default-path migration from old XDG/legacy state, and v2 apply state files with v1 compatibility.
- Add `deck state show/list/clear` plus documentation and tests for state paths, migration, and state management.

## Tests
- `make test`
- `make lint`