### PR TITLE
feat(server): detect and reject ambiguous registry alias collisions

### DIFF
--- a/docs/server-audit-log.md
+++ b/docs/server-audit-log.md
@@ -44,6 +44,12 @@ Example request record:
 {"ts":"2026-04-03T05:00:00Z","schema_version":2,"component":"server","event":"request","level":"info","message":"http request handled","method":"GET","path":"/healthz","proto":"HTTP/1.1","status":200,"bytes":0,"remote_addr":"127.0.0.1:53422","duration_ms":1}
 ```
 
+The registry emits a `registry_alias_collision` event (`level: warn`) when a request targets a domain-stripped alias that maps to more than one canonical repository. The request is rejected with `404`, and the record lists the colliding repositories under `canonical_repos`. See [Alias collisions](server/registry.md#alias-collisions).
+
+```json
+{"ts":"2026-04-03T05:00:00Z","schema_version":2,"component":"server","event":"registry_alias_collision","level":"warn","message":"ambiguous registry alias rejected","alias":"calico/node","canonical_repos":["quay.io/calico/node","registry.example.com/calico/node"],"method":"GET","path":"/v2/calico/node/manifests/v1"}
+```
+
 ## Compatibility note
 
 - current `deck server up` writes the structured version-2 shape above

--- a/docs/server/registry.md
+++ b/docs/server/registry.md
@@ -82,6 +82,16 @@ This lets clients pull using either the fully-qualified name or the shorter form
 
 > **Docker Hub note:** go-containerregistry normalizes `docker.io` to `index.docker.io`, so a tag stored as `docker.io/library/alpine:3.18` is registered under the canonical name `index.docker.io/library/alpine`. Clients should pull via `index.docker.io/library/alpine` or the domain-stripped alias `library/alpine`.
 
+### Alias collisions {#alias-collisions}
+
+Two images from different registries can strip to the same alias. For example `quay.io/calico/node` and `registry.example.com/calico/node` both produce the alias `calico/node`. Because the alias no longer identifies a single image, the server treats it as ambiguous:
+
+- The ambiguous alias is **omitted from the catalog** (`/v2/_catalog`).
+- Requests to the ambiguous alias for tags, manifests, or blobs return **`404 Not Found`** rather than silently serving an arbitrary one of the colliding images. Each rejection is recorded in the [server audit log](../server-audit-log.md) as a `registry_alias_collision` event listing the colliding canonical repositories.
+- The **canonical, domain-prefixed names always keep working** — pull `quay.io/calico/node` or `registry.example.com/calico/node` explicitly to disambiguate.
+
+If a requested name is simultaneously a canonical repository and an alias of another image, the canonical repository wins.
+
 ## Read-only enforcement
 
 Any method other than `GET` or `HEAD` — including `POST`, `PUT`, `DELETE`, and `PATCH` — returns `405 Method Not Allowed` before any path dispatch occurs. There are no push, delete, or upload endpoints.

--- a/internal/server/http_audit.go
+++ b/internal/server/http_audit.go
@@ -34,6 +34,8 @@ const (
 	auditSourceServer  = "server"
 	auditEventRequest  = "http_request"
 
+	auditEventRegistryAliasCollision = "registry_alias_collision"
+
 	defaultAuditMaxSizeMB = 50
 	defaultAuditMaxFiles  = 10
 )

--- a/internal/server/http_registry.go
+++ b/internal/server/http_registry.go
@@ -3,6 +3,7 @@ package server
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -11,6 +12,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/google/go-containerregistry/pkg/name"
 	v1 "github.com/google/go-containerregistry/pkg/v1"
@@ -31,6 +33,79 @@ type registryCatalogEntry struct {
 
 func (e registryCatalogEntry) isCanonical() bool {
 	return e.canonicalRepo == "" || e.repo == e.canonicalRepo
+}
+
+// registryAliasCollisionError indicates that a requested repository path is a
+// domain-stripped alias that maps to more than one distinct canonical
+// repository, so it cannot be resolved to a single image unambiguously.
+type registryAliasCollisionError struct {
+	alias          string
+	canonicalRepos []string
+}
+
+func (e *registryAliasCollisionError) Error() string {
+	return fmt.Sprintf("ambiguous repository alias %q maps to multiple images: %s", e.alias, strings.Join(e.canonicalRepos, ", "))
+}
+
+// selectRepoEntries applies the alias-collision policy for a requested repo
+// path and returns the catalog entries that should serve it:
+//   - a request matching a canonical repository serves only that repository's
+//     canonical entries (canonical is preferred over any alias);
+//   - a pure alias mapping to a single canonical repository serves normally;
+//   - a pure alias mapping to more than one canonical repository is ambiguous
+//     and yields a *registryAliasCollisionError with no entries.
+//
+// A repo with no matching entries returns (nil, nil) so callers can treat it
+// as not found.
+func selectRepoEntries(entries []registryCatalogEntry, repo string) ([]registryCatalogEntry, error) {
+	matches := make([]registryCatalogEntry, 0)
+	canonical := make([]registryCatalogEntry, 0)
+	distinct := make([]string, 0)
+	seen := map[string]bool{}
+	for _, entry := range entries {
+		if entry.repo != repo {
+			continue
+		}
+		matches = append(matches, entry)
+		if entry.isCanonical() {
+			canonical = append(canonical, entry)
+		}
+		if !seen[entry.canonicalRepo] {
+			seen[entry.canonicalRepo] = true
+			distinct = append(distinct, entry.canonicalRepo)
+		}
+	}
+	if len(matches) == 0 {
+		return nil, nil
+	}
+	if len(canonical) > 0 {
+		// The requested path is itself a canonical repository; prefer it and
+		// ignore alias contributions from other canonical repositories.
+		return canonical, nil
+	}
+	if len(distinct) > 1 {
+		sort.Strings(distinct)
+		return nil, &registryAliasCollisionError{alias: repo, canonicalRepos: distinct}
+	}
+	return matches, nil
+}
+
+func (h *serverHandler) maybeAuditAliasCollision(r *http.Request, err error) {
+	var collErr *registryAliasCollisionError
+	if !errors.As(err, &collErr) {
+		return
+	}
+	if h.logger == nil {
+		return
+	}
+	entry := buildServerAuditRecord(time.Now().UTC(), auditEventRegistryAliasCollision, "warn", "ambiguous registry alias rejected")
+	addExtra(entry, map[string]any{
+		"alias":           collErr.alias,
+		"canonical_repos": collErr.canonicalRepos,
+		"method":          r.Method,
+		"path":            r.URL.RequestURI(),
+	})
+	_ = h.logger.Write(entry)
 }
 
 type registryResolvedImage struct {
@@ -99,6 +174,12 @@ func (h *serverHandler) handleRegistryCatalog(w http.ResponseWriter, r *http.Req
 			continue
 		}
 		seen[entry.repo] = true
+		// Omit ambiguous aliases (and anything else with nothing to serve)
+		// so the catalog never advertises a repo that would fail to resolve.
+		selected, selErr := selectRepoEntries(entries, entry.repo)
+		if selErr != nil || len(selected) == 0 {
+			continue
+		}
 		repos = append(repos, entry.repo)
 	}
 	sort.Strings(repos)
@@ -135,10 +216,16 @@ func (h *serverHandler) handleRegistryTags(w http.ResponseWriter, r *http.Reques
 		w.WriteHeader(http.StatusInternalServerError)
 		return
 	}
+	selected, selErr := selectRepoEntries(entries, req.repo)
+	if selErr != nil {
+		h.maybeAuditAliasCollision(r, selErr)
+		w.WriteHeader(http.StatusNotFound)
+		return
+	}
 	tags := make([]string, 0)
 	seen := map[string]bool{}
-	for _, entry := range entries {
-		if entry.repo != req.repo || seen[entry.tag] {
+	for _, entry := range selected {
+		if seen[entry.tag] {
 			continue
 		}
 		seen[entry.tag] = true
@@ -203,6 +290,7 @@ func parseRegistryBlobRequest(urlPath string) (registryBlobRequest, bool) {
 func (h *serverHandler) handleRegistryManifest(w http.ResponseWriter, r *http.Request, req registryManifestRequest) {
 	resolved, err := h.resolveRegistryImage(req.repo, req.ref)
 	if err != nil {
+		h.maybeAuditAliasCollision(r, err)
 		w.WriteHeader(http.StatusNotFound)
 		return
 	}
@@ -224,6 +312,7 @@ func (h *serverHandler) handleRegistryManifest(w http.ResponseWriter, r *http.Re
 func (h *serverHandler) handleRegistryBlob(w http.ResponseWriter, r *http.Request, req registryBlobRequest) {
 	resolved, err := h.resolveRegistryImage(req.repo, req.digest)
 	if err != nil {
+		h.maybeAuditAliasCollision(r, err)
 		w.WriteHeader(http.StatusNotFound)
 		return
 	}
@@ -252,11 +341,9 @@ func (h *serverHandler) resolveRegistryImage(repo, ref string) (*registryResolve
 	if err != nil {
 		return nil, err
 	}
-	candidates := make([]registryCatalogEntry, 0)
-	for _, entry := range entries {
-		if entry.repo == repo {
-			candidates = append(candidates, entry)
-		}
+	candidates, err := selectRepoEntries(entries, repo)
+	if err != nil {
+		return nil, err
 	}
 	if len(candidates) == 0 {
 		return nil, fmt.Errorf("repo not found: %s", repo)

--- a/internal/server/http_registry_collision_test.go
+++ b/internal/server/http_registry_collision_test.go
@@ -1,0 +1,191 @@
+package server
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/google/go-containerregistry/pkg/name"
+	"github.com/google/go-containerregistry/pkg/v1/random"
+	"github.com/google/go-containerregistry/pkg/v1/tarball"
+)
+
+func writeRegistryTestImage(t *testing.T, root, ref string) {
+	t.Helper()
+	tag, err := name.NewTag(ref, name.WeakValidation)
+	if err != nil {
+		t.Fatalf("name.NewTag %s: %v", ref, err)
+	}
+	img, err := random.Image(256, 1)
+	if err != nil {
+		t.Fatalf("random.Image %s: %v", ref, err)
+	}
+	safe := strings.NewReplacer("/", "_", ":", "_").Replace(ref)
+	tarPath := filepath.Join(root, "outputs", "images", safe+".tar")
+	if err := tarball.WriteToFile(tarPath, tag, img); err != nil {
+		t.Fatalf("tarball.WriteToFile %s: %v", ref, err)
+	}
+}
+
+func registryStatus(t *testing.T, h http.Handler, path string) int {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodGet, path, nil)
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+	return rr.Code
+}
+
+func registryCatalogRepos(t *testing.T, h http.Handler) []string {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodGet, "/v2/_catalog", nil)
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("catalog status = %d, want 200", rr.Code)
+	}
+	var payload struct {
+		Repositories []string `json:"repositories"`
+	}
+	if err := json.Unmarshal(rr.Body.Bytes(), &payload); err != nil {
+		t.Fatalf("decode catalog: %v", err)
+	}
+	return payload.Repositories
+}
+
+// Two source images whose repository names differ only by registry domain
+// (quay.io/team/app and example.com/team/app) both strip to the alias
+// "team/app". The alias is ambiguous and must not silently resolve to an
+// arbitrary one; both canonical repositories must still work.
+func TestRegistryAmbiguousAliasIsRejected(t *testing.T) {
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, "outputs", "images"), 0o755); err != nil {
+		t.Fatalf("mkdir images: %v", err)
+	}
+	writeRegistryTestImage(t, root, "quay.io/team/app:v1")
+	writeRegistryTestImage(t, root, "example.com/team/app:v2")
+
+	h, err := NewHandler(root, HandlerOptions{})
+	if err != nil {
+		t.Fatalf("NewHandler: %v", err)
+	}
+
+	repos := registryCatalogRepos(t, h)
+	if !containsString(repos, "quay.io/team/app") {
+		t.Fatalf("catalog missing canonical quay.io/team/app: %v", repos)
+	}
+	if !containsString(repos, "example.com/team/app") {
+		t.Fatalf("catalog missing canonical example.com/team/app: %v", repos)
+	}
+	if containsString(repos, "team/app") {
+		t.Fatalf("ambiguous alias team/app must be hidden from catalog: %v", repos)
+	}
+
+	if got := registryStatus(t, h, "/v2/team/app/tags/list"); got != http.StatusNotFound {
+		t.Fatalf("ambiguous alias tags status = %d, want 404", got)
+	}
+	if got := registryStatus(t, h, "/v2/team/app/manifests/v1"); got != http.StatusNotFound {
+		t.Fatalf("ambiguous alias manifest status = %d, want 404", got)
+	}
+
+	if got := registryStatus(t, h, "/v2/quay.io/team/app/manifests/v1"); got != http.StatusOK {
+		t.Fatalf("canonical quay.io/team/app manifest status = %d, want 200", got)
+	}
+	if got := registryStatus(t, h, "/v2/example.com/team/app/manifests/v2"); got != http.StatusOK {
+		t.Fatalf("canonical example.com/team/app manifest status = %d, want 200", got)
+	}
+
+	// The rejected alias access must be recorded in the audit log with the
+	// colliding canonical repositories for operator diagnosis.
+	auditRaw, err := os.ReadFile(filepath.Join(root, ".deck", "logs", "server-audit.log"))
+	if err != nil {
+		t.Fatalf("read audit log: %v", err)
+	}
+	audit := string(auditRaw)
+	if !strings.Contains(audit, auditEventRegistryAliasCollision) {
+		t.Fatalf("audit log missing collision event: %s", audit)
+	}
+	for _, want := range []string{"quay.io/team/app", "example.com/team/app"} {
+		if !strings.Contains(audit, want) {
+			t.Fatalf("audit log missing colliding repo %q: %s", want, audit)
+		}
+	}
+}
+
+func TestSelectRepoEntries(t *testing.T) {
+	entries := []registryCatalogEntry{
+		{repo: "quay.io/team/app", canonicalRepo: "quay.io/team/app", tag: "v1", tarPath: "a"},
+		{repo: "team/app", canonicalRepo: "quay.io/team/app", tag: "v1", tarPath: "a"},
+		{repo: "example.com/team/app", canonicalRepo: "example.com/team/app", tag: "v2", tarPath: "b"},
+		{repo: "team/app", canonicalRepo: "example.com/team/app", tag: "v2", tarPath: "b"},
+		{repo: "quay.io/solo/app", canonicalRepo: "quay.io/solo/app", tag: "v3", tarPath: "c"},
+		{repo: "solo/app", canonicalRepo: "quay.io/solo/app", tag: "v3", tarPath: "c"},
+	}
+
+	t.Run("canonical repo served", func(t *testing.T) {
+		sel, err := selectRepoEntries(entries, "quay.io/team/app")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(sel) != 1 || sel[0].canonicalRepo != "quay.io/team/app" {
+			t.Fatalf("unexpected selection: %+v", sel)
+		}
+	})
+
+	t.Run("ambiguous alias rejected", func(t *testing.T) {
+		sel, err := selectRepoEntries(entries, "team/app")
+		if sel != nil {
+			t.Fatalf("expected no entries for ambiguous alias, got %+v", sel)
+		}
+		var collErr *registryAliasCollisionError
+		if !errors.As(err, &collErr) {
+			t.Fatalf("expected *registryAliasCollisionError, got %v", err)
+		}
+		if collErr.alias != "team/app" {
+			t.Fatalf("collision alias = %q, want team/app", collErr.alias)
+		}
+		if len(collErr.canonicalRepos) != 2 ||
+			collErr.canonicalRepos[0] != "example.com/team/app" ||
+			collErr.canonicalRepos[1] != "quay.io/team/app" {
+			t.Fatalf("collision canonicalRepos = %v, want sorted [example.com/team/app quay.io/team/app]", collErr.canonicalRepos)
+		}
+	})
+
+	t.Run("unambiguous alias served", func(t *testing.T) {
+		sel, err := selectRepoEntries(entries, "solo/app")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(sel) != 1 || sel[0].canonicalRepo != "quay.io/solo/app" {
+			t.Fatalf("unexpected selection: %+v", sel)
+		}
+	})
+
+	t.Run("unknown repo returns nothing", func(t *testing.T) {
+		sel, err := selectRepoEntries(entries, "does/not-exist")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if sel != nil {
+			t.Fatalf("expected nil selection, got %+v", sel)
+		}
+	})
+
+	t.Run("prefer canonical over colliding alias", func(t *testing.T) {
+		mixed := []registryCatalogEntry{
+			{repo: "foo/bar", canonicalRepo: "foo/bar", tag: "v1", tarPath: "x"},
+			{repo: "foo/bar", canonicalRepo: "quay.io/foo/bar", tag: "v9", tarPath: "y"},
+		}
+		sel, err := selectRepoEntries(mixed, "foo/bar")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(sel) != 1 || sel[0].canonicalRepo != "foo/bar" || sel[0].tag != "v1" {
+			t.Fatalf("expected only the canonical foo/bar entry, got %+v", sel)
+		}
+	})
+}

--- a/website/i18n/ko/docusaurus-plugin-content-docs/current/server-audit-log.md
+++ b/website/i18n/ko/docusaurus-plugin-content-docs/current/server-audit-log.md
@@ -1,33 +1,33 @@
 ---
 source: docs/server-audit-log.md
-source_hash: 620f8dc9fb0796fe8bbfadcafd8da8c258559a9f
+source_hash: 854ba70599bece6d677ff6ad54c2c3c4dc765d9a
 ---
 # 서버 감사 로그
 
-`deck server up`은 감사 레코드를 번들 루트 아래의 JSONL 로그 파일에 기록합니다.
+`deck server up`은 번들 루트 아래 JSONL 로그 파일에 감사 기록을 남깁니다.
 
 ## 위치
 
-기본 파일 위치:
+기본 파일 위치는 다음과 같습니다.
 
 ```text
 <root>/.deck/logs/server-audit.log
 ```
 
-## 현재 방출되는 레코드 형태
+## 현재 기록되는 레코드 형태
 
-`deck server up`은 현재 구조화된 최상위 필드를 갖는 감사 스키마 버전 `2` 레코드를 방출합니다.
+`deck server up`은 감사 스키마 버전 `2` 레코드를 최상위 필드로 구성한 구조화된 형태로 남깁니다.
 
-공통 필드:
+공통 필드는 다음과 같습니다.
 
 - `ts`: UTC 기준 RFC3339Nano 타임스탬프
-- `schema_version`: 현재 `2`
-- `component`: 로그 생산자, 현재 `server`
-- `event`: `request`와 같은 정규화된 이벤트 이름
-- `level`: `info`, `warn`, 또는 `error`
-- `message`: 짧은 사람이 읽을 수 있는 설명
+- `schema_version`: 현재 값은 `2`
+- `component`: 로그를 생성한 주체이며, 현재는 `server`
+- `event`: 정규화된 이벤트 이름으로, 예를 들면 `request`
+- `level`: `info`, `warn`, `error` 중 하나
+- `message`: 사람이 읽을 수 있는 짧은 설명
 
-요청 레코드에는 다음과 같은 최상위 요청 속성도 포함됩니다:
+요청 레코드에는 다음과 같은 최상위 요청 속성도 함께 담깁니다.
 
 - `method`
 - `path`
@@ -37,10 +37,10 @@ source_hash: 620f8dc9fb0796fe8bbfadcafd8da8c258559a9f
 - `remote_addr`
 - `duration_ms`
 
-## 일반적인 예시
+## 대표적인 예시
 
-- 사이트 API, 레지스트리, 정적 파일, 헬스 체크를 포함한 라우팅된 서버 응답에 대해 레코드가 기록됩니다
-- 현재 라이터는 요청 속성을 중첩된 `extra` 객체 아래가 아닌 최상위에 유지합니다
+- 사이트 API, 레지스트리, 정적 파일, 헬스 체크 등 라우팅된 서버 응답마다 레코드를 남깁니다
+- 현재 작성기는 요청 속성을 중첩된 `extra` 객체가 아니라 최상위에 둡니다
 
 요청 레코드 예시:
 
@@ -48,16 +48,22 @@ source_hash: 620f8dc9fb0796fe8bbfadcafd8da8c258559a9f
 {"ts":"2026-04-03T05:00:00Z","schema_version":2,"component":"server","event":"request","level":"info","message":"http request handled","method":"GET","path":"/healthz","proto":"HTTP/1.1","status":200,"bytes":0,"remote_addr":"127.0.0.1:53422","duration_ms":1}
 ```
 
