### PR TITLE
Add apply source locators

### DIFF
--- a/cmd/deck/apply_cli_test.go
+++ b/cmd/deck/apply_cli_test.go
@@ -216,6 +216,182 @@ phases:
 	}
 }
 
+func TestApplySourceLocatorRootScenario(t *testing.T) {
+	root := t.TempDir()
+	workflowDir := filepath.Join(root, "workflows")
+	scenarioDir := filepath.Join(workflowDir, "scenarios")
+	varsDir := filepath.Join(workflowDir, "vars")
+	if err := os.MkdirAll(scenarioDir, 0o755); err != nil {
+		t.Fatalf("mkdir scenarios: %v", err)
+	}
+	if err := os.MkdirAll(varsDir, 0o755); err != nil {
+		t.Fatalf("mkdir vars: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(workflowDir, "vars.yaml"), []byte("mode: base\n"), 0o644); err != nil {
+		t.Fatalf("write base vars: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(varsDir, "site.yaml"), []byte("mode: site\n"), 0o644); err != nil {
+		t.Fatalf("write site vars: %v", err)
+	}
+	writeWorkflowYAML(t, filepath.Join(scenarioDir, "apply.yaml"), `version: v1alpha1
+phases:
+  - name: install
+    steps:
+      - id: root-vars-match
+        kind: Command
+        when: vars.mode == "site"
+        spec:
+          command: ["true"]
+`)
+
+	planOut, err := runWithCapturedStdout([]string{"plan", "--root", root, "--scenario", "apply", "-f", "vars/site.yaml"})
+	if err != nil {
+		t.Fatalf("plan with root failed: %v", err)
+	}
+	if !strings.Contains(planOut, "root-vars-match Command RUN") {
+		t.Fatalf("expected root scenario vars overlay, got %q", planOut)
+	}
+	applyOut, err := runWithCapturedStdout([]string{"apply", "--root", root, "--scenario", "apply", "--dry-run", "-f", "vars/site.yaml"})
+	if err != nil {
+		t.Fatalf("apply dry-run with root failed: %v", err)
+	}
+	if !strings.Contains(applyOut, "root-vars-match Command PLAN") {
+		t.Fatalf("expected root scenario apply plan, got %q", applyOut)
+	}
+	stateOut, err := runWithCapturedStdout([]string{"state", "show", "--root", root, "--scenario", "apply", "-f", "vars/site.yaml"})
+	if err != nil {
+		t.Fatalf("state show with root failed: %v", err)
+	}
+	if !strings.Contains(stateOut, "status=running") || !strings.Contains(stateOut, filepath.Join(root, "workflows", "scenarios", "apply.yaml")) {
+		t.Fatalf("unexpected root state output: %q", stateOut)
+	}
+}
+
+func TestApplySourceLocatorServerScenario(t *testing.T) {
+	stateHome := filepath.Join(t.TempDir(), "state")
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("XDG_STATE_HOME", stateHome)
+	t.Setenv("DECK_SERVER_CONFIG_PATH", filepath.Join(t.TempDir(), "source.json"))
+	workflowBody := `version: v1alpha1
+phases:
+  - name: install
+    steps:
+      - id: server-vars-match
+        kind: Command
+        when: vars.mode == "site"
+        spec:
+          command: ["true"]
+`
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/workflows/scenarios/apply.yaml":
+			_, _ = w.Write([]byte(workflowBody))
+		case "/workflows/vars.yaml":
+			_, _ = w.Write([]byte("mode: base\n"))
+		case "/workflows/vars/site.yaml":
+			_, _ = w.Write([]byte("mode: site\n"))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer ts.Close()
+
+	planOut, err := runWithCapturedStdout([]string{"plan", "--server", ts.URL, "--scenario", "apply", "-f", "vars/site.yaml"})
+	if err != nil {
+		t.Fatalf("plan with server failed: %v", err)
+	}
+	if !strings.Contains(planOut, "server-vars-match Command RUN") {
+		t.Fatalf("expected server scenario vars overlay, got %q", planOut)
+	}
+	if err := saveSourceDefaults(sourceDefaults{URL: ts.URL}); err != nil {
+		t.Fatalf("save source defaults: %v", err)
+	}
+	compatPlanOut, err := runWithCapturedStdout([]string{"plan", "--source", "server", "--scenario", "apply", "-f", "vars/site.yaml"})
+	if err != nil {
+		t.Fatalf("compat plan with source server failed: %v", err)
+	}
+	if !strings.Contains(compatPlanOut, "server-vars-match Command RUN") {
+		t.Fatalf("expected source server compatibility, got %q", compatPlanOut)
+	}
+	varsRes := execute([]string{"plan", "vars", "--server", ts.URL, "--scenario", "apply", "-f", "vars/site.yaml", "-o", "json"})
+	if varsRes.err != nil {
+		t.Fatalf("plan vars with server failed: %v", varsRes.err)
+	}
+	if !strings.Contains(varsRes.stdout, `"workflowPath": "`+ts.URL+`/workflows/scenarios/apply.yaml"`) || !strings.Contains(varsRes.stdout, `"mode": "site"`) {
+		t.Fatalf("unexpected plan vars output: %q", varsRes.stdout)
+	}
+	applyOut, err := runWithCapturedStdout([]string{"apply", "--server", ts.URL, "--scenario", "apply", "--dry-run", "-f", "vars/site.yaml"})
+	if err != nil {
+		t.Fatalf("apply dry-run with server failed: %v", err)
+	}
+	if !strings.Contains(applyOut, "server-vars-match Command PLAN") {
+		t.Fatalf("expected server scenario apply plan, got %q", applyOut)
+	}
+	if _, err := runWithCapturedStdout([]string{"apply", "--server", ts.URL, "--scenario", "apply", "-f", "vars/site.yaml"}); err != nil {
+		t.Fatalf("apply with server failed: %v", err)
+	}
+	runsRoot := filepath.Join(stateHome, "deck", "runs")
+	runEntries, err := os.ReadDir(runsRoot)
+	if err != nil {
+		t.Fatalf("read runs root: %v", err)
+	}
+	if len(runEntries) != 1 {
+		t.Fatalf("expected one run directory, got %d", len(runEntries))
+	}
+	runRecordPath := filepath.Join(runsRoot, runEntries[0].Name(), "record.json")
+	rawRunRecord, err := os.ReadFile(runRecordPath)
+	if err != nil {
+		t.Fatalf("read run record: %v", err)
+	}
+	var runRecord struct {
+		WorkflowRef    string `json:"workflow_ref"`
+		WorkflowSource string `json:"workflow_source"`
+	}
+	if err := json.Unmarshal(rawRunRecord, &runRecord); err != nil {
+		t.Fatalf("decode run record: %v\n%s", err, string(rawRunRecord))
+	}
+	if runRecord.WorkflowRef != ts.URL+"/workflows/scenarios/apply.yaml" || runRecord.WorkflowSource != scenarioSourceServer {
+		t.Fatalf("expected server workflow source metadata, got %#v", runRecord)
+	}
+	stateOut, err := runWithCapturedStdout([]string{"state", "show", "--server", ts.URL, "--scenario", "apply", "-f", "vars/site.yaml"})
+	if err != nil {
+		t.Fatalf("state show with server failed: %v", err)
+	}
+	if !strings.Contains(stateOut, "status=running") || !strings.Contains(stateOut, "workflow="+ts.URL+"/workflows/scenarios/apply.yaml") {
+		t.Fatalf("unexpected server state output: %q", stateOut)
+	}
+}
+
+func TestApplySourceLocatorRejectsInvalidCombinations(t *testing.T) {
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, "workflows", "scenarios"), 0o755); err != nil {
+		t.Fatalf("mkdir scenarios: %v", err)
+	}
+	writeWorkflowYAML(t, filepath.Join(root, "workflows", "scenarios", "apply.yaml"), "version: v1alpha1\nphases: []\n")
+
+	res := execute([]string{"plan", "--root", root, "--server", "https://example.invalid", "--scenario", "apply"})
+	if res.err == nil || !strings.Contains(res.err.Error(), "--root and --server are mutually exclusive") {
+		t.Fatalf("expected root/server conflict, got err=%v stderr=%q", res.err, res.stderr)
+	}
+	res = execute([]string{"apply", "--server", "https://example.invalid"})
+	if res.err == nil || !strings.Contains(res.err.Error(), "apply with --server requires --scenario or --workflow") {
+		t.Fatalf("expected server entry error, got err=%v stderr=%q", res.err, res.stderr)
+	}
+	res = execute([]string{"apply", "--root", root, "--scenario", "apply", root})
+	if res.err == nil || !strings.Contains(res.err.Error(), "apply accepts either --root or a positional bundle path") {
+		t.Fatalf("expected root/positional conflict, got err=%v stderr=%q", res.err, res.stderr)
+	}
+	workflowPath := filepath.Join(root, "workflows", "scenarios", "apply.yaml")
+	res = execute([]string{"plan", "--workflow", workflowPath, "--scenario", "apply"})
+	if res.err == nil || !strings.Contains(res.err.Error(), "plan accepts either --workflow or --scenario") {
+		t.Fatalf("expected plan workflow/scenario conflict, got err=%v stderr=%q", res.err, res.stderr)
+	}
+	res = execute([]string{"apply", "--workflow", workflowPath, "--scenario", "apply"})
+	if res.err == nil || !strings.Contains(res.err.Error(), "apply accepts either --workflow or --scenario") {
+		t.Fatalf("expected apply workflow/scenario conflict, got err=%v stderr=%q", res.err, res.stderr)
+	}
+}
+
 func TestPlanVarsApplyShowsEffectiveInputs(t *testing.T) {
 	root := t.TempDir()
 	workflowDir := filepath.Join(root, "workflows")

--- a/cmd/deck/apply_cli_test.go
+++ b/cmd/deck/apply_cli_test.go
@@ -217,6 +217,8 @@ phases:
 }
 
 func TestApplySourceLocatorRootScenario(t *testing.T) {
+	stateHome := filepath.Join(t.TempDir(), "state")
+	t.Setenv("XDG_STATE_HOME", stateHome)
 	root := t.TempDir()
 	workflowDir := filepath.Join(root, "workflows")
 	scenarioDir := filepath.Join(workflowDir, "scenarios")
@@ -227,6 +229,7 @@ func TestApplySourceLocatorRootScenario(t *testing.T) {
 	if err := os.MkdirAll(varsDir, 0o755); err != nil {
 		t.Fatalf("mkdir vars: %v", err)
 	}
+	createValidBundleManifest(t, root)
 	if err := os.WriteFile(filepath.Join(workflowDir, "vars.yaml"), []byte("mode: base\n"), 0o644); err != nil {
 		t.Fatalf("write base vars: %v", err)
 	}
@@ -257,6 +260,31 @@ phases:
 	}
 	if !strings.Contains(applyOut, "root-vars-match Command PLAN") {
 		t.Fatalf("expected root scenario apply plan, got %q", applyOut)
+	}
+	if _, err := runWithCapturedStdout([]string{"apply", "--root", root, "--source", "server", "--scenario", "apply", "-f", "vars/site.yaml"}); err != nil {
+		t.Fatalf("apply with root and source server failed: %v", err)
+	}
+	runsRoot := filepath.Join(stateHome, "deck", "runs")
+	runEntries, err := os.ReadDir(runsRoot)
+	if err != nil {
+		t.Fatalf("read runs root: %v", err)
+	}
+	if len(runEntries) != 1 {
+		t.Fatalf("expected one run directory, got %d", len(runEntries))
+	}
+	runRecordPath := filepath.Join(runsRoot, runEntries[0].Name(), "record.json")
+	rawRunRecord, err := os.ReadFile(runRecordPath)
+	if err != nil {
+		t.Fatalf("read run record: %v", err)
+	}
+	var runRecord struct {
+		WorkflowSource string `json:"workflow_source"`
+	}
+	if err := json.Unmarshal(rawRunRecord, &runRecord); err != nil {
+		t.Fatalf("decode run record: %v\n%s", err, string(rawRunRecord))
+	}
+	if runRecord.WorkflowSource != scenarioSourceLocal {
+		t.Fatalf("expected local workflow source metadata, got %#v", runRecord)
 	}
 	stateOut, err := runWithCapturedStdout([]string{"state", "show", "--root", root, "--scenario", "apply", "-f", "vars/site.yaml"})
 	if err != nil {

--- a/cmd/deck/cmd_apply.go
+++ b/cmd/deck/cmd_apply.go
@@ -17,6 +17,8 @@ type diffOptions struct {
 	workflowPath  string
 	scenario      string
 	source        string
+	root          string
+	server        string
 	fresh         bool
 	stateDir      string
 	selectedPhase string
@@ -30,8 +32,10 @@ type planVarsOptions struct {
 	workflowPath  string
 	scenario      string
 	source        string
+	server        string
 	selectedPhase string
 	preparedRoot  string
+	rootExplicit  bool
 	fresh         bool
 	output        string
 	varOverrides  map[string]string
@@ -42,6 +46,8 @@ func newPlanCommand(env *cliEnv) *cobra.Command {
 	vars := &varFlag{}
 	varsFiles := &stringSliceFlag{}
 	var stateDir string
+	var root string
+	var server string
 	cmd := &cobra.Command{
 		Use:     "plan",
 		Aliases: []string{"diff"},
@@ -75,6 +81,8 @@ func newPlanCommand(env *cliEnv) *cobra.Command {
 				workflowPath:  workflowPath,
 				scenario:      scenario,
 				source:        source,
+				root:          root,
+				server:        server,
 				fresh:         fresh,
 				stateDir:      stateDir,
 				selectedPhase: selectedPhase,
@@ -88,14 +96,16 @@ func newPlanCommand(env *cliEnv) *cobra.Command {
 	cmd.Flags().String("workflow", "", "path or URL to workflow file")
 	cmd.Flags().String("scenario", "", "scenario name to plan")
 	cmd.Flags().String("source", scenarioSourceLocal, "scenario source (local|server)")
+	cmd.Flags().StringVar(&root, "root", "", "local workflow root containing workflows/")
+	cmd.Flags().StringVar(&server, "server", "", "remote workflow server URL")
 	cmd.Flags().String("phase", "", "phase name to plan (defaults to all phases)")
 	cmd.Flags().Bool("fresh", false, "ignore saved apply state for this invocation")
 	cmd.Flags().StringVar(&stateDir, "state-dir", "", "directory for apply state files (overrides local .deck/state/apply or remote XDG state)")
 	cmd.Flags().StringP("output", "o", "text", "output format (text|json)")
-	cmd.Flags().VarP(varsFiles, "vars-file", "f", "vars file overlay relative to workflows/ (repeatable)")
+	cmd.Flags().VarP(varsFiles, "vars-file", "f", "vars overlay path relative to the selected workflow root (workflows/), repeatable")
 	cmd.Flags().Var(vars, "var", "set variable override (key=value), repeatable")
 	registerScenarioSourceCompletion(cmd, "source", false)
-	registerScenarioNameCompletion(cmd, "scenario", "source", "", false)
+	registerScenarioNameCompletionWithSourceLocator(cmd, "scenario", "source", "root", "server", false)
 	cmd.AddCommand(newPlanVarsCommand(env))
 	return cmd
 }
@@ -103,6 +113,7 @@ func newPlanCommand(env *cliEnv) *cobra.Command {
 func newPlanVarsCommand(env *cliEnv) *cobra.Command {
 	vars := &varFlag{}
 	varsFiles := &stringSliceFlag{}
+	var server string
 	cmd := &cobra.Command{
 		Use:   "vars",
 		Short: "Show effective vars, context, and initial runtime values",
@@ -145,8 +156,10 @@ func newPlanVarsCommand(env *cliEnv) *cobra.Command {
 				workflowPath:  workflowPath,
 				scenario:      scenario,
 				source:        source,
+				server:        server,
 				selectedPhase: selectedPhase,
 				preparedRoot:  preparedRoot,
+				rootExplicit:  cmd.Flags().Changed("root"),
 				fresh:         fresh,
 				output:        output,
 				varOverrides:  vars.AsMap(),
@@ -158,14 +171,15 @@ func newPlanVarsCommand(env *cliEnv) *cobra.Command {
 	cmd.Flags().String("workflow", "", "path or URL to apply workflow file")
 	cmd.Flags().String("scenario", "", "scenario name to inspect for apply")
 	cmd.Flags().String("source", scenarioSourceLocal, "scenario source for apply (local|server)")
+	cmd.Flags().StringVar(&server, "server", "", "remote workflow server URL for --command apply")
 	cmd.Flags().String("phase", "", "phase name to inspect (defaults to all phases)")
-	cmd.Flags().String("root", workspacepaths.DefaultPreparedRoot("."), "prepared bundle output directory for --command prepare")
+	cmd.Flags().String("root", workspacepaths.DefaultPreparedRoot("."), "workflow root for --command apply or prepared bundle output directory for --command prepare")
 	cmd.Flags().Bool("fresh", false, "ignore saved apply state for this invocation")
 	cmd.Flags().StringP("output", "o", "text", "output format (text|json)")
-	cmd.Flags().VarP(varsFiles, "vars-file", "f", "vars file overlay relative to workflows/ (repeatable)")
+	cmd.Flags().VarP(varsFiles, "vars-file", "f", "vars overlay path relative to the selected workflow root (workflows/), repeatable")
 	cmd.Flags().Var(vars, "var", "set variable override (key=value), repeatable")
 	registerScenarioSourceCompletion(cmd, "source", false)
-	registerScenarioNameCompletion(cmd, "scenario", "source", "", false)
+	registerScenarioNameCompletionWithSourceLocator(cmd, "scenario", "source", "", "server", false)
 	return cmd
 }
 
@@ -180,7 +194,11 @@ func runPlanVarsWithOptions(env *cliEnv, ctx context.Context, opts planVarsOptio
 	}
 	workflowPath := strings.TrimSpace(opts.workflowPath)
 	if command == planvars.CommandApply {
-		workflowPath, err = resolvePlanWorkflowPath(ctx, workflowPath, strings.TrimSpace(opts.scenario), strings.TrimSpace(opts.source))
+		root := ""
+		if opts.rootExplicit {
+			root = strings.TrimSpace(opts.preparedRoot)
+		}
+		workflowPath, err = resolvePlanWorkflowPath(ctx, workflowPath, strings.TrimSpace(opts.scenario), strings.TrimSpace(opts.source), root, strings.TrimSpace(opts.server))
 		if err != nil {
 			return err
 		}
@@ -204,7 +222,7 @@ func runDiffWithOptions(env *cliEnv, ctx context.Context, opts diffOptions) erro
 	if err := env.commandStarted("plan"); err != nil {
 		return err
 	}
-	workflowPath, err := resolvePlanWorkflowPath(ctx, strings.TrimSpace(opts.workflowPath), strings.TrimSpace(opts.scenario), strings.TrimSpace(opts.source))
+	workflowPath, err := resolvePlanWorkflowPath(ctx, strings.TrimSpace(opts.workflowPath), strings.TrimSpace(opts.scenario), strings.TrimSpace(opts.source), strings.TrimSpace(opts.root), strings.TrimSpace(opts.server))
 	if err != nil {
 		return err
 	}
@@ -235,6 +253,9 @@ type applyOptions struct {
 	workflowPath   string
 	scenario       string
 	source         string
+	sourceExplicit bool
+	root           string
+	server         string
 	selectedPhase  string
 	fresh          bool
 	stateDir       string
@@ -249,6 +270,8 @@ func newApplyCommand(env *cliEnv) *cobra.Command {
 	vars := &varFlag{}
 	varsFiles := &stringSliceFlag{}
 	var stateDir string
+	var root string
+	var server string
 	cmd := &cobra.Command{
 		Use:   "apply [workflow] [bundle]",
 		Short: "Execute an apply file against a bundle",
@@ -291,6 +314,9 @@ func newApplyCommand(env *cliEnv) *cobra.Command {
 				workflowPath:   workflowPath,
 				scenario:       scenario,
 				source:         source,
+				sourceExplicit: cmd.Flags().Changed("source"),
+				root:           root,
+				server:         server,
 				selectedPhase:  selectedPhase,
 				fresh:          fresh,
 				stateDir:       stateDir,
@@ -306,15 +332,17 @@ func newApplyCommand(env *cliEnv) *cobra.Command {
 	cmd.Flags().String("workflow", "", "path or URL to workflow file")
 	cmd.Flags().String("scenario", "", "scenario name to execute")
 	cmd.Flags().String("source", scenarioSourceLocal, "scenario source (local|server)")
+	cmd.Flags().StringVar(&root, "root", "", "local workflow root containing workflows/")
+	cmd.Flags().StringVar(&server, "server", "", "remote workflow server URL")
 	cmd.Flags().String("phase", "", "phase name to execute (defaults to all phases)")
 	cmd.Flags().Bool("fresh", false, "ignore saved apply state for this invocation")
 	cmd.Flags().StringVar(&stateDir, "state-dir", "", "directory for apply state files (overrides local .deck/state/apply or remote XDG state)")
 	cmd.Flags().Bool("dry-run", false, "print apply plan without executing steps")
 	cmd.Flags().Bool("non-interactive", false, "fail or use defaults for operator interaction steps instead of prompting")
-	cmd.Flags().VarP(varsFiles, "vars-file", "f", "vars file overlay relative to workflows/ (repeatable)")
+	cmd.Flags().VarP(varsFiles, "vars-file", "f", "vars overlay path relative to the selected workflow root (workflows/), repeatable")
 	cmd.Flags().Var(vars, "var", "set variable override (key=value), repeatable")
 	registerScenarioSourceCompletion(cmd, "source", false)
-	registerScenarioNameCompletion(cmd, "scenario", "source", "", false)
+	registerScenarioNameCompletionWithSourceLocator(cmd, "scenario", "source", "root", "server", false)
 	return cmd
 }
 
@@ -337,11 +365,17 @@ func runApplyWithOptions(env *cliEnv, ctx context.Context, opts applyOptions) er
 	if err != nil {
 		return err
 	}
+	workflowSource := inferWorkflowSource(workflowPath, "")
+	if strings.TrimSpace(opts.server) != "" {
+		workflowSource = scenarioSourceServer
+	} else if opts.sourceExplicit {
+		workflowSource = inferWorkflowSource(workflowPath, strings.TrimSpace(opts.source))
+	}
 	invocationID := newInvocationID("apply")
 	return applycli.RunApplyCommand(ctx, applycli.ApplyCommandOptions{
 		WorkflowPath:     workflowPath,
 		BundleRoot:       bundleRoot,
-		WorkflowSource:   inferWorkflowSource(workflowPath, strings.TrimSpace(opts.source)),
+		WorkflowSource:   workflowSource,
 		Scenario:         strings.TrimSpace(opts.scenario),
 		SelectedPhase:    opts.selectedPhase,
 		Fresh:            opts.fresh,

--- a/cmd/deck/cmd_apply.go
+++ b/cmd/deck/cmd_apply.go
@@ -179,7 +179,7 @@ func newPlanVarsCommand(env *cliEnv) *cobra.Command {
 	cmd.Flags().VarP(varsFiles, "vars-file", "f", "vars overlay path relative to the selected workflow root (workflows/), repeatable")
 	cmd.Flags().Var(vars, "var", "set variable override (key=value), repeatable")
 	registerScenarioSourceCompletion(cmd, "source", false)
-	registerScenarioNameCompletionWithSourceLocator(cmd, "scenario", "source", "", "server", false)
+	registerScenarioNameCompletionWithSourceLocator(cmd, "scenario", "source", "root", "server", false)
 	return cmd
 }
 
@@ -366,9 +366,12 @@ func runApplyWithOptions(env *cliEnv, ctx context.Context, opts applyOptions) er
 		return err
 	}
 	workflowSource := inferWorkflowSource(workflowPath, "")
-	if strings.TrimSpace(opts.server) != "" {
+	switch {
+	case strings.TrimSpace(opts.server) != "":
 		workflowSource = scenarioSourceServer
-	} else if opts.sourceExplicit {
+	case strings.TrimSpace(opts.root) != "":
+		workflowSource = scenarioSourceLocal
+	case opts.sourceExplicit:
 		workflowSource = inferWorkflowSource(workflowPath, strings.TrimSpace(opts.source))
 	}
 	invocationID := newInvocationID("apply")

--- a/cmd/deck/cmd_apply_events.go
+++ b/cmd/deck/cmd_apply_events.go
@@ -27,11 +27,13 @@ func displayValueOrDash(value string) string {
 	return trimmed
 }
 
-func resolvePlanWorkflowPath(ctx context.Context, workflowPath, scenario, source string) (string, error) {
+func resolvePlanWorkflowPath(ctx context.Context, workflowPath, scenario, source, root, server string) (string, error) {
 	return applycli.ResolvePlanWorkflowPath(ctx, applycli.InvocationOptions{
 		WorkflowPath:     workflowPath,
 		Scenario:         scenario,
 		Source:           source,
+		Root:             root,
+		Server:           server,
 		DefaultLocalRoot: ".",
 		ResolveScenario:  resolveScenarioWorkflowReference,
 	})
@@ -42,6 +44,8 @@ func resolveApplyWorkflowAndBundle(ctx context.Context, opts applyOptions, posit
 		WorkflowPath:    opts.workflowPath,
 		Scenario:        opts.scenario,
 		Source:          opts.source,
+		Root:            opts.root,
+		Server:          opts.server,
 		PositionalArgs:  positionalArgs,
 		ResolveScenario: resolveScenarioWorkflowReference,
 	})

--- a/cmd/deck/cmd_state.go
+++ b/cmd/deck/cmd_state.go
@@ -19,6 +19,8 @@ type stateWorkflowOptions struct {
 	workflowPath string
 	scenario     string
 	source       string
+	root         string
+	server       string
 	stateDir     string
 	output       string
 	varOverrides map[string]string
@@ -111,12 +113,14 @@ func addStateWorkflowFlags(cmd *cobra.Command, opts *stateWorkflowOptions, vars 
 	cmd.Flags().StringVar(&opts.workflowPath, "workflow", "", "path or URL to workflow file")
 	cmd.Flags().StringVar(&opts.scenario, "scenario", "", "scenario name")
 	cmd.Flags().StringVar(&opts.source, "source", scenarioSourceLocal, "scenario source (local|server)")
+	cmd.Flags().StringVar(&opts.root, "root", "", "local workflow root containing workflows/")
+	cmd.Flags().StringVar(&opts.server, "server", "", "remote workflow server URL")
 	cmd.Flags().StringVar(&opts.stateDir, "state-dir", "", "directory for apply state files (overrides local .deck/state/apply or remote XDG state)")
 	cmd.Flags().StringVarP(&opts.output, "output", "o", "text", "output format (text|json)")
-	cmd.Flags().VarP(varsFiles, "vars-file", "f", "vars file overlay relative to workflows/ (repeatable)")
+	cmd.Flags().VarP(varsFiles, "vars-file", "f", "vars overlay path relative to the selected workflow root (workflows/), repeatable")
 	cmd.Flags().Var(vars, "var", "set variable override (key=value), repeatable")
 	registerScenarioSourceCompletion(cmd, "source", false)
-	registerScenarioNameCompletion(cmd, "scenario", "source", "", false)
+	registerScenarioNameCompletionWithSourceLocator(cmd, "scenario", "source", "root", "server", false)
 }
 
 func runStateShow(env *cliEnv, ctx context.Context, opts stateWorkflowOptions) error {
@@ -185,7 +189,7 @@ func runStateClear(_ *cliEnv, ctx context.Context, opts stateClearOptions) error
 }
 
 func resolveStateRequest(ctx context.Context, opts stateWorkflowOptions) (applycli.ExecutionRequest, error) {
-	workflowPath, err := resolvePlanWorkflowPath(ctx, strings.TrimSpace(opts.workflowPath), strings.TrimSpace(opts.scenario), strings.TrimSpace(opts.source))
+	workflowPath, err := resolvePlanWorkflowPath(ctx, strings.TrimSpace(opts.workflowPath), strings.TrimSpace(opts.scenario), strings.TrimSpace(opts.source), strings.TrimSpace(opts.root), strings.TrimSpace(opts.server))
 	if err != nil {
 		return applycli.ExecutionRequest{}, err
 	}

--- a/cmd/deck/help_completion_test.go
+++ b/cmd/deck/help_completion_test.go
@@ -146,6 +146,34 @@ func TestScenarioFlagCompletion(t *testing.T) {
 			t.Fatalf("expected scenario completion, got %q", res.stdout)
 		}
 	})
+
+	t.Run("plan vars root scenario names", func(t *testing.T) {
+		workspace := t.TempDir()
+		root := t.TempDir()
+		if err := os.MkdirAll(filepath.Join(root, "workflows", "scenarios"), 0o755); err != nil {
+			t.Fatalf("mkdir scenarios: %v", err)
+		}
+		if err := os.WriteFile(filepath.Join(root, "workflows", "scenarios", "apply.yaml"), []byte("version: v1alpha1\nsteps: []\n"), 0o644); err != nil {
+			t.Fatalf("write scenario: %v", err)
+		}
+
+		oldWD, err := os.Getwd()
+		if err != nil {
+			t.Fatalf("getwd: %v", err)
+		}
+		if err := os.Chdir(workspace); err != nil {
+			t.Fatalf("chdir: %v", err)
+		}
+		defer func() { _ = os.Chdir(oldWD) }()
+
+		res := execute([]string{"__complete", "plan", "vars", "--root", root, "--scenario", "a"})
+		if res.err != nil {
+			t.Fatalf("expected completion success, got %v", res.err)
+		}
+		if !strings.Contains(res.stdout, "apply") {
+			t.Fatalf("expected plan vars scenario completion, got %q", res.stdout)
+		}
+	})
 }
 
 func TestRunTopLevelStubUsage(t *testing.T) {

--- a/cmd/deck/scenario_cli.go
+++ b/cmd/deck/scenario_cli.go
@@ -271,7 +271,7 @@ func normalizeScenarioName(raw string) (string, error) {
 	return filepath.ToSlash(trimmed), nil
 }
 
-func resolveScenarioWorkflowReference(source, scenario string, localRoot string) (string, error) {
+func resolveScenarioWorkflowReference(source, scenario string, localRoot string, server string) (string, error) {
 	resolvedScenario, err := normalizeScenarioName(scenario)
 	if err != nil {
 		return "", err
@@ -281,7 +281,7 @@ func resolveScenarioWorkflowReference(source, scenario string, localRoot string)
 		return "", err
 	}
 	if resolvedSource == scenarioSourceServer {
-		serverURL, _, err := resolveRequiredSourceURL("")
+		serverURL, _, err := resolveRequiredSourceURL(server)
 		if err != nil {
 			return "", err
 		}
@@ -349,13 +349,21 @@ func registerScenarioSourceCompletion(cmd *cobra.Command, flagName string, allow
 	})
 }
 
-func registerScenarioNameCompletion(cmd *cobra.Command, flagName, sourceFlagName, localRootFlagName string, allowAll bool) {
+func registerScenarioNameCompletionWithSourceLocator(cmd *cobra.Command, flagName, sourceFlagName, localRootFlagName, serverFlagName string, allowAll bool) {
 	_ = cmd.RegisterFlagCompletionFunc(flagName, func(cmd *cobra.Command, _ []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		source := scenarioSourceLocal
 		if sourceFlagName != "" {
 			value := cmd.Flags().Lookup(sourceFlagName)
 			if value != nil {
 				source = value.Value.String()
+			}
+		}
+		explicitServer := ""
+		if serverFlagName != "" {
+			flag := cmd.Flags().Lookup(serverFlagName)
+			if flag != nil && strings.TrimSpace(flag.Value.String()) != "" {
+				explicitServer = strings.TrimSpace(flag.Value.String())
+				source = scenarioSourceServer
 			}
 		}
 		resolvedSource, err := normalizeScenarioSource(source, allowAll)
@@ -371,12 +379,12 @@ func registerScenarioNameCompletion(cmd *cobra.Command, flagName, sourceFlagName
 			}
 		}
 
-		items := completeScenarioNames(cmd.Context(), resolvedSource, localRoot, toComplete)
+		items := completeScenarioNames(cmd.Context(), resolvedSource, localRoot, explicitServer, toComplete)
 		return items, cobra.ShellCompDirectiveNoFileComp
 	})
 }
 
-func completeScenarioNames(ctx context.Context, source, localRoot, toComplete string) []string {
+func completeScenarioNames(ctx context.Context, source, localRoot, explicitServer, toComplete string) []string {
 	candidates := map[string]bool{}
 	if source == scenarioSourceLocal || source == scenarioSourceAll {
 		if entries, err := discoverLocalScenarioEntries(localRoot); err == nil {
@@ -388,7 +396,7 @@ func completeScenarioNames(ctx context.Context, source, localRoot, toComplete st
 		}
 	}
 	if source == scenarioSourceServer || source == scenarioSourceAll {
-		if serverURL, _, err := resolveSourceURL(""); err == nil && strings.TrimSpace(serverURL) != "" {
+		if serverURL, _, err := resolveSourceURL(explicitServer); err == nil && strings.TrimSpace(serverURL) != "" {
 			if entries, err := discoverServerScenarioEntries(ctx, serverURL); err == nil {
 				for _, entry := range entries {
 					if strings.HasPrefix(entry.Name, toComplete) {

--- a/cmd/deck/scenario_cli.go
+++ b/cmd/deck/scenario_cli.go
@@ -374,7 +374,7 @@ func registerScenarioNameCompletionWithSourceLocator(cmd *cobra.Command, flagNam
 		localRoot := "."
 		if localRootFlagName != "" {
 			flag := cmd.Flags().Lookup(localRootFlagName)
-			if flag != nil && strings.TrimSpace(flag.Value.String()) != "" {
+			if flag != nil && cmd.Flags().Changed(localRootFlagName) && strings.TrimSpace(flag.Value.String()) != "" {
 				localRoot = strings.TrimSpace(flag.Value.String())
 			}
 		}

--- a/cmd/deck/scenario_cli_test.go
+++ b/cmd/deck/scenario_cli_test.go
@@ -38,7 +38,7 @@ func TestCompleteScenarioNamesMergesLocalAndServerForAll(t *testing.T) {
 		t.Fatalf("saveSourceDefaults: %v", err)
 	}
 
-	got := completeScenarioNames(context.Background(), scenarioSourceAll, root, "")
+	got := completeScenarioNames(context.Background(), scenarioSourceAll, root, "", "")
 	want := []string{"apply", "nested/only-local", "server-only"}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("unexpected completion candidates\nwant: %#v\ngot:  %#v", want, got)
@@ -56,12 +56,12 @@ func TestCompleteScenarioNamesRemoteFailureFailsClosed(t *testing.T) {
 		t.Fatalf("saveSourceDefaults: %v", err)
 	}
 
-	got := completeScenarioNames(context.Background(), scenarioSourceServer, root, "")
+	got := completeScenarioNames(context.Background(), scenarioSourceServer, root, "", "")
 	if len(got) != 0 {
 		t.Fatalf("expected empty candidates on remote failure, got %#v", got)
 	}
 
-	got = completeScenarioNames(context.Background(), scenarioSourceAll, root, "")
+	got = completeScenarioNames(context.Background(), scenarioSourceAll, root, "", "")
 	if len(got) != 0 {
 		t.Fatalf("expected no noisy remote candidates when local is empty, got %#v", got)
 	}
@@ -85,7 +85,7 @@ func TestResolveScenarioWorkflowReferenceRespectsExplicitSource(t *testing.T) {
 		t.Fatalf("saveSourceDefaults: %v", err)
 	}
 
-	resolvedLocal, err := resolveScenarioWorkflowReference(scenarioSourceLocal, "apply", root)
+	resolvedLocal, err := resolveScenarioWorkflowReference(scenarioSourceLocal, "apply", root, "")
 	if err != nil {
 		t.Fatalf("resolve local scenario: %v", err)
 	}
@@ -93,13 +93,21 @@ func TestResolveScenarioWorkflowReferenceRespectsExplicitSource(t *testing.T) {
 		t.Fatalf("expected local path %q, got %q", localPath, resolvedLocal)
 	}
 
-	resolvedServer, err := resolveScenarioWorkflowReference(scenarioSourceServer, "apply", root)
+	resolvedServer, err := resolveScenarioWorkflowReference(scenarioSourceServer, "apply", root, "")
 	if err != nil {
 		t.Fatalf("resolve server scenario: %v", err)
 	}
 	wantServer := serverURL + "/workflows/scenarios/apply.yaml"
 	if resolvedServer != wantServer {
 		t.Fatalf("expected server path %q, got %q", wantServer, resolvedServer)
+	}
+
+	explicitServer, err := resolveScenarioWorkflowReference(scenarioSourceServer, "apply", root, "http://127.0.0.1:9090")
+	if err != nil {
+		t.Fatalf("resolve explicit server scenario: %v", err)
+	}
+	if explicitServer != "http://127.0.0.1:9090/workflows/scenarios/apply.yaml" {
+		t.Fatalf("expected explicit server to win, got %q", explicitServer)
 	}
 }
 

--- a/docs/apply-state.md
+++ b/docs/apply-state.md
@@ -20,8 +20,8 @@ $XDG_STATE_HOME/deck/state/apply/<state-key>.json
 Use `--state-dir` to choose an explicit directory:
 
 ```bash
-deck apply --state-dir /var/lib/deck/state/apply --workflow https://example.invalid/apply.yaml
-deck plan --state-dir /var/lib/deck/state/apply --workflow https://example.invalid/apply.yaml
+deck apply --state-dir /var/lib/deck/state/apply --server https://example.invalid --scenario apply
+deck plan --state-dir /var/lib/deck/state/apply --server https://example.invalid --scenario apply
 ```
 
 When `--state-dir` is supplied, deck uses only `<dir>/<state-key>.json`. It does not infer workspace-local state, read old default paths, or run automatic migration.
@@ -124,9 +124,10 @@ Use `--fresh` to ignore saved apply state for that invocation.
 Use `deck state` to inspect and delete apply state:
 
 ```bash
-deck state show --workflow workflows/scenarios/apply.yaml
+deck state show --root . --scenario apply
+deck state show --server https://example.invalid --scenario apply
 deck state list
-deck state clear --workflow workflows/scenarios/apply.yaml --yes
+deck state clear --root . --scenario apply --yes
 deck state clear --all --yes
 ```
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -191,11 +191,29 @@ Use these when you want to test a different site value without editing `workflow
 
 ```bash
 deck prepare -f vars/site.yaml --var registryHost=mirror.local --var kubernetesVersion=v1.30.1
-deck plan --scenario apply -f vars/site.yaml -f vars/worker.yaml --var role=worker
-deck apply --scenario apply -f vars/site.yaml -f vars/cp1.yaml --var role=control-plane --var nodeIP=10.0.0.10
+deck plan --root . --scenario apply -f vars/site.yaml -f vars/worker.yaml --var role=worker
+deck apply --root . --scenario apply -f vars/site.yaml -f vars/cp1.yaml --var role=control-plane --var nodeIP=10.0.0.10
 ```
 
-Vars file paths are relative to the same `workflows/` location that contains `vars.yaml`. For example, `-f vars/site.yaml` reads `workflows/vars/site.yaml` for a local workflow tree.
+Vars file paths are relative to the selected workflow root. For example, `--root ./demo -f vars/site.yaml` reads `./demo/workflows/vars/site.yaml`, and `--server https://server -f vars/site.yaml` reads `https://server/workflows/vars/site.yaml`.
+
+### Workflow source locators
+
+For `plan`, `apply`, and `state`, prefer selecting the workflow source and the entrypoint separately:
+
+```bash
+deck apply --root ./demo --scenario apply
+deck plan --server https://server --scenario apply
+deck state show --server https://server --scenario apply
+```
+
+- `--root <path>` selects a local workflow tree or bundle root containing `workflows/`.
+- `--server <url>` selects a remote workflow server and resolves scenarios under `<url>/workflows/scenarios/`.
+- `--scenario <name>` selects `workflows/scenarios/<name>.yaml` under the selected source.
+- `--workflow <path-or-url>` remains available as an explicit workflow-file escape hatch.
+- `--root` and `--server` are mutually exclusive.
+- `--workflow` and `--scenario` are mutually exclusive.
+- Existing `--source server --scenario <name>` still works with `DECK_SERVER` or `deck server remote set`, but `--server <url> --scenario <name>` is the clearer inline form.
 
 ### Node-scoped workflow variables
 
@@ -262,12 +280,12 @@ deck prepare --bundle-binary-source release --bundle-binary-version v0.1.0 --bun
 deck prepare -f vars/site.yaml --var registryHost=mirror.local --var kubernetesVersion=v1.30.1
 deck plan vars --command prepare -f vars/site.yaml --var registryHost=mirror.local
 deck bundle build --out ./bundle.tar
-deck plan --scenario apply --source local
-deck plan --scenario apply --source local -o json
-deck plan --scenario apply --source local -f vars/worker.yaml --var role=worker
-deck plan vars --scenario apply --source local -f vars/worker.yaml --var role=worker
-deck apply --scenario apply --source local
-deck apply --scenario apply --source local -f vars/cp1.yaml --var role=control-plane --var nodeIP=10.0.0.10
+deck plan --root . --scenario apply
+deck plan --root . --scenario apply -o json
+deck plan --root . --scenario apply -f vars/worker.yaml --var role=worker
+deck plan vars --root . --scenario apply -f vars/worker.yaml --var role=worker
+deck apply --root . --scenario apply
+deck apply --root . --scenario apply -f vars/cp1.yaml --var role=control-plane --var nodeIP=10.0.0.10
 deck cache clean --older-than 30d --dry-run
 ```
 
@@ -294,7 +312,7 @@ deck server health --server http://127.0.0.1:8080 -o json
 deck server logs --root ./bundle --source file -o json --v=1
 deck bundle verify --file ./bundle -o json
 deck cache list -o json --v=1
-deck plan --scenario apply --source server
+deck plan --server http://127.0.0.1:8080 --scenario apply
 
 deck ask config set --provider openai --model gpt-5.4 --endpoint https://api.openai.com/v1 --api-key "$DECK_ASK_API_KEY"
 deck ask status --provider openai
@@ -359,7 +377,8 @@ Optional transport override example:
 - `plan` and `apply` support `--fresh` to ignore saved apply state for that invocation.
 - `plan`, `apply`, and `state` support `--state-dir` to use an explicit apply state directory.
 - `deck state show/list/clear` inspects and removes saved apply state.
-- `--source` controls whether `--scenario` resolves from the local workspace or the saved remote server.
+- `--root` and `--server` are the preferred source locators for local and remote scenario execution.
+- `--source` remains supported for compatibility and controls whether `--scenario` resolves from the local workspace or the saved remote server.
 - local workflow apply state stays under `./.deck/state/apply/`; remote workflow apply state uses the user-local XDG state root under `deck/state/apply/`.
 - workspace-local metadata stays under `./.deck/`, while user-global config, remote workflow state, cache, and run history use standard XDG locations.
 - `ask` workspace context lives under `./.deck/ask/`, while saved ask config defaults live under `~/.config/deck/config.json` as the top-level `ask` object.

--- a/docs/workflow-model.md
+++ b/docs/workflow-model.md
@@ -124,7 +124,7 @@ vars:
 **CLI vars files** — overlay site or node values without editing `workflows/vars.yaml`:
 
 ```bash
-deck apply --scenario apply -f vars/site.yaml -f vars/cp1.yaml
+deck apply --root . --scenario apply -f vars/site.yaml -f vars/cp1.yaml
 ```
 
 Vars file paths are relative to the same `workflows/` location that contains `vars.yaml`.

--- a/internal/applycli/invocation.go
+++ b/internal/applycli/invocation.go
@@ -12,8 +12,10 @@ type InvocationOptions struct {
 	WorkflowPath     string
 	Scenario         string
 	Source           string
+	Root             string
+	Server           string
 	PositionalArgs   []string
-	ResolveScenario  func(source, scenario, localRoot string) (string, error)
+	ResolveScenario  func(source, scenario, localRoot, server string) (string, error)
 	DefaultLocalRoot string
 }
 
@@ -24,9 +26,21 @@ func ResolvePlanWorkflowPath(ctx context.Context, opts InvocationOptions) (strin
 	resolvedWorkflow := strings.TrimSpace(opts.WorkflowPath)
 	resolvedScenario := strings.TrimSpace(opts.Scenario)
 	resolvedSource := strings.TrimSpace(opts.Source)
+	server := strings.TrimRight(strings.TrimSpace(opts.Server), "/")
 	localRoot := strings.TrimSpace(opts.DefaultLocalRoot)
+	if strings.TrimSpace(opts.Root) != "" {
+		localRoot = strings.TrimSpace(opts.Root)
+	}
 	if localRoot == "" {
 		localRoot = "."
+	}
+	if err := validateSourceLocator(strings.TrimSpace(opts.Root), server); err != nil {
+		return "", err
+	}
+	if server != "" {
+		resolvedSource = "server"
+	} else if strings.TrimSpace(opts.Root) != "" {
+		resolvedSource = "local"
 	}
 	if resolvedWorkflow != "" && resolvedScenario != "" {
 		return "", fmt.Errorf("plan accepts either --workflow or --scenario, not both")
@@ -38,7 +52,10 @@ func ResolvePlanWorkflowPath(ctx context.Context, opts InvocationOptions) (strin
 		if opts.ResolveScenario == nil {
 			return "", fmt.Errorf("scenario resolver is nil")
 		}
-		return opts.ResolveScenario(resolvedSource, resolvedScenario, localRoot)
+		return opts.ResolveScenario(resolvedSource, resolvedScenario, localRoot, server)
+	}
+	if server != "" {
+		return "", fmt.Errorf("plan with --server requires --scenario or --workflow")
 	}
 	if resolvedSource == "server" {
 		return "", fmt.Errorf("plan with --source server requires --scenario or --workflow")
@@ -53,9 +70,22 @@ func ResolveApplyWorkflowAndBundle(ctx context.Context, opts InvocationOptions) 
 	resolvedWorkflow := strings.TrimSpace(opts.WorkflowPath)
 	resolvedScenario := strings.TrimSpace(opts.Scenario)
 	resolvedSource := strings.TrimSpace(opts.Source)
+	server := strings.TrimRight(strings.TrimSpace(opts.Server), "/")
+	root := strings.TrimSpace(opts.Root)
 	positionalWorkflow, positionalBundle, err := parseApplyPositionals(opts.PositionalArgs)
 	if err != nil {
 		return "", "", err
+	}
+	if err := validateSourceLocator(root, server); err != nil {
+		return "", "", err
+	}
+	if root != "" && strings.TrimSpace(positionalBundle) != "" {
+		return "", "", fmt.Errorf("apply accepts either --root or a positional bundle path, not both")
+	}
+	if server != "" {
+		resolvedSource = "server"
+	} else if root != "" {
+		resolvedSource = "local"
 	}
 	if resolvedWorkflow != "" && resolvedScenario != "" {
 		return "", "", fmt.Errorf("apply accepts either --workflow or --scenario, not both")
@@ -64,6 +94,9 @@ func ResolveApplyWorkflowAndBundle(ctx context.Context, opts InvocationOptions) 
 		return "", "", fmt.Errorf("apply accepts at most one workflow reference")
 	}
 	if resolvedWorkflow == "" && resolvedScenario == "" && resolvedSource == "server" {
+		if server != "" {
+			return "", "", fmt.Errorf("apply with --server requires --scenario or --workflow")
+		}
 		return "", "", fmt.Errorf("apply with --source server requires --scenario or --workflow")
 	}
 	if (resolvedWorkflow != "" || resolvedScenario != "") && len(opts.PositionalArgs) > 1 {
@@ -87,9 +120,35 @@ func ResolveApplyWorkflowAndBundle(ctx context.Context, opts InvocationOptions) 
 		return resolvedWorkflow, bundleRoot, nil
 	}
 
-	bundleRoot, err := ResolveBundleRoot(positionalBundle)
-	if err != nil {
-		return "", "", err
+	if resolvedSource == "server" && resolvedScenario != "" {
+		bundleRoot := ""
+		if strings.TrimSpace(positionalBundle) != "" {
+			bundleRoot, err = ResolveBundleRoot(positionalBundle)
+			if err != nil {
+				return "", "", err
+			}
+		}
+		if opts.ResolveScenario == nil {
+			return "", "", fmt.Errorf("scenario resolver is nil")
+		}
+		workflowPath, err := opts.ResolveScenario(resolvedSource, resolvedScenario, ".", server)
+		if err != nil {
+			return "", "", err
+		}
+		return workflowPath, bundleRoot, nil
+	}
+
+	bundleRoot := ""
+	if root != "" {
+		bundleRoot, err = ResolveBundleRoot(root)
+		if err != nil {
+			return "", "", err
+		}
+	} else {
+		bundleRoot, err = ResolveBundleRoot(positionalBundle)
+		if err != nil {
+			return "", "", err
+		}
 	}
 	if resolvedScenario != "" {
 		if opts.ResolveScenario == nil {
@@ -99,7 +158,7 @@ func ResolveApplyWorkflowAndBundle(ctx context.Context, opts InvocationOptions) 
 		if resolvedSource == "local" {
 			localRoot = bundleRoot
 		}
-		workflowPath, err := opts.ResolveScenario(resolvedSource, resolvedScenario, localRoot)
+		workflowPath, err := opts.ResolveScenario(resolvedSource, resolvedScenario, localRoot, server)
 		if err != nil {
 			return "", "", err
 		}
@@ -110,6 +169,13 @@ func ResolveApplyWorkflowAndBundle(ctx context.Context, opts InvocationOptions) 
 		return "", "", err
 	}
 	return workflowPath, bundleRoot, nil
+}
+
+func validateSourceLocator(root string, server string) error {
+	if strings.TrimSpace(root) != "" && strings.TrimSpace(server) != "" {
+		return fmt.Errorf("--root and --server are mutually exclusive")
+	}
+	return nil
 }
 
 func parseApplyPositionals(positionalArgs []string) (string, string, error) {


### PR DESCRIPTION
## Summary
- Add explicit `--root` and `--server` source locators for apply, plan, plan vars, and state workflow selection.
- Preserve existing `--source server`, direct `--workflow`, and positional apply behavior while documenting source locators as preferred.
- Cover local/remote vars overlays, state lookup, completion, metadata, and invalid selector combinations.

## Tests
- `go test ./cmd/deck ./internal/applycli`
- `make test && make lint`