### PR TITLE
Fix release GoReleaser version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,17 +30,11 @@ jobs:
           make test
           make lint
 
-      - name: Setup GoReleaser
-        uses: goreleaser/goreleaser-action@v7
-        with:
-          version: "~> v2"
-          install-only: true
-
       - name: Validate GoReleaser config
         run: make release-check
 
       - name: Build snapshot artifacts
-        run: goreleaser release --snapshot --clean
+        run: make release-snapshot
 
       - name: Smoke test tarballs
         run: |
@@ -97,12 +91,6 @@ jobs:
           make test
           make lint
 
-      - name: Setup GoReleaser
-        uses: goreleaser/goreleaser-action@v7
-        with:
-          version: "~> v2"
-          install-only: true
-
       - name: Validate GoReleaser config
         run: make release-check
 
@@ -110,4 +98,4 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           HOMEBREW_TAP_GITHUB_TOKEN: ${{ secrets.HOMEBREW_TAP_GITHUB_TOKEN }}
-        run: goreleaser release --clean
+        run: make release-publish

--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,7 @@ GOVULNCHECK_GOTOOLCHAIN ?= go1.26.4
 GORELEASER ?= $(BIN_DIR)/goreleaser
 GORELEASER_PKG ?= github.com/goreleaser/goreleaser/v2
 GORELEASER_VERSION ?= v2.14.3
+GORELEASER_VERSION_NUMBER := $(patsubst v%,%,$(GORELEASER_VERSION))
 BUILDINFO_PKG ?= github.com/Airgap-Castaways/deck/internal/buildinfo
 VERSION ?= dev
 COMMIT ?= $(shell git rev-parse --short HEAD 2>/dev/null || printf unknown)
@@ -68,7 +69,7 @@ print-build-meta:
 
 ensure-goreleaser:
 	@mkdir -p "$(BIN_DIR)"
-	@if [ ! -x "$(GORELEASER)" ] || ! "$(GORELEASER)" --version 2>/dev/null | grep -q "GitVersion:[[:space:]]*$(GORELEASER_VERSION)"; then \
+	@if [ ! -x "$(GORELEASER)" ] || ! "$(GORELEASER)" --version 2>/dev/null | grep -q -E "(GitVersion|version):[[:space:]]*v?$(GORELEASER_VERSION_NUMBER)"; then \
 		GOBIN="$(abspath $(BIN_DIR))" $(GO) install $(GORELEASER_PKG)@$(GORELEASER_VERSION); \
 	fi
 

--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,9 @@ GOVULNCHECK ?= $(BIN_DIR)/govulncheck
 GOVULNCHECK_PKG ?= golang.org/x/vuln/cmd/govulncheck
 GOVULNCHECK_VERSION ?= v1.1.4
 GOVULNCHECK_GOTOOLCHAIN ?= go1.26.4
+GORELEASER ?= $(BIN_DIR)/goreleaser
+GORELEASER_PKG ?= github.com/goreleaser/goreleaser/v2
+GORELEASER_VERSION ?= v2.14.3
 BUILDINFO_PKG ?= github.com/Airgap-Castaways/deck/internal/buildinfo
 VERSION ?= dev
 COMMIT ?= $(shell git rev-parse --short HEAD 2>/dev/null || printf unknown)
@@ -15,7 +18,7 @@ DATE ?= $(shell date -u +%Y-%m-%dT%H:%M:%SZ)
 DIRTY ?= $(shell if [ -n "$$(git status --short 2>/dev/null)" ]; then printf true; else printf false; fi)
 LDFLAGS ?= -X $(BUILDINFO_PKG).Version=$(VERSION) -X $(BUILDINFO_PKG).Commit=$(COMMIT) -X $(BUILDINFO_PKG).Date=$(DATE) -X $(BUILDINFO_PKG).Dirty=$(DIRTY)
 
-.PHONY: build test lint vuln generate verify-generated print-build-meta release-check release-snapshot
+.PHONY: build test lint vuln generate verify-generated print-build-meta ensure-goreleaser release-check release-snapshot release-publish
 
 GENERATED_PATHS := \
 	docs/contributing/tool-definition-schema.md \
@@ -63,8 +66,17 @@ vuln: $(GOVULNCHECK)
 print-build-meta:
 	@printf 'VERSION=%s\nCOMMIT=%s\nDATE=%s\nDIRTY=%s\n' "$(VERSION)" "$(COMMIT)" "$(DATE)" "$(DIRTY)"
 
-release-check:
-	goreleaser check
+ensure-goreleaser:
+	@mkdir -p "$(BIN_DIR)"
+	@if [ ! -x "$(GORELEASER)" ] || ! "$(GORELEASER)" --version 2>/dev/null | grep -q "GitVersion:[[:space:]]*$(GORELEASER_VERSION)"; then \
+		GOBIN="$(abspath $(BIN_DIR))" $(GO) install $(GORELEASER_PKG)@$(GORELEASER_VERSION); \
+	fi
 
-release-snapshot:
-	goreleaser release --snapshot --clean
+release-check: ensure-goreleaser
+	$(GORELEASER) check
+
+release-snapshot: ensure-goreleaser
+	$(GORELEASER) release --snapshot --clean
+
+release-publish: ensure-goreleaser
+	$(GORELEASER) release --clean


### PR DESCRIPTION
## Summary
- Pins the release GoReleaser tool through Makefile-managed installation so CI and local release commands use the same version.
- Updates the release workflow to use `make release-check`, `make release-snapshot`, and `make release-publish` instead of installing the latest GoReleaser v2 action binary.
- Avoids GoReleaser v2.16 treating the current Homebrew formula `brews` deprecation as a release-blocking config error.

## Tests
- `make release-check`
- `make test`
- `make lint`
- `make release-snapshot`
- `git diff --check`

## Release recovery
- Deleted failed `v0.2.9` local and remote tag after the tag-triggered workflow failed before publishing artifacts.
- After this PR merges, recreate `v0.2.9` from latest `main` to rerun the release workflow.