+레지스트리는 도메인이 제거된 별칭(alias)이 둘 이상의 정식(canonical) 저장소로 매핑되는 요청을 받으면 `registry_alias_collision` 이벤트(`level: warn`)를 남깁니다. 이때 요청은 `404`로 거부되며, 레코드의 `canonical_repos`에 충돌한 저장소 목록이 담깁니다. 자세한 내용은 [별칭 충돌](server/registry.md#alias-collisions)을 참고하세요.
+
+```json
+{"ts":"2026-04-03T05:00:00Z","schema_version":2,"component":"server","event":"registry_alias_collision","level":"warn","message":"ambiguous registry alias rejected","alias":"calico/node","canonical_repos":["quay.io/calico/node","registry.example.com/calico/node"],"method":"GET","path":"/v2/calico/node/manifests/v1"}
+```
+
 ## 호환성 참고
 
-- 현재 `deck server up`은 위의 구조화된 버전 2 형태를 기록합니다
-- `deck server logs`는 `source`, `event_type`, 또는 중첩된 `extra`와 같은 필드를 사용하던 이전 레거시 레코드도 여전히 정규화할 수 있습니다
-- 원시 감사 파일을 읽는 다운스트림 소비자는 앞으로 버전 2 최상위 구조를 예상해야 합니다
+- 현재 `deck server up`은 위에서 설명한 구조화된 버전 2 형태로 기록합니다
+- `deck server logs`는 `source`, `event_type`, 중첩된 `extra` 같은 필드를 쓰던 기존 레거시 레코드도 여전히 정규화할 수 있습니다
+- 원본 감사 파일을 직접 읽는 다운스트림 소비자는 앞으로 버전 2의 최상위 구조를 기준으로 삼아야 합니다
 
 ## 로테이션
 
-- `deck server up`은 감사 로그가 설정된 크기 제한을 초과하면 로테이션합니다
-- 기본값: 최대 크기 `50` MB, 보존 파일 `10`개
+- `deck server up`은 감사 로그가 설정된 크기 한도를 넘으면 로테이션합니다
+- 기본값은 최대 크기 `50` MB, 보관 파일 `10`개입니다
 - 관련 플래그: `--audit-max-size-mb`, `--audit-max-files`
 
 ## 로그 보기

--- a/website/i18n/ko/docusaurus-plugin-content-docs/current/server/registry.md
+++ b/website/i18n/ko/docusaurus-plugin-content-docs/current/server/registry.md
@@ -1,22 +1,22 @@
 ---
 source: docs/server/registry.md
-source_hash: 9da4bae85f5c67817284a541d68b507b95015265
+source_hash: 95ea7de6a9aec0197165e9a0f8c84e656ff13780
 ---
-# 서버 레지스트리
+# Server registry
 
-`deck server up`은 `/v2` 접두사에서 읽기 전용 OCI Distribution v2 레지스트리를 노출합니다. `deck prepare`가 번들로 다운로드한 컨테이너 이미지 아카이브를 제공하므로, `containerd`, `docker`, `crane` 같은 런타임이 외부 네트워크 접근 없이 로컬 서버에서 직접 이미지를 풀할 수 있습니다.
+`deck server up`은 `/v2` 접두사에서 읽기 전용 OCI Distribution v2 레지스트리를 제공합니다. 이 레지스트리는 `deck prepare`가 번들에 내려받아 둔 컨테이너 이미지 아카이브를 서빙하므로, `containerd`, `docker`, `crane` 같은 런타임이 외부 네트워크 없이 로컬 서버에서 곧바로 이미지를 받을 수 있습니다.
 
 ## 개요
 
-이 레지스트리는 풀 전용입니다. 푸시나 그 밖의 쓰기 작업은 받지 않습니다. `GET` 또는 `HEAD`가 아닌 모든 요청은 `405 Method Not Allowed`를 반환합니다.
+레지스트리는 pull 전용입니다. push를 비롯한 쓰기 작업은 지원하지 않으며, `GET`이나 `HEAD`가 아닌 요청에는 모두 `405 Method Not Allowed`를 반환합니다.
 
-레지스트리는 번들 루트 아래의 `outputs/images/`(및 레거시 `images/` 경로)에서 `.tar` 파일을 스캔하여 이미지를 검색합니다. 각 tar는 Docker tarball 형식으로 읽습니다. `.deckignore`에 의해 제외된 파일은 건너뜁니다.
+이미지는 번들 루트 아래의 `outputs/images/`(및 레거시 경로인 `images/`)에서 `.tar` 파일을 훑어 찾아냅니다. 각 tar은 Docker tarball 형식으로 읽으며, `.deckignore`로 제외된 파일은 건너뜁니다.
 
-`outputs/images/`가 어떻게 채워지는지는 [Bundle Layout](../bundle-layout.md)을 참고하세요.
+`outputs/images/`가 채워지는 방식은 [Bundle Layout](../bundle-layout.md)을 참고하세요.
 
-## 엔드포인트
+## Endpoints
 
-`GET` 및 `HEAD` 응답은 `Docker-Distribution-API-Version: registry/2.0` 응답 헤더를 설정합니다. 거부된 비-`GET`/`HEAD` 요청은 이 헤더 없이 `405 Method Not Allowed`를 받습니다.
+`GET`과 `HEAD` 응답에는 `Docker-Distribution-API-Version: registry/2.0` 헤더가 붙습니다. `GET`/`HEAD`가 아니어서 거부된 요청에는 이 헤더 없이 `405 Method Not Allowed`만 반환됩니다.
 
 ### Ping
 
@@ -27,7 +27,7 @@ GET  /v2/
 HEAD /v2/
 ```
 
-빈 본문과 함께 `200 OK`를 반환합니다. 표준 OCI/Docker 레지스트리 디스커버리 검사입니다.
+빈 본문과 함께 `200 OK`를 반환합니다. 표준 OCI/Docker 레지스트리 탐색 확인 절차입니다.
 
 ### Catalog
 
@@ -36,7 +36,7 @@ GET  /v2/_catalog
 HEAD /v2/_catalog
 ```
 
-서버가 제공할 수 있는 모든 리포지토리 이름을 나열하는 JSON 객체를 반환합니다.
+서버가 서빙할 수 있는 모든 리포지터리 이름을 담은 JSON 객체를 반환합니다.
 
 ```json
 {"repositories": ["calico/node-driver-registrar", "quay.io/calico/node-driver-registrar"]}
@@ -49,7 +49,7 @@ GET  /v2/<name>/tags/list
 HEAD /v2/<name>/tags/list
 ```
 
-명명된 리포지토리의 모든 태그를 나열하는 JSON 객체를 반환합니다. 리포지토리를 찾을 수 없으면 `404`를 반환합니다.
+지정한 리포지터리의 태그를 모두 담은 JSON 객체를 반환합니다. 리포지터리를 찾지 못하면 `404`를 반환합니다.
 
 ```json
 {"name": "calico/node-driver-registrar", "tags": ["v3.28.0"]}
@@ -62,7 +62,7 @@ GET  /v2/<name>/manifests/<ref>
 HEAD /v2/<name>/manifests/<ref>
 ```
 
-`<ref>`는 태그(예: `3.18`) 또는 다이제스트(예: `sha256:abc123…`)일 수 있습니다. 적절한 `Content-Type`과 `Docker-Content-Digest` 헤더와 함께 원본 이미지 매니페스트를 반환합니다. 이미지를 찾을 수 없으면 `404`를 반환합니다.
+`<ref>`에는 태그(예: `3.18`) 또는 digest(예: `sha256:abc123…`)를 쓸 수 있습니다. 알맞은 `Content-Type`과 `Docker-Content-Digest` 헤더를 붙여 원본 이미지 매니페스트를 반환하며, 이미지를 찾지 못하면 `404`를 반환합니다.
 
 ### Blob
 
@@ -71,30 +71,40 @@ GET  /v2/<name>/blobs/<digest>
 HEAD /v2/<name>/blobs/<digest>
 ```
 
-`<digest>`로 식별되는 이미지 구성(config) 또는 압축된 레이어를 반환합니다. 명명된 리포지토리 내에서 다이제스트를 찾을 수 없으면 `404`를 반환합니다.
+`<digest>`로 식별되는 이미지 config나 압축된 레이어를 반환합니다. 지정한 리포지터리 안에서 해당 digest를 찾지 못하면 `404`를 반환합니다.
 
-## 리포지토리 이름 별칭
+## Repository name aliases
 
-이미지 tarball은 `RepoTags` 필드를 포함합니다. 서버는 약한 검증으로 각 태그를 파싱하여 정규 리포지토리 이름을 도출합니다. 예를 들어 `quay.io/calico/node-driver-registrar:v3.28.0` 태그의 정규 리포지토리는 `quay.io/calico/node-driver-registrar`입니다.
+이미지 tarball에는 `RepoTags` 필드가 들어 있습니다. 서버는 각 태그를 느슨하게 검증하며 파싱해 정규 리포지터리 이름을 도출합니다. 예를 들어 `quay.io/calico/node-driver-registrar:v3.28.0` 태그의 정규 리포지터리는 `quay.io/calico/node-driver-registrar`입니다.
 
-정규 이름의 첫 번째 경로 구성 요소가 레지스트리 도메인처럼 보이면(`.` 또는 `:`를 포함하거나 `localhost`와 같으면), 서버는 도메인 접두사를 제거한 두 번째 별칭을 등록합니다. 위 예시를 사용하면 다음 두 이름은 모두 같은 이미지를 가리키며 서로 바꿔 쓸 수 있습니다.
+정규 이름의 첫 경로 구성 요소가 레지스트리 도메인처럼 보이면(`.`이나 `:`을 포함하거나 `localhost`이면), 서버는 도메인 접두사를 떼어낸 두 번째 alias도 함께 등록합니다. 위 예시에서는 다음 두 이름이 같은 이미지를 가리키며 서로 바꿔 쓸 수 있습니다.
 
 - `quay.io/calico/node-driver-registrar` (정규, 도메인 접두사 포함)
-- `calico/node-driver-registrar` (별칭, 도메인 제거됨)
+- `calico/node-driver-registrar` (alias, 도메인 제거)
 
-이를 통해 클라이언트는 정규화된 전체 이름 또는 더 짧은 형식 중 하나로 풀할 수 있습니다.
+덕분에 클라이언트는 완전히 정규화된 이름이든 더 짧은 형태든 어느 쪽으로도 이미지를 받을 수 있습니다.
 
-> **Docker Hub 참고:** go-containerregistry는 `docker.io`를 `index.docker.io`로 정규화하므로, `docker.io/library/alpine:3.18`로 저장된 태그는 정규 이름 `index.docker.io/library/alpine` 아래에 등록됩니다. 클라이언트는 `index.docker.io/library/alpine` 또는 도메인이 제거된 별칭 `library/alpine`을 통해 풀해야 합니다.
+> **Docker Hub 참고:** go-containerregistry는 `docker.io`를 `index.docker.io`로 정규화하므로, `docker.io/library/alpine:3.18`로 저장된 태그는 정규 이름 `index.docker.io/library/alpine`으로 등록됩니다. 클라이언트는 `index.docker.io/library/alpine`이나 도메인을 떼어낸 alias인 `library/alpine`으로 받아야 합니다.
 
-## 읽기 전용 강제
+### Alias collisions {#alias-collisions}
 
-`GET` 또는 `HEAD` 이외의 모든 메서드(`POST`, `PUT`, `DELETE`, `PATCH` 포함)는 어떤 경로 디스패치도 일어나기 전에 `405 Method Not Allowed`를 반환합니다. 푸시, 삭제, 업로드 엔드포인트는 없습니다.
+서로 다른 레지스트리의 두 이미지가 같은 alias로 축약될 수 있습니다. 예를 들어 `quay.io/calico/node`와 `registry.example.com/calico/node`는 둘 다 `calico/node`라는 alias를 만들어냅니다. 이런 alias는 더 이상 이미지 하나를 특정하지 못하므로, 서버는 이를 모호한(ambiguous) 것으로 취급합니다.
+
+- 모호한 alias는 **카탈로그(`/v2/_catalog`)에서 제외됩니다.**
+- 모호한 alias에 대한 태그, 매니페스트, blob 요청에는 충돌하는 이미지 중 하나를 임의로 서빙하지 않고 **`404 Not Found`**를 반환합니다. 거부할 때마다 충돌한 정규 리포지터리들을 나열한 `registry_alias_collision` 이벤트를 [서버 감사 로그](../server-audit-log.md)에 남깁니다.
+- **정규(도메인 접두사 포함) 이름은 언제나 정상적으로 동작합니다.** 모호함을 해소하려면 `quay.io/calico/node`나 `registry.example.com/calico/node`를 명시적으로 받으면 됩니다.
+
+요청한 이름이 어떤 이미지의 정규 리포지터리이면서 동시에 다른 이미지의 alias이기도 하면, 정규 리포지터리가 우선합니다.
+
+## Read-only enforcement
+
+`GET`이나 `HEAD`가 아닌 메서드(`POST`, `PUT`, `DELETE`, `PATCH` 포함)는 모두 경로 디스패치 이전 단계에서 `405 Method Not Allowed`를 반환합니다. push, delete, upload 엔드포인트는 아예 존재하지 않습니다.
 
 ## `.deckignore`
 
-서버는 이미지 tarball을 스캔하기 전에 번들 루트에서 `.deckignore`를 로드합니다. 경로(번들 루트 기준)가 무시 규칙과 일치하는 모든 `.tar` 파일은 카탈로그에서 제외되며 제공될 수 없습니다.
+서버는 이미지 tarball을 스캔하기 전에 번들 루트에서 `.deckignore`를 읽습니다. 번들 루트 기준 경로가 ignore 규칙에 매칭되는 `.tar` 파일은 카탈로그에서 제외되며 서빙되지 않습니다.
 
-## 사용 예시
+## Usage example
 
 기본 주소로 서버를 시작합니다.
 
@@ -102,12 +112,12 @@ HEAD /v2/<name>/blobs/<digest>
 deck server up --root /path/to/bundle
 ```
 
-레지스트리는 나머지 서버와 동일한 주소(기본값 `:8080`, `--addr`로 구성 가능)에서 수신 대기합니다. `crane`을 사용하여 이미지를 풀합니다.
+레지스트리는 서버의 나머지 부분과 같은 주소에서 수신 대기합니다(기본값 `:8080`, `--addr`로 설정 가능). `crane`으로 이미지를 받습니다.
 
 ```sh
 crane pull localhost:8080/calico/node-driver-registrar:v3.28.0 node-driver-registrar.tar
 ```
 
-또는 `containerd`를 레지스트리의 미러로 서버를 사용하도록 구성하고 `http://localhost:8080`을 가리키게 합니다.
+또는 `containerd`가 이 서버를 레지스트리 미러로 사용하도록 설정하고 `http://localhost:8080`을 가리키게 하면 됩니다.
 
-TLS 옵션 및 데몬 모드는 [deck server up](../cli/deck_server_up.md)을 참고하세요.
+TLS 옵션과 데몬 모드는 [deck server up](../cli/deck_server_up.md)을 참고하세요.


### PR DESCRIPTION
Closes #193.

## Problem
`deck server` strips the registry domain from an image's canonical repository to serve a mirror-compatibility alias — e.g. `quay.io/calico/node` is also served as `calico/node`. Two source images from **different registries** can strip to the **same alias**:

- `quay.io/calico/node` → `calico/node`
- `registry.example.com/calico/node` → `calico/node`

Previously this collision was undetected: tag listing silently **unioned** both images' tags under the alias, and manifest/blob resolution returned whichever image sorted first by tar path — a **non-deterministic, potentially wrong image**.

## Change
New `selectRepoEntries` centralizes the resolution policy:

| Requested name | Behavior |
|---|---|
| A canonical repository | Served (canonical **preferred** over any alias) |
| Pure alias → 1 canonical repo | Served as before |
| Pure alias → ≥2 canonical repos | **Ambiguous**: hidden from catalog, `404` on tags/manifest/blob, audit-logged |

- No more silent wrong-image serving — the ambiguous alias hard-fails instead.
- **Canonical, domain-prefixed names always keep resolving**, so operators disambiguate by pulling the fully-qualified name.
- Each rejection emits a `registry_alias_collision` audit event listing the colliding canonical repositories.

## Tests
- `TestSelectRepoEntries` — unit coverage for every branch (canonical, single alias, ambiguous, unknown, prefer-canonical).
- `TestRegistryAmbiguousAliasIsRejected` — HTTP-level: two colliding source images; asserts catalog omission, `404` on the alias, both canonical repos still `200`, and the audit-log record.

## Docs
- `docs/server/registry.md` — new "Alias collisions" section.
- `docs/server-audit-log.md` — documents the `registry_alias_collision` event.
- Korean i18n mirror regenerated (`make docs-translate`); `make docs-check` passes.

## Verification
`go build ./...`, `make lint` (0 issues), `internal/server` + `internal/doccheck` tests, and `govulncheck` (no vulnerabilities) all pass.