### PR TITLE
Clear apply state for fresh runs

### DIFF
--- a/cmd/deck/apply_cli_test.go
+++ b/cmd/deck/apply_cli_test.go
@@ -802,15 +802,44 @@ func TestPlanJSONAndVerboseDiagnostics(t *testing.T) {
 	}
 }
 
-func TestApplyAndPlanFresh(t *testing.T) {
+func TestPlanFreshFlagRemoved(t *testing.T) {
+	for _, args := range [][]string{
+		{"plan", "--fresh"},
+		{"plan", "vars", "--fresh"},
+	} {
+		res := execute(args)
+		if res.err == nil {
+			t.Fatalf("expected %v to fail", args)
+		}
+		if !strings.Contains(res.stderr, "unknown flag: --fresh") {
+			t.Fatalf("expected unknown fresh flag for %v, got %q", args, res.stderr)
+		}
+	}
+}
+
+func TestApplyFreshRejectsDryRun(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
+	wfPath := filepath.Join(t.TempDir(), "apply-fresh-dry-run.yaml")
+	writeWorkflowYAML(t, wfPath, "version: v1alpha1\nphases:\n  - name: install\n    steps:\n      - id: once\n        kind: Command\n        spec:\n          command: [\"true\"]\n")
+
+	res := execute([]string{"apply", "--workflow", wfPath, "--dry-run", "--fresh"})
+	if res.err == nil {
+		t.Fatalf("expected apply --dry-run --fresh to fail")
+	}
+	if !strings.Contains(res.stderr, "apply --fresh cannot be combined with --dry-run because --fresh clears apply state") {
+		t.Fatalf("expected dry-run fresh rejection, got %q", res.stderr)
+	}
+}
+
+func TestApplyFreshClearsState(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_STATE_HOME", filepath.Join(home, ".local", "state"))
 	wfPath := filepath.Join(t.TempDir(), "apply-fresh.yaml")
 	logPath := filepath.Join(t.TempDir(), "fresh.log")
 	writeWorkflowYAML(t, wfPath, fmt.Sprintf("version: v1alpha1\nphases:\n  - name: install\n    steps:\n      - id: once\n        kind: Command\n        spec:\n          command: [\"sh\", \"-c\", \"echo run >> %s\"]\n", strings.ReplaceAll(logPath, "\\", "\\\\")))
 
-	if _, err := runWithCapturedStdout([]string{"apply", "--workflow", wfPath}); err != nil {
-		t.Fatalf("initial apply failed: %v", err)
-	}
+	statePath := statePathFromVerboseApply(t, []string{"apply", "--workflow", wfPath})
 	planOut, err := runWithCapturedStdout([]string{"plan", "--workflow", wfPath})
 	if err != nil {
 		t.Fatalf("plan failed: %v", err)
@@ -818,19 +847,86 @@ func TestApplyAndPlanFresh(t *testing.T) {
 	if !strings.Contains(planOut, "SKIP (completed)") {
 		t.Fatalf("expected completed phase skip in plan output, got %q", planOut)
 	}
-	freshPlan, err := runWithCapturedStdout([]string{"plan", "--workflow", wfPath, "--fresh"})
-	if err != nil {
-		t.Fatalf("fresh plan failed: %v", err)
+	stateKey := strings.TrimSuffix(filepath.Base(statePath), filepath.Ext(statePath))
+	fallbackStatePath := filepath.Join(home, ".local", "state", "deck", "state", stateKey+".json")
+	if err := os.MkdirAll(filepath.Dir(fallbackStatePath), 0o755); err != nil {
+		t.Fatalf("mkdir fallback state dir: %v", err)
 	}
-	if !strings.Contains(freshPlan, "once Command RUN") {
-		t.Fatalf("expected fresh plan to rerun step, got %q", freshPlan)
+	if err := os.WriteFile(fallbackStatePath, []byte("{\"phase\":\"completed\",\"completedPhases\":[\"install\"]}"), 0o600); err != nil {
+		t.Fatalf("write fallback state: %v", err)
+	}
+	legacyStatePath := filepath.Join(home, ".deck", "state", stateKey+".json")
+	if err := os.MkdirAll(filepath.Dir(legacyStatePath), 0o755); err != nil {
+		t.Fatalf("mkdir legacy state dir: %v", err)
+	}
+	if err := os.WriteFile(legacyStatePath, []byte("{\"phase\":\"completed\",\"completedPhases\":[\"install\"]}"), 0o600); err != nil {
+		t.Fatalf("write legacy state: %v", err)
 	}
 	if _, err := runWithCapturedStdout([]string{"apply", "--workflow", wfPath, "--fresh"}); err != nil {
 		t.Fatalf("fresh apply failed: %v", err)
 	}
+	if _, err := os.Stat(fallbackStatePath); !os.IsNotExist(err) {
+		t.Fatalf("expected fallback state to be cleared, stat err: %v", err)
+	}
+	if _, err := os.Stat(legacyStatePath); !os.IsNotExist(err) {
+		t.Fatalf("expected legacy state to be cleared, stat err: %v", err)
+	}
 	raw, err := os.ReadFile(logPath)
 	if err != nil {
 		t.Fatalf("read fresh log: %v", err)
+	}
+	if got := strings.Count(strings.TrimSpace(string(raw)), "run"); got != 2 {
+		t.Fatalf("expected 2 executions after fresh apply, got %d (%q)", got, string(raw))
+	}
+}
+
+func TestApplyFreshWithStateDirClearsOnlySelectedState(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_STATE_HOME", filepath.Join(home, ".local", "state"))
+	stateDir := t.TempDir()
+	wfPath := filepath.Join(t.TempDir(), "apply-fresh-state-dir.yaml")
+	logPath := filepath.Join(t.TempDir(), "fresh-state-dir.log")
+	writeWorkflowYAML(t, wfPath, fmt.Sprintf("version: v1alpha1\nphases:\n  - name: install\n    steps:\n      - id: once\n        kind: Command\n        spec:\n          command: [\"sh\", \"-c\", \"echo run >> %s\"]\n", strings.ReplaceAll(logPath, "\\", "\\\\")))
+
+	statePath := statePathFromVerboseApply(t, []string{"apply", "--workflow", wfPath, "--state-dir", stateDir})
+	stateKey := strings.TrimSuffix(filepath.Base(statePath), filepath.Ext(statePath))
+	fallbackStatePath := filepath.Join(home, ".local", "state", "deck", "state", stateKey+".json")
+	if err := os.MkdirAll(filepath.Dir(fallbackStatePath), 0o755); err != nil {
+		t.Fatalf("mkdir fallback state dir: %v", err)
+	}
+	if err := os.WriteFile(fallbackStatePath, []byte("{}"), 0o600); err != nil {
+		t.Fatalf("write fallback state: %v", err)
+	}
+	legacyStatePath := filepath.Join(home, ".deck", "state", stateKey+".json")
+	if err := os.MkdirAll(filepath.Dir(legacyStatePath), 0o755); err != nil {
+		t.Fatalf("mkdir legacy state dir: %v", err)
+	}
+	if err := os.WriteFile(legacyStatePath, []byte("{}"), 0o600); err != nil {
+		t.Fatalf("write legacy state: %v", err)
+	}
+	unrelatedPath := filepath.Join(stateDir, "unrelated.json")
+	if err := os.WriteFile(unrelatedPath, []byte("{}"), 0o600); err != nil {
+		t.Fatalf("write unrelated state: %v", err)
+	}
+	if _, err := runWithCapturedStdout([]string{"apply", "--workflow", wfPath, "--state-dir", stateDir, "--fresh"}); err != nil {
+		t.Fatalf("fresh apply failed: %v", err)
+	}
+	if _, err := os.Stat(statePath); err != nil {
+		t.Fatalf("expected selected state to be rewritten: %v", err)
+	}
+	if _, err := os.Stat(unrelatedPath); err != nil {
+		t.Fatalf("expected unrelated state to remain: %v", err)
+	}
+	if _, err := os.Stat(fallbackStatePath); err != nil {
+		t.Fatalf("expected fallback state to remain with explicit state dir: %v", err)
+	}
+	if _, err := os.Stat(legacyStatePath); err != nil {
+		t.Fatalf("expected legacy state to remain with explicit state dir: %v", err)
+	}
+	raw, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("read log: %v", err)
 	}
 	if got := strings.Count(strings.TrimSpace(string(raw)), "run"); got != 2 {
 		t.Fatalf("expected 2 executions after fresh apply, got %d (%q)", got, string(raw))

--- a/cmd/deck/cmd_apply.go
+++ b/cmd/deck/cmd_apply.go
@@ -17,7 +17,6 @@ type diffOptions struct {
 	workflowPath  string
 	scenario      string
 	source        string
-	fresh         bool
 	stateDir      string
 	selectedPhase string
 	output        string
@@ -32,7 +31,6 @@ type planVarsOptions struct {
 	source        string
 	selectedPhase string
 	preparedRoot  string
-	fresh         bool
 	output        string
 	varOverrides  map[string]string
 	varsFiles     []string
@@ -63,10 +61,6 @@ func newPlanCommand(env *cliEnv) *cobra.Command {
 			if err != nil {
 				return err
 			}
-			fresh, err := cmdFlagBoolValue(cmd, "fresh")
-			if err != nil {
-				return err
-			}
 			output, err := cmdFlagValue(cmd, "output")
 			if err != nil {
 				return err
@@ -75,7 +69,6 @@ func newPlanCommand(env *cliEnv) *cobra.Command {
 				workflowPath:  workflowPath,
 				scenario:      scenario,
 				source:        source,
-				fresh:         fresh,
 				stateDir:      stateDir,
 				selectedPhase: selectedPhase,
 				output:        output,
@@ -89,7 +82,6 @@ func newPlanCommand(env *cliEnv) *cobra.Command {
 	cmd.Flags().String("scenario", "", "scenario name to plan")
 	cmd.Flags().String("source", scenarioSourceLocal, "scenario source (local|server)")
 	cmd.Flags().String("phase", "", "phase name to plan (defaults to all phases)")
-	cmd.Flags().Bool("fresh", false, "ignore saved apply state for this invocation")
 	cmd.Flags().StringVar(&stateDir, "state-dir", "", "directory for apply state files (overrides local .deck/state/apply or remote XDG state)")
 	cmd.Flags().StringP("output", "o", "text", "output format (text|json)")
 	cmd.Flags().VarP(varsFiles, "vars-file", "f", "vars file overlay relative to workflows/ (repeatable)")
@@ -132,10 +124,6 @@ func newPlanVarsCommand(env *cliEnv) *cobra.Command {
 			if err != nil {
 				return err
 			}
-			fresh, err := cmdFlagBoolValue(cmd, "fresh")
-			if err != nil {
-				return err
-			}
 			output, err := cmdFlagValue(cmd, "output")
 			if err != nil {
 				return err
@@ -147,7 +135,6 @@ func newPlanVarsCommand(env *cliEnv) *cobra.Command {
 				source:        source,
 				selectedPhase: selectedPhase,
 				preparedRoot:  preparedRoot,
-				fresh:         fresh,
 				output:        output,
 				varOverrides:  vars.AsMap(),
 				varsFiles:     varsFiles.Values(),
@@ -160,7 +147,6 @@ func newPlanVarsCommand(env *cliEnv) *cobra.Command {
 	cmd.Flags().String("source", scenarioSourceLocal, "scenario source for apply (local|server)")
 	cmd.Flags().String("phase", "", "phase name to inspect (defaults to all phases)")
 	cmd.Flags().String("root", workspacepaths.DefaultPreparedRoot("."), "prepared bundle output directory for --command prepare")
-	cmd.Flags().Bool("fresh", false, "ignore saved apply state for this invocation")
 	cmd.Flags().StringP("output", "o", "text", "output format (text|json)")
 	cmd.Flags().VarP(varsFiles, "vars-file", "f", "vars file overlay relative to workflows/ (repeatable)")
 	cmd.Flags().Var(vars, "var", "set variable override (key=value), repeatable")
@@ -191,7 +177,6 @@ func runPlanVarsWithOptions(env *cliEnv, ctx context.Context, opts planVarsOptio
 		Scenario:        strings.TrimSpace(opts.scenario),
 		SelectedPhase:   strings.TrimSpace(opts.selectedPhase),
 		PreparedRoot:    strings.TrimSpace(opts.preparedRoot),
-		Fresh:           opts.fresh,
 		VarOverrides:    varsAsAnyMap(opts.varOverrides),
 		VarsFiles:       append([]string(nil), opts.varsFiles...),
 		Output:          resolvedOutput,
@@ -209,17 +194,16 @@ func runDiffWithOptions(env *cliEnv, ctx context.Context, opts diffOptions) erro
 		return err
 	}
 	selectedPhase := strings.TrimSpace(opts.selectedPhase)
-	return executeDiff(env, ctx, workflowPath, strings.TrimSpace(opts.scenario), selectedPhase, opts.output, opts.fresh, opts.stateDir, opts.varsFiles, varsAsAnyMap(opts.varOverrides))
+	return executeDiff(env, ctx, workflowPath, strings.TrimSpace(opts.scenario), selectedPhase, opts.output, opts.stateDir, opts.varsFiles, varsAsAnyMap(opts.varOverrides))
 }
 
-func executeDiff(env *cliEnv, ctx context.Context, workflowPath, scenario, selectedPhase, output string, fresh bool, stateDir string, varsFiles []string, varOverrides map[string]any) error {
+func executeDiff(env *cliEnv, ctx context.Context, workflowPath, scenario, selectedPhase, output string, stateDir string, varsFiles []string, varOverrides map[string]any) error {
 	stateDir = strings.TrimSpace(stateDir)
 	return applycli.RunPlanCommand(ctx, applycli.PlanCommandOptions{
 		WorkflowPath:     workflowPath,
 		Scenario:         scenario,
 		SelectedPhase:    selectedPhase,
 		Output:           output,
-		Fresh:            fresh,
 		StateDir:         stateDir,
 		StateDirExplicit: stateDir != "",
 		VarOverrides:     varOverrides,
@@ -307,7 +291,7 @@ func newApplyCommand(env *cliEnv) *cobra.Command {
 	cmd.Flags().String("scenario", "", "scenario name to execute")
 	cmd.Flags().String("source", scenarioSourceLocal, "scenario source (local|server)")
 	cmd.Flags().String("phase", "", "phase name to execute (defaults to all phases)")
-	cmd.Flags().Bool("fresh", false, "ignore saved apply state for this invocation")
+	cmd.Flags().Bool("fresh", false, "clear saved apply state before execution")
 	cmd.Flags().StringVar(&stateDir, "state-dir", "", "directory for apply state files (overrides local .deck/state/apply or remote XDG state)")
 	cmd.Flags().Bool("dry-run", false, "print apply plan without executing steps")
 	cmd.Flags().Bool("non-interactive", false, "fail or use defaults for operator interaction steps instead of prompting")

--- a/docs/apply-state.md
+++ b/docs/apply-state.md
@@ -112,12 +112,13 @@ Use [Workflow Model](workflow-model.md#parallel-batches) for the current batchin
 
 ## `--fresh`
 
-Use `--fresh` to ignore saved apply state for that invocation.
+Use `deck apply --fresh` to clear the selected saved apply state before execution.
 
-- `deck apply --fresh` reruns all phases and writes fresh state back to the normal path
-- `deck plan --fresh` shows a fresh-run view with no completed-phase skips or saved runtime vars
+- `deck apply --fresh` reruns all phases and writes fresh state back to the normal path.
+- Only the selected state key is cleared. Other state files in the same directory are preserved.
+- `deck apply --dry-run --fresh` is rejected because `--fresh` clears state.
 
-`--fresh` does not delete the state file before execution.
+`deck plan` is read-only and does not support `--fresh`. Use `deck state clear` for explicit state management without running apply.
 
 ## State management
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -356,7 +356,7 @@ Optional transport override example:
 - `prepare` expects a workflow tree rooted at `workflows/` with entrypoints under `workflows/scenarios/`.
 - scenario entrypoints live under `workflows/scenarios/`
 - `plan` and `apply` accept `--scenario` for named scenarios and `--workflow` for an explicit path or URL.
-- `plan` and `apply` support `--fresh` to ignore saved apply state for that invocation.
+- `apply` supports `--fresh` to clear the selected saved apply state before execution.
 - `plan`, `apply`, and `state` support `--state-dir` to use an explicit apply state directory.
 - `deck state show/list/clear` inspects and removes saved apply state.
 - `--source` controls whether `--scenario` resolves from the local workspace or the saved remote server.

--- a/internal/applycli/command.go
+++ b/internal/applycli/command.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"os"
 	"path/filepath"
 	"strings"
 
@@ -18,7 +19,6 @@ type PlanCommandOptions struct {
 	Scenario         string
 	SelectedPhase    string
 	Output           string
-	Fresh            bool
 	StateDir         string
 	StateDirExplicit bool
 	VarOverrides     map[string]any
@@ -118,7 +118,6 @@ func RunPlanCommand(ctx context.Context, opts PlanCommandOptions) error {
 		NodeScopedVars:               true,
 		Hostname:                     opts.Hostname,
 		DetectHostname:               opts.DetectHostname,
-		Fresh:                        opts.Fresh,
 		StateDir:                     strings.TrimSpace(opts.StateDir),
 		StateDirExplicit:             opts.StateDirExplicit,
 		SelectedPhase:                strings.TrimSpace(opts.SelectedPhase),
@@ -181,6 +180,14 @@ func RunApplyCommand(ctx context.Context, opts ApplyCommandOptions) error {
 	}
 	if err := applyContextStateKey(&resolvedRequest, execContext); err != nil {
 		return err
+	}
+	if opts.DryRun && resolvedRequest.Fresh {
+		return fmt.Errorf("apply --fresh cannot be combined with --dry-run because --fresh clears apply state")
+	}
+	if resolvedRequest.Fresh {
+		if err := clearSelectedApplyState(resolvedRequest); err != nil {
+			return err
+		}
 	}
 	execContext.Paths.StateFile = resolvedRequest.StatePath
 	return Execute(ctx, ExecuteOptions{
@@ -264,6 +271,35 @@ func applyContextStateKey(request *ExecutionRequest, execContext workflowcontext
 		return err
 	}
 	request.StatePath = statePath
+	return nil
+}
+
+func clearSelectedApplyState(request ExecutionRequest) error {
+	paths := []string{strings.TrimSpace(request.StatePath)}
+	if !request.StateDirExplicit && request.Workflow != nil {
+		if xdgPath, err := install.XDGStatePath(request.Workflow); err == nil {
+			paths = append(paths, xdgPath)
+		} else {
+			return err
+		}
+		if legacyPath, err := install.LegacyStatePath(request.Workflow); err == nil {
+			paths = append(paths, legacyPath)
+		} else {
+			return err
+		}
+	}
+
+	seen := map[string]bool{}
+	for _, path := range paths {
+		path = strings.TrimSpace(path)
+		if path == "" || seen[path] {
+			continue
+		}
+		seen[path] = true
+		if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+			return fmt.Errorf("clear apply state %s: %w", path, err)
+		}
+	}
 	return nil
 }
 

--- a/internal/applycli/command.go
+++ b/internal/applycli/command.go
@@ -279,13 +279,9 @@ func clearSelectedApplyState(request ExecutionRequest) error {
 	if !request.StateDirExplicit && request.Workflow != nil {
 		if xdgPath, err := install.XDGStatePath(request.Workflow); err == nil {
 			paths = append(paths, xdgPath)
-		} else {
-			return err
 		}
 		if legacyPath, err := install.LegacyStatePath(request.Workflow); err == nil {
 			paths = append(paths, legacyPath)
-		} else {
-			return err
 		}
 	}
 

--- a/internal/applycli/command_test.go
+++ b/internal/applycli/command_test.go
@@ -1,0 +1,30 @@
+package applycli
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/Airgap-Castaways/deck/internal/config"
+)
+
+func TestClearSelectedApplyStateIgnoresUnresolvedFallbackPaths(t *testing.T) {
+	t.Setenv("HOME", "")
+	t.Setenv("XDG_STATE_HOME", "")
+
+	statePath := filepath.Join(t.TempDir(), "selected.json")
+	if err := os.WriteFile(statePath, []byte("{}"), 0o600); err != nil {
+		t.Fatalf("write selected state: %v", err)
+	}
+
+	err := clearSelectedApplyState(ExecutionRequest{
+		Workflow:  &config.Workflow{StateKey: "selected"},
+		StatePath: statePath,
+	})
+	if err != nil {
+		t.Fatalf("clear selected state: %v", err)
+	}
+	if _, err := os.Stat(statePath); !os.IsNotExist(err) {
+		t.Fatalf("expected selected state to be cleared, stat err: %v", err)
+	}
+}

--- a/internal/planvars/report.go
+++ b/internal/planvars/report.go
@@ -27,7 +27,6 @@ type Options struct {
 	Scenario        string
 	SelectedPhase   string
 	PreparedRoot    string
-	Fresh           bool
 	VarOverrides    map[string]any
 	VarsFiles       []string
 	Output          string
@@ -99,7 +98,6 @@ func buildApplyReport(ctx context.Context, opts Options) (Report, error) {
 		VarOverrides:                 opts.VarOverrides,
 		VarsFiles:                    append([]string(nil), opts.VarsFiles...),
 		NodeScopedVars:               true,
-		Fresh:                        opts.Fresh,
 		SelectedPhase:                strings.TrimSpace(opts.SelectedPhase),
 		DefaultPhase:                 "",
 		BuildExecutionWorkflow:       true,


### PR DESCRIPTION
## Summary
- Change `deck apply --fresh` to clear the selected persisted apply state before execution.
- Remove `--fresh` from read-only plan commands and reject `apply --dry-run --fresh`.
- Document the new behavior and cover fallback/legacy state deletion and explicit `--state-dir` preservation.

## Tests
- `go test ./cmd/deck ./internal/applycli ./internal/install ./internal/planvars`
- `make test`
- `make lint`
- `make vuln`
- `git diff --check